### PR TITLE
fix(helm): guard wait-for-minio init container with minio.enabled

### DIFF
--- a/charts/floe-platform/templates/job-polaris-bootstrap.yaml
+++ b/charts/floe-platform/templates/job-polaris-bootstrap.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       restartPolicy: Never
       initContainers:
+{{- if .Values.minio.enabled }}
         - name: wait-for-minio
           image: curlimages/curl:8.5.0
           command:
@@ -47,6 +48,7 @@ spec:
             requests:
               cpu: 50m
               memory: 32Mi
+{{- end }}
         - name: wait-for-polaris
           image: curlimages/curl:8.5.0
           command:


### PR DESCRIPTION
## Summary

- Guard the `wait-for-minio` init container in the Polaris bootstrap job with `{{- if .Values.minio.enabled }}` so it is skipped when MinIO is disabled
- Prevents 5 E2E test errors caused by the bootstrap job timing out waiting for a non-existent MinIO service

## Acceptance Criteria

| AC | Status | Evidence |
|----|--------|----------|
| AC-21.1: wait-for-minio skipped when `minio.enabled=false` | PASS | `helm template --set minio.enabled=false` renders 0 occurrences of `wait-for-minio`, 1 of `wait-for-polaris` |
| AC-21.2: wait-for-minio present when MinIO enabled | PASS | `helm template` (default values) renders 1 occurrence of `wait-for-minio` |
| AC-21.3: Template renders valid YAML in both modes | PASS | `helm lint` exits 0, template valid in both modes |
| AC-21.4: No changes to non-MinIO init containers or main container | PASS | `git diff` shows exactly 2 added lines around `wait-for-minio` block |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| gate-build | PASS | 0/0/0 |
| gate-tests | PASS | 0/0/0 |
| gate-security | PASS | 0/0/0 |
| gate-wiring | PASS | 0/0/0 |
| gate-spec | PASS | 0/0/0 |

## Evidence

- 12 unit tests + 843 contract tests pass (no regressions)
- `helm lint` passes; `helm template` valid YAML in both `minio.enabled` modes
- Diff is exactly 2 lines: `{{- if .Values.minio.enabled }}` and `{{- end }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)