### PR TITLE
feat(ci): add --atomic, --cleanup-on-fail, and helm-diff to integration stage

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -421,7 +421,7 @@ jobs:
       - name: Install helm-diff plugin
         run: helm plugin install https://github.com/databus23/helm-diff --version v3.9.12
 
-      - name: Diff upgrade (informational)
+      - name: Diff upgrade (informational — exits 2 on fresh cluster, non-zero is expected)
         continue-on-error: true
         run: |
           helm diff upgrade floe-test charts/floe-platform \


### PR DESCRIPTION
## Summary

- Add `--atomic --cleanup-on-fail` to the Helm integration stage for automatic rollback and resource cleanup on failed upgrades
- Add helm-diff step (pinned v3.9.12) before upgrade for change visibility with `--detailed-exitcode --suppress-secrets --three-way-merge`
- Remove redundant `--wait` flag (implied by `--atomic`)

## Acceptance Criteria

| AC | Status | Evidence |
|----|--------|----------|
| AC-1: `--atomic` present, `--wait` removed | PASS | `helm-ci.yaml:439` |
| AC-2: `--cleanup-on-fail` present | PASS | `helm-ci.yaml:439` |
| AC-3: helm-diff installed (pinned version) | PASS | `helm-ci.yaml:422` — `--version v3.9.12` |
| AC-4: helm-diff flags correct | PASS | `helm-ci.yaml:430-432` — all flags present, `head -200`, `continue-on-error: true` |
| AC-5: Pipeline structure preserved | PASS | `needs`, `if`, `--create-namespace`, `helm test`, failure step all unchanged |
| AC-6: YAML valid | PASS | `yaml.safe_load` passes, no duplicate keys |

## Blast Radius

- **`.github/workflows/helm-ci.yaml`** — integration stage only (Stage 6)
- No changes to chart templates, values, tests, or application code
- Only affects main branch CI runs (`if: github.ref == 'refs/heads/main'`)

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| Build (YAML + helm-unittest) | PASS | 0/0/0 |
| Tests (140/140) | PASS | 0/0/0 |
| Security | SKIPPED — no code changes, workflow YAML only |
| Wiring | SKIPPED — no code changes, workflow YAML only |
| Spec Compliance (6/6 AC) | PASS | 0/0/0 |

## Evidence

- Verification report: `.specwright/work/fix-e2e-test-infra/units/ci-pipeline-hardening/evidence/verify-report.md`
- Spec: `.specwright/work/fix-e2e-test-infra/units/ci-pipeline-hardening/spec.md`
- Plan (with as-built notes): `.specwright/work/fix-e2e-test-infra/units/ci-pipeline-hardening/plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)