### PR TITLE
feat(lineage): add per-model OpenLineage emission in compile_pipeline

### DIFF
--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -559,13 +559,25 @@ def compile_pipeline(
                     secrets_scanned=post_summary.secrets_scanned,
                 )
 
-            # Per-model lineage emission (non-blocking)
+            # Per-model lineage emission (non-blocking).
+            # Records model presence in lineage graph during compilation;
+            # execution-time events are emitted by Dagster at runtime.
             for model in transforms.models:
                 model_job_name = f"model.floe.{model.name}"
+                model_run_id: UUID | None = None
                 try:
                     model_run_id = emitter.emit_start(job_name=model_job_name)
                     emitter.emit_complete(model_run_id, model_job_name)
                 except Exception as _model_err:
+                    if model_run_id is not None:
+                        try:
+                            emitter.emit_fail(
+                                model_run_id,
+                                model_job_name,
+                                error_message=type(_model_err).__name__,
+                            )
+                        except Exception:
+                            pass  # Best-effort fail event
                     log.warning(
                         "lineage_model_emit_failed",
                         model=model.name,

--- a/packages/floe-core/tests/integration/test_lineage_wiring.py
+++ b/packages/floe-core/tests/integration/test_lineage_wiring.py
@@ -10,14 +10,12 @@ Requirements: AC-1 (env var override wiring), AC-1/AC-2/AC-3 (per-model emission
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
-import structlog
 
 ENV_VAR_ENDPOINT = "http://override.example.com:5100/api/v1/lineage"
 """OPENLINEAGE_URL env var value used in override tests."""
@@ -208,8 +206,10 @@ class TestPerModelLineageEmission:
         model_complete_calls = [
             c
             for c in complete_mock.call_args_list
-            if c.kwargs.get("job_name") is not None
-            and str(c.kwargs.get("job_name", "")).startswith(MODEL_JOB_NAME_PREFIX)
+            if (
+                c.kwargs.get("job_name") is not None
+                and str(c.kwargs.get("job_name", "")).startswith(MODEL_JOB_NAME_PREFIX)
+            )
             or (len(c.args) >= 2 and str(c.args[1]).startswith(MODEL_JOB_NAME_PREFIX))
         ]
 
@@ -392,8 +392,12 @@ class TestPerModelLineageEmission:
             result = compile_pipeline(spec_path, manifest_path)
 
         # Compilation must produce a valid result
-        assert result is not None, "compile_pipeline() returned None after model emission failure"
-        assert hasattr(result, "version"), "Result missing version attribute"
+        from floe_core.schemas.compiled_artifacts import CompiledArtifacts
+
+        assert isinstance(result, CompiledArtifacts), (
+            "compile_pipeline() must return CompiledArtifacts after model emission failure"
+        )
+        assert result.metadata.product_name is not None, "Result missing product_name"
 
         # The failing model should have had emit_start attempted
         failing_start_calls = [
@@ -407,9 +411,11 @@ class TestPerModelLineageEmission:
         other_complete_calls = [
             c
             for c in complete_mock.call_args_list
-            if c.kwargs.get("job_name") is not None
-            and str(c.kwargs.get("job_name", "")).startswith(MODEL_JOB_NAME_PREFIX)
-            and str(c.kwargs.get("job_name", "")) != failing_job_name
+            if (
+                c.kwargs.get("job_name") is not None
+                and str(c.kwargs.get("job_name", "")).startswith(MODEL_JOB_NAME_PREFIX)
+                and str(c.kwargs.get("job_name", "")) != failing_job_name
+            )
             or (
                 len(c.args) >= 2
                 and str(c.args[1]).startswith(MODEL_JOB_NAME_PREFIX)
@@ -460,20 +466,9 @@ class TestPerModelLineageEmission:
         ) -> Any:
             return emitter
 
-        log_buffer = io.StringIO()
+        from structlog.testing import capture_logs
 
-        # Configure structlog to write to our buffer so we can inspect output
-        structlog.configure(
-            processors=[
-                structlog.stdlib.add_log_level,
-                structlog.dev.ConsoleRenderer(),
-            ],
-            wrapper_class=structlog.stdlib.BoundLogger,
-            logger_factory=lambda *_args: structlog.PrintLogger(log_buffer),
-            cache_logger_on_first_use=False,
-        )
-
-        try:
+        with capture_logs() as cap_logs:
             with patch(
                 "floe_core.lineage.emitter.create_sync_emitter",
                 side_effect=_factory,
@@ -481,30 +476,30 @@ class TestPerModelLineageEmission:
                 from floe_core.compilation.stages import compile_pipeline
 
                 compile_pipeline(spec_path, manifest_path)
-        finally:
-            # Reset structlog to default configuration
-            structlog.reset_defaults()
 
-        log_output = log_buffer.getvalue()
+        # Find the lineage_model_emit_failed log entries
+        fail_events = [e for e in cap_logs if e.get("event") == "lineage_model_emit_failed"]
 
-        # Must contain the event name
-        assert "lineage_model_emit_failed" in log_output, (
-            "Expected 'lineage_model_emit_failed' in log output "
+        # Must contain the event
+        assert len(fail_events) >= 1, (
+            "Expected 'lineage_model_emit_failed' in captured logs "
             f"when emit_start fails for model {failing_model}. "
-            f"Log output: {log_output[:500]}"
+            f"Captured events: {[e.get('event') for e in cap_logs]}"
         )
         # Must contain model name for debugging
-        assert failing_model in log_output, f"Log output missing model name '{failing_model}'"
+        model_event = [e for e in fail_events if e.get("model") == failing_model]
+        assert len(model_event) >= 1, f"Log missing event for model '{failing_model}'"
         # Must contain exception type name (CWE-532: type only)
-        assert "ConnectionError" in log_output, (
-            "Log output missing exception type 'ConnectionError'"
+        assert model_event[0].get("error") == "ConnectionError", (
+            f"Expected error='ConnectionError', got {model_event[0].get('error')!r}"
         )
         # Must NOT contain the secret URL (CWE-532 violation)
-        assert secret_url not in log_output, (
-            "CWE-532 VIOLATION: Log output contains credential-bearing URL"
+        event_str = str(model_event[0])
+        assert secret_url not in event_str, (
+            "CWE-532 VIOLATION: Log event contains credential-bearing URL"
         )
-        assert "password" not in log_output.lower(), (
-            "CWE-532 VIOLATION: Log output may contain credentials"
+        assert "password" not in event_str.lower(), (
+            "CWE-532 VIOLATION: Log event may contain credentials"
         )
 
     @pytest.mark.requirement("AC-1")

--- a/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
+++ b/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
@@ -310,7 +310,8 @@ class TestCompilePipelineLineageStart:
 
         # Pipeline-level emit_start must be called (per-model calls also present)
         pipeline_start_calls = [
-            c for c in mock_emitter.emit_start.call_args_list
+            c
+            for c in mock_emitter.emit_start.call_args_list
             if _get_arg(c, 0, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_start_calls) == 1, (
@@ -343,7 +344,8 @@ class TestCompilePipelineLineageStart:
         mock_builder_cls.from_otel_context.assert_called_once()
         # Pipeline-level emit_start carries the trace facet
         pipeline_start_calls = [
-            c for c in mock_emitter.emit_start.call_args_list
+            c
+            for c in mock_emitter.emit_start.call_args_list
             if _get_arg(c, 0, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_start_calls) == 1
@@ -379,7 +381,8 @@ class TestCompilePipelineLineageStart:
 
         # Verify pipeline-level emit_start was attempted (side_effect fired)
         pipeline_start_calls = [
-            c for c in mock_emitter.emit_start.call_args_list
+            c
+            for c in mock_emitter.emit_start.call_args_list
             if _get_arg(c, 0, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_start_calls) == 1
@@ -416,7 +419,8 @@ class TestCompilePipelineLineageComplete:
 
         # Pipeline-level emit_complete must use the run_id from pipeline emit_start
         pipeline_complete_calls = [
-            c for c in mock_emitter.emit_complete.call_args_list
+            c
+            for c in mock_emitter.emit_complete.call_args_list
             if _get_arg(c, 1, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_complete_calls) == 1, (
@@ -442,7 +446,8 @@ class TestCompilePipelineLineageComplete:
 
         # Pipeline-level emit_complete must use pipeline job_name
         pipeline_complete_calls = [
-            c for c in mock_emitter.emit_complete.call_args_list
+            c
+            for c in mock_emitter.emit_complete.call_args_list
             if _get_arg(c, 1, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_complete_calls) == 1
@@ -470,7 +475,8 @@ class TestCompilePipelineLineageComplete:
 
         # Verify pipeline-level emit_complete was attempted
         pipeline_complete_calls = [
-            c for c in mock_emitter.emit_complete.call_args_list
+            c
+            for c in mock_emitter.emit_complete.call_args_list
             if _get_arg(c, 1, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_complete_calls) == 1
@@ -549,8 +555,10 @@ class TestCompilePipelineLineageComplete:
         # pipeline emit_complete, close
         assert call_order[0] == "emit_start", f"First call must be emit_start, got {call_order}"
         assert call_order[-1] == "close", f"Last call must be close, got {call_order}"
-        # Pipeline-level emit_complete must appear before close
-        assert "emit_complete" in call_order, f"emit_complete missing from lifecycle: {call_order}"
+        # Pipeline-level emit_complete must be second-to-last (just before close)
+        assert call_order[-2] == "emit_complete", (
+            f"Pipeline emit_complete must be second-to-last (before close), got {call_order}"
+        )
 
 
 class TestCompilePipelineLineageFail:
@@ -823,11 +831,13 @@ class TestCompilePipelineLineageEdgeCases:
         # Pipeline-level lifecycle calls still happen (NoOp emitter handles them silently)
         # Per-model calls also present, so filter for pipeline-level
         pipeline_start_calls = [
-            c for c in mock_emitter.emit_start.call_args_list
+            c
+            for c in mock_emitter.emit_start.call_args_list
             if _get_arg(c, 0, "job_name") == PRODUCT_NAME
         ]
         pipeline_complete_calls = [
-            c for c in mock_emitter.emit_complete.call_args_list
+            c
+            for c in mock_emitter.emit_complete.call_args_list
             if _get_arg(c, 1, "job_name") == PRODUCT_NAME
         ]
         assert len(pipeline_start_calls) == 1
@@ -903,4 +913,7 @@ class TestCompilePipelineLineageEdgeCases:
             # Must not raise — falls back to NoOp emitter
             result = compile_pipeline(spec_path, lineage_manifest_path)
 
-        assert result is not None
+        from floe_core.schemas.compiled_artifacts import CompiledArtifacts
+
+        assert isinstance(result, CompiledArtifacts)
+        assert result.metadata.product_name == PRODUCT_NAME


### PR DESCRIPTION
## Summary

- Add per-dbt-model OpenLineage START/COMPLETE emission inside `compile_pipeline()`, completing all 4 required emission points (pipeline START/COMPLETE + per-model START/COMPLETE)
- Each model in `transforms.models` gets non-blocking `emit_start` + `emit_complete` with job name `model.floe.{model.name}`
- Failures are isolated per-model and logged with `type(exc).__name__` only (CWE-532)

## Acceptance Criteria

| AC | Description | Status | Evidence |
|----|-------------|--------|----------|
| AC-1 | Per-model START and COMPLETE events emitted | **PASS** | 3 integration tests verify call counts, run ID threading |
| AC-2 | Job name format `model.floe.{model.name}` | **PASS** | 2 integration tests verify exact names and start/complete consistency |
| AC-3 | Per-model failures non-blocking + CWE-532 | **PASS** | 2 integration tests: selective failure isolation, credential-free logging |
| AC-4 | `test_openlineage_four_emission_points` passes | **DEFERRED** | Requires live K8s/Marquez stack — post-merge E2E verification |

## Blast Radius

| Module | Scope | Propagation |
|--------|-------|-------------|
| `stages.py` | 11 lines added (model loop) | Local — failure logged, never raises |
| E2E tests | No changes needed | N/A |
| `SyncLineageEmitter` | No changes | N/A |
| Marquez | Receives additional model jobs | Local — `floe.compilation` namespace |

**NOT changed**: emitter API, transport layer, manifest schema, Dagster runtime emission, `CompiledArtifacts` contract.

## Gate Results

| Gate | Status | Findings (B/W/I) |
|------|--------|-------------------|
| build | PASS | 0/0/0 |
| tests | WARN | 0/2/2 |
| security | PASS | 0/0/0 |
| wiring | PASS | 0/0/0 |
| spec | PASS | 0/0/0 |

**Tests gate WARNs**: 2 weak `assert result is not None` assertions in error-path tests (non-blocking, tracked for follow-up).

## Evidence

- `gate-build.md`: 31/31 tests pass (24 unit + 7 integration)
- `gate-security.md`: CWE-532 compliant, no secrets, no injection surface
- `gate-wiring.md`: All imports used, correct test tiers, no circular deps
- `gate-tests.md`: Strong side-effect verification, mock discipline, CWE-532 tested
- `gate-spec.md`: AC-1/2/3 fully covered, AC-4 deferred to E2E

## Changed Files

| File | Change |
|------|--------|
| `packages/floe-core/src/floe_core/compilation/stages.py:562-573` | Per-model emission loop |
| `packages/floe-core/tests/integration/test_lineage_wiring.py` | 6 new tests in `TestPerModelLineageEmission` |
| `packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py` | Updated assertions for per-model emission compatibility |

🤖 Generated with [Claude Code](https://claude.com/claude-code)