### PR TITLE
fix(wu-34): Dagster 1.12.x GraphQL pipelineName alignment

### DIFF
--- a/tests/e2e/test_compile_deploy_materialize_e2e.py
+++ b/tests/e2e/test_compile_deploy_materialize_e2e.py
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+# Dagster's implicit job name for ad-hoc asset materializations.
+# Required in the launchRun GraphQL selector since Dagster 1.12.x.
+# Source: dagster._core.definitions.assets_job.IMPLICIT_ASSET_JOB_NAME
+IMPLICIT_ASSET_JOB_NAME = "__ASSET_JOB"
+
 # Demo product paths relative to project root
 DEMO_PRODUCTS = {
     "customer-360": "demo/customer-360/floe.yaml",
@@ -529,6 +534,7 @@ class TestCompileDeployMaterialize:
                 "selector": {
                     "repositoryName": repo_name,
                     "repositoryLocationName": location_name,
+                    "pipelineName": IMPLICIT_ASSET_JOB_NAME,
                     "assetSelection": [{"path": ["stg_customers"]}],
                 },
                 "mode": "default",


### PR DESCRIPTION
## Summary

- Add missing `pipelineName` field to Dagster `launchRun` GraphQL mutation selector
- Dagster 1.12.x requires `pipelineName: "__ASSET_JOB"` for ad-hoc asset materializations (was optional in 1.9.x)
- Extract magic string to documented module constant `IMPLICIT_ASSET_JOB_NAME`

## Acceptance Criteria

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-34.1 | `pipelineName` included in GraphQL selector | PASS | `test_compile_deploy_materialize_e2e.py:537` |
| AC-34.2 | Asset materialization test passes | INFO | Deferred to CI (requires live Dagster) |
| AC-34.3 | Cascading Iceberg table test passes | INFO | Deferred to CI (requires live Dagster) |
| AC-34.4 | `__ASSET_JOB` documented as constant | PASS | `test_compile_deploy_materialize_e2e.py:37-40` |

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| build | PASS | 0/0/0 |
| tests | PASS | 0/1/4 |
| security | PASS | 0/1/3 |
| wiring | PASS | 0/0/5 |
| spec | PASS | 0/0/2 |

## Constraints Verified

- Single test file change only — no production code
- Raw GraphQL preserved (not Dagster Python client) for API contract transparency
- Pattern P15 followed: subchart upgrade API change tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)