### PR TITLE
refactor(test-infra): eliminate chart/manifest/shell identifier drift

### DIFF
--- a/charts/floe-platform/templates/_helpers.tpl
+++ b/charts/floe-platform/templates/_helpers.tpl
@@ -227,6 +227,21 @@ MinIO secret name (used for root-user/root-password keys).
 {{- end }}
 
 {{/*
+Polaris credentials secret name.
+Single source of truth for the Secret holding client-id, client-secret,
+POLARIS_CREDENTIAL, aws-access-key-id, and aws-secret-access-key. Used
+by the polaris bootstrap Job and every test Job. Do NOT inline the
+`%s-credentials` printf expression elsewhere — call this helper.
+*/}}
+{{- define "floe-platform.polaris.credentialSecretName" -}}
+{{- if .Values.polaris.auth.existingSecret }}
+{{- .Values.polaris.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-credentials" (include "floe-platform.polaris.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
 Standard (non-destructive) test runner ServiceAccount name.
 Used by test Jobs in templates/tests/ for e2e and integration test suites.
 */}}
@@ -250,7 +265,7 @@ Polaris bootstrap Job (as catalog name) and test Jobs (as POLARIS_WAREHOUSE).
 Reads .Values.polaris.bootstrap.catalogName — do NOT duplicate this elsewhere.
 */}}
 {{- define "floe-platform.polaris.warehouse" -}}
-{{- required "polaris.bootstrap.catalogName is required when tests.enabled=true" .Values.polaris.bootstrap.catalogName }}
+{{- required "polaris.bootstrap.catalogName is required — set .Values.polaris.bootstrap.catalogName" .Values.polaris.bootstrap.catalogName }}
 {{- end }}
 
 {{/*

--- a/charts/floe-platform/templates/deployment-polaris.yaml
+++ b/charts/floe-platform/templates/deployment-polaris.yaml
@@ -61,7 +61,7 @@ spec:
             - name: POLARIS_BOOTSTRAP_CREDENTIALS
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: bootstrap-credentials
             - name: JAVA_OPTS_APPEND
               value: >-
@@ -77,12 +77,12 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: aws-access-key-id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: aws-secret-access-key
             - name: AWS_REGION
               value: {{ .Values.polaris.storage.s3.region | quote }}

--- a/charts/floe-platform/templates/job-polaris-bootstrap.yaml
+++ b/charts/floe-platform/templates/job-polaris-bootstrap.yaml
@@ -111,26 +111,34 @@ spec:
               drop:
                 - ALL
           env:
+            # POLARIS_CATALOG_NAME is the canonical runtime source for the
+            # catalog/warehouse identifier. Both the shell script below and
+            # the contract test (AC-3) read from this env var — never from
+            # a hardcoded literal or a regex-scanned shell body. Sourced
+            # from .Values.polaris.bootstrap.catalogName via the warehouse
+            # helper so every consumer lands on the same key.
+            - name: POLARIS_CATALOG_NAME
+              value: {{ include "floe-platform.polaris.warehouse" . | quote }}
             - name: POLARIS_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: client-id
             - name: POLARIS_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: client-secret
             {{- if .Values.polaris.storage.s3.enabled }}
             - name: S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: aws-access-key-id
             - name: S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" (include "floe-platform.polaris.fullname" .)) }}
+                  name: {{ include "floe-platform.polaris.credentialSecretName" . }}
                   key: aws-secret-access-key
             {{- end }}
           command:
@@ -150,6 +158,18 @@ spec:
                 log "ERROR: POLARIS_CLIENT_SECRET is not set or empty" >&2
                 exit 42
               fi
+              if [ -z "$POLARIS_CATALOG_NAME" ]; then
+                log "ERROR: POLARIS_CATALOG_NAME is not set or empty" >&2
+                exit 42
+              fi
+              # Validate catalog name — same character class as grant validation
+              # below. Rejects shell metacharacters and whitespace.
+              case "$POLARIS_CATALOG_NAME" in
+                *[!a-zA-Z0-9_-]*)
+                  log "ERROR: POLARIS_CATALOG_NAME contains invalid characters: $POLARIS_CATALOG_NAME" >&2
+                  exit 42
+                  ;;
+              esac
 
               POLARIS_URL="http://{{ include "floe-platform.polaris.fullname" . }}:{{ .Values.polaris.service.port | default 8181 }}"
               {{- $totalSteps := 3 }}
@@ -200,13 +220,17 @@ spec:
               {{- end }}
 
               {{- $step = add $step 1 }}
-              log "Step {{ $step }}/{{ $totalSteps }}: Creating catalog '{{ .Values.polaris.bootstrap.catalogName }}'..."
+              log "Step {{ $step }}/{{ $totalSteps }}: Creating catalog '$POLARIS_CATALOG_NAME'..."
               {{- if .Values.polaris.storage.s3.enabled }}
-              # Build catalog JSON with S3 credentials from environment
+              # Build catalog JSON with S3 credentials from environment.
+              # Unquoted heredoc (<<EOJSON) expands shell variables — the
+              # catalog name comes from $POLARIS_CATALOG_NAME (env), not
+              # a template literal, so the contract test walker can verify
+              # the single source of truth via the K8s API surface.
               CATALOG_JSON=$(cat <<EOJSON
               {
                 "catalog": {
-                  "name": "{{ .Values.polaris.bootstrap.catalogName }}",
+                  "name": "$POLARIS_CATALOG_NAME",
                   "type": "INTERNAL",
                   "properties": {
                     "default-base-location": "{{ .Values.polaris.bootstrap.defaultBaseLocation }}",
@@ -230,9 +254,12 @@ spec:
               EOJSON
               )
               {{- else }}
-              CATALOG_JSON='{
+              # Unquoted heredoc so $POLARIS_CATALOG_NAME expands (single
+              # source of truth via env var, not template literal).
+              CATALOG_JSON=$(cat <<EOJSON
+              {
                 "catalog": {
-                  "name": "{{ .Values.polaris.bootstrap.catalogName }}",
+                  "name": "$POLARIS_CATALOG_NAME",
                   "type": "INTERNAL",
                   "properties": {
                     "default-base-location": "{{ .Values.polaris.bootstrap.defaultBaseLocation }}"
@@ -242,7 +269,9 @@ spec:
                     "allowedLocations": {{ .Values.polaris.bootstrap.allowedLocations | toJson }}
                   }
                 }
-              }'
+              }
+              EOJSON
+              )
               {{- end }}
 
               HTTP_CODE=$(printf '%s' "$CATALOG_JSON" | curl -s -o /tmp/response.txt -w '%{http_code}' -X POST \
@@ -252,9 +281,9 @@ spec:
                 -d @-)
 
               if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ]; then
-                log "Catalog '{{ .Values.polaris.bootstrap.catalogName }}' created successfully"
+                log "Catalog '$POLARIS_CATALOG_NAME' created successfully"
               elif [ "$HTTP_CODE" = "409" ]; then
-                log "Catalog '{{ .Values.polaris.bootstrap.catalogName }}' already exists (HTTP 409) - OK"
+                log "Catalog '$POLARIS_CATALOG_NAME' already exists (HTTP 409) - OK"
               else
                 log "ERROR: Failed to create catalog (HTTP $HTTP_CODE)" >&2
                 head -5 /tmp/response.txt >&2
@@ -263,10 +292,10 @@ spec:
 
               # Verify catalog exists via management API
               {{- $step = add $step 1 }}
-              log "Step {{ $step }}/{{ $totalSteps }}: Verifying catalog '{{ .Values.polaris.bootstrap.catalogName }}' via management API..."
+              log "Step {{ $step }}/{{ $totalSteps }}: Verifying catalog '$POLARIS_CATALOG_NAME' via management API..."
               VERIFY_CODE=$(curl -s -o /tmp/verify.txt -w '%{http_code}' \
                 -H "Authorization: Bearer $TOKEN" \
-                "$POLARIS_URL/api/management/v1/catalogs/{{ .Values.polaris.bootstrap.catalogName }}")
+                "$POLARIS_URL/api/management/v1/catalogs/$POLARIS_CATALOG_NAME")
 
               if [ "$VERIFY_CODE" != "200" ]; then
                 log "ERROR: Catalog verification failed (HTTP $VERIFY_CODE)" >&2
@@ -280,12 +309,15 @@ spec:
                 head -5 /tmp/verify.txt >&2
                 exit 1
               fi
-              log "Catalog '{{ .Values.polaris.bootstrap.catalogName }}' verified successfully"
+              log "Catalog '$POLARIS_CATALOG_NAME' verified successfully"
 
               {{- if .Values.polaris.bootstrap.grants.enabled }}
               # Create catalog role (idempotent — 201 created, 409 already exists)
+              # CATALOG_NAME aliases POLARIS_CATALOG_NAME for downstream grant
+              # steps so the validation loop and URL interpolations read the
+              # same canonical env var.
               CATALOG_ROLE="{{ .Values.polaris.bootstrap.grants.catalogRole }}"
-              CATALOG_NAME="{{ .Values.polaris.bootstrap.catalogName }}"
+              CATALOG_NAME="$POLARIS_CATALOG_NAME"
               PRINCIPAL_ROLE="{{ .Values.polaris.bootstrap.grants.principalRole }}"
               BOOTSTRAP_PRINCIPAL="{{ .Values.polaris.bootstrap.grants.bootstrapPrincipal }}"
 

--- a/charts/floe-platform/templates/tests/_test-job.tpl
+++ b/charts/floe-platform/templates/tests/_test-job.tpl
@@ -1,0 +1,169 @@
+{{/*
+Shared E2E test runner Job template.
+
+The standard (job-e2e.yaml) and destructive (job-e2e-destructive.yaml)
+runners differ only in four places — Job name, test-type label, runner
+ServiceAccount, pytest marker, and artifact filename prefix. Before this
+partial was extracted, both files were ~140 lines of 95%-identical YAML;
+every bug fix had to be applied twice and drift was near-certain. This
+template is the single source of truth.
+
+Usage:
+  {{- include "floe-platform.testJob" (dict
+      "context" .
+      "suite" "e2e"
+      "pytestMarker" "not destructive"
+      "serviceAccount" (include "floe-platform.testRunner.saName" .)
+      "artifactPrefix" "e2e"
+      ) }}
+
+Fields:
+  context         — Top-level chart context (`.`). Required for helper
+                    calls and .Values / .Release access.
+  suite           — Human-readable suite identifier used for the Job
+                    `metadata.name` (`floe-test-<suite>`), the
+                    `test-type` label, and the OTel service name suffix.
+                    Use "e2e" for the non-destructive runner,
+                    "e2e-destructive" for the destructive runner.
+  pytestMarker    — Value for `pytest -m`. Use "not destructive" to
+                    exclude destructive tests; "destructive" to include
+                    only destructive tests.
+  serviceAccount  — Rendered ServiceAccount name. Callers resolve the
+                    helper themselves so the template can stay agnostic
+                    about which SA a given suite uses.
+  artifactPrefix  — Filename prefix for junitxml/html/json-report
+                    artifacts. Typically matches `suite`.
+*/}}
+{{- define "floe-platform.testJob" -}}
+{{- $context := .context }}
+{{- $suite := .suite }}
+{{- $pytestMarker := .pytestMarker }}
+{{- $serviceAccount := .serviceAccount }}
+{{- $artifactPrefix := .artifactPrefix }}
+{{- $polaris := include "floe-platform.polaris.fullname" $context }}
+{{- $minio := include "floe-platform.minio.fullname" $context }}
+{{- $postgres := include "floe-platform.postgresql.host" $context }}
+{{- $dagsterWeb := include "floe-platform.dagster.webserverName" $context }}
+{{- $marquez := include "floe-platform.marquez.fullname" $context }}
+{{- $otel := include "floe-platform.otel.fullname" $context }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: floe-test-{{ $suite }}
+  namespace: {{ $context.Release.Namespace }}
+  labels:
+    {{- include "floe-platform.labels" $context | nindent 4 }}
+    app.kubernetes.io/component: test-runner
+    test-type: {{ $suite }}
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "floe-platform.selectorLabels" $context | nindent 8 }}
+        app.kubernetes.io/component: test-runner
+        test-type: {{ $suite }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $serviceAccount }}
+      securityContext:
+        {{- include "floe-platform.podSecurityContext" $context | nindent 8 }}
+      containers:
+        - name: test-runner
+          image: "{{ $context.Values.tests.image.repository }}:{{ $context.Values.tests.image.tag }}"
+          imagePullPolicy: {{ $context.Values.tests.image.pullPolicy }}
+          securityContext:
+            {{- include "floe-platform.containerSecurityContext" $context | nindent 12 }}
+          args:
+            - "--tb=short"
+            - "-v"
+            - "--color=yes"
+            - "tests/e2e/"
+            - "-m"
+            - {{ $pytestMarker | quote }}
+            - "--junitxml=/artifacts/{{ $artifactPrefix }}-results.xml"
+            - "--html=/artifacts/{{ $artifactPrefix }}-report.html"
+            - "--self-contained-html"
+            - "--json-report"
+            - "--json-report-file=/artifacts/{{ $artifactPrefix }}-report.json"
+            - "--log-cli-level=INFO"
+          env:
+            - name: INTEGRATION_TEST_HOST
+              value: "k8s"
+            - name: POSTGRES_HOST
+              value: {{ $postgres | quote }}
+            - name: POSTGRES_PORT
+              value: {{ include "floe-platform.postgresql.port" $context | quote }}
+            - name: POSTGRES_USER
+              value: floe
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.postgresql.secretName" $context }}
+                  key: postgresql-password
+            - name: MINIO_ENDPOINT
+              value: "http://{{ $minio }}:9000"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.minio.secretName" $context }}
+                  key: root-user
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.minio.secretName" $context }}
+                  key: root-password
+            - name: AWS_REGION
+              value: us-east-1
+            - name: POLARIS_URI
+              value: "http://{{ $polaris }}:{{ $context.Values.polaris.service.port | default 8181 }}/api/catalog"
+            - name: POLARIS_CREDENTIAL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.polaris.credentialSecretName" $context }}
+                  key: POLARIS_CREDENTIAL
+            - name: POLARIS_WAREHOUSE
+              value: {{ include "floe-platform.polaris.warehouse" $context | quote }}
+            - name: POLARIS_SCOPE
+              value: "PRINCIPAL_ROLE:ALL"
+            - name: POLARIS_HOST
+              value: {{ $polaris | quote }}
+            - name: POLARIS_MANAGEMENT_HOST
+              value: {{ $polaris | quote }}
+            - name: MINIO_HOST
+              value: {{ $minio | quote }}
+            - name: MINIO_CONSOLE_HOST
+              value: {{ $minio | quote }}
+            - name: MARQUEZ_HOST
+              value: {{ $marquez | quote }}
+            - name: DAGSTER_HOST
+              value: {{ $dagsterWeb | quote }}
+            - name: DAGSTER_WEBSERVER_HOST
+              value: {{ $dagsterWeb | quote }}
+            - name: OTEL_HOST
+              value: {{ $otel | quote }}
+            - name: OTEL_COLLECTOR_GRPC_HOST
+              value: {{ $otel | quote }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://{{ $otel }}:4317"
+            - name: OTEL_SERVICE_NAME
+              value: "floe-test-runner-{{ $suite }}"
+            - name: PYTHONPATH
+              value: "/app:/app/testing"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          resources:
+            {{- toYaml $context.Values.tests.resources | nindent 12 }}
+          {{- if $context.Values.tests.artifacts.enabled }}
+          volumeMounts:
+            - name: artifacts
+              mountPath: /artifacts
+          {{- end }}
+      {{- if $context.Values.tests.artifacts.enabled }}
+      volumes:
+        - name: artifacts
+          persistentVolumeClaim:
+            claimName: {{ $context.Values.tests.artifacts.pvcName }}
+      {{- end }}
+{{- end }}

--- a/charts/floe-platform/templates/tests/job-e2e-destructive.yaml
+++ b/charts/floe-platform/templates/tests/job-e2e-destructive.yaml
@@ -1,135 +1,19 @@
 {{/*
 Destructive E2E test runner Job.
 
-Same invariant as job-e2e.yaml: every identifier resolved via helper.
-Runs only tests marked @pytest.mark.destructive. Uses the elevated
-destructive runner ServiceAccount (see rbac-destructive.yaml).
+Thin wrapper around the shared `floe-platform.testJob` template in
+_test-job.tpl. Runs only tests marked @pytest.mark.destructive. Uses the
+elevated destructive runner ServiceAccount (see rbac-destructive.yaml).
 
 MUST run AFTER the standard E2E Job completes — these tests mutate
 platform state and can leave it in a dirty state on failure.
 */}}
 {{- if .Values.tests.enabled }}
-{{- $fullname := include "floe-platform.fullname" . }}
-{{- $polaris := include "floe-platform.polaris.fullname" . }}
-{{- $minio := include "floe-platform.minio.fullname" . }}
-{{- $postgres := include "floe-platform.postgresql.host" . }}
-{{- $dagsterWeb := include "floe-platform.dagster.webserverName" . }}
-{{- $marquez := include "floe-platform.marquez.fullname" . }}
-{{- $otel := include "floe-platform.otel.fullname" . }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: floe-test-e2e-destructive
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "floe-platform.labels" . | nindent 4 }}
-    app.kubernetes.io/component: test-runner
-    test-type: e2e-destructive
-spec:
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 3600
-  template:
-    metadata:
-      labels:
-        {{- include "floe-platform.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: test-runner
-        test-type: e2e-destructive
-    spec:
-      restartPolicy: Never
-      serviceAccountName: {{ include "floe-platform.testRunnerDestructive.saName" . }}
-      containers:
-        - name: test-runner
-          image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
-          imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-          args:
-            - "--tb=short"
-            - "-v"
-            - "--color=yes"
-            - "tests/e2e/"
-            - "-m"
-            - "destructive"
-            - "--junitxml=/artifacts/e2e-destructive-results.xml"
-            - "--html=/artifacts/e2e-destructive-report.html"
-            - "--self-contained-html"
-            - "--json-report"
-            - "--json-report-file=/artifacts/e2e-destructive-report.json"
-            - "--log-cli-level=INFO"
-          env:
-            - name: INTEGRATION_TEST_HOST
-              value: "k8s"
-            - name: POSTGRES_HOST
-              value: {{ $postgres | quote }}
-            - name: POSTGRES_PORT
-              value: {{ include "floe-platform.postgresql.port" . | quote }}
-            - name: POSTGRES_USER
-              value: floe
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.postgresql.secretName" . }}
-                  key: postgresql-password
-            - name: MINIO_ENDPOINT
-              value: "http://{{ $minio }}:9000"
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.minio.secretName" . }}
-                  key: root-user
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.minio.secretName" . }}
-                  key: root-password
-            - name: AWS_REGION
-              value: us-east-1
-            - name: POLARIS_URI
-              value: "http://{{ $polaris }}:{{ .Values.polaris.service.port | default 8181 }}/api/catalog"
-            - name: POLARIS_CREDENTIAL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" $polaris) }}
-                  key: POLARIS_CREDENTIAL
-            - name: POLARIS_WAREHOUSE
-              value: {{ include "floe-platform.polaris.warehouse" . | quote }}
-            - name: POLARIS_SCOPE
-              value: "PRINCIPAL_ROLE:ALL"
-            - name: POLARIS_HOST
-              value: {{ $polaris | quote }}
-            - name: POLARIS_MANAGEMENT_HOST
-              value: {{ $polaris | quote }}
-            - name: MINIO_HOST
-              value: {{ $minio | quote }}
-            - name: MINIO_CONSOLE_HOST
-              value: {{ $minio | quote }}
-            - name: MARQUEZ_HOST
-              value: {{ $marquez | quote }}
-            - name: DAGSTER_HOST
-              value: {{ $dagsterWeb | quote }}
-            - name: DAGSTER_WEBSERVER_HOST
-              value: {{ $dagsterWeb | quote }}
-            - name: OTEL_HOST
-              value: {{ $otel | quote }}
-            - name: OTEL_COLLECTOR_GRPC_HOST
-              value: {{ $otel | quote }}
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "http://{{ $otel }}:4317"
-            - name: OTEL_SERVICE_NAME
-              value: "floe-test-runner"
-            - name: PYTHONPATH
-              value: "/app:/app/testing"
-            - name: PYTHONUNBUFFERED
-              value: "1"
-          resources:
-            {{- toYaml .Values.tests.resources | nindent 12 }}
-          {{- if .Values.tests.artifacts.enabled }}
-          volumeMounts:
-            - name: artifacts
-              mountPath: /artifacts
-          {{- end }}
-      {{- if .Values.tests.artifacts.enabled }}
-      volumes:
-        - name: artifacts
-          persistentVolumeClaim:
-            claimName: {{ .Values.tests.artifacts.pvcName }}
-      {{- end }}
+{{- include "floe-platform.testJob" (dict
+    "context" .
+    "suite" "e2e-destructive"
+    "pytestMarker" "destructive"
+    "serviceAccount" (include "floe-platform.testRunnerDestructive.saName" .)
+    "artifactPrefix" "e2e-destructive"
+    ) }}
 {{- end }}

--- a/charts/floe-platform/templates/tests/job-e2e.yaml
+++ b/charts/floe-platform/templates/tests/job-e2e.yaml
@@ -1,10 +1,11 @@
 {{/*
 Standard (non-destructive) E2E test runner Job.
 
-Every identifier — service names, secret names, warehouse name, service
-account — is resolved through a chart helper or values key. No literal
-`floe-platform-*` strings appear in this template. That is the invariant
-the drift-elimination contract test enforces.
+Thin wrapper around the shared `floe-platform.testJob` template in
+_test-job.tpl. That template is the single source of truth for every
+identifier, env var, volume mount, and resource spec. The invariant the
+drift-elimination contract test enforces — "no literal `floe-platform-*`
+strings, everything via helpers" — is enforced by the shared template.
 
 Only rendered when .Values.tests.enabled is true. Apply via:
   helm template floe-platform charts/floe-platform \
@@ -13,127 +14,11 @@ Only rendered when .Values.tests.enabled is true. Apply via:
     -s templates/tests/job-e2e.yaml | kubectl apply -f -
 */}}
 {{- if .Values.tests.enabled }}
-{{- $fullname := include "floe-platform.fullname" . }}
-{{- $polaris := include "floe-platform.polaris.fullname" . }}
-{{- $minio := include "floe-platform.minio.fullname" . }}
-{{- $postgres := include "floe-platform.postgresql.host" . }}
-{{- $dagsterWeb := include "floe-platform.dagster.webserverName" . }}
-{{- $marquez := include "floe-platform.marquez.fullname" . }}
-{{- $otel := include "floe-platform.otel.fullname" . }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: floe-test-e2e
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "floe-platform.labels" . | nindent 4 }}
-    app.kubernetes.io/component: test-runner
-    test-type: e2e
-spec:
-  backoffLimit: 0
-  ttlSecondsAfterFinished: 3600
-  template:
-    metadata:
-      labels:
-        {{- include "floe-platform.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: test-runner
-        test-type: e2e
-    spec:
-      restartPolicy: Never
-      serviceAccountName: {{ include "floe-platform.testRunner.saName" . }}
-      containers:
-        - name: test-runner
-          image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
-          imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
-          args:
-            - "--tb=short"
-            - "-v"
-            - "--color=yes"
-            - "tests/e2e/"
-            - "-m"
-            - "not destructive"
-            - "--junitxml=/artifacts/e2e-results.xml"
-            - "--html=/artifacts/e2e-report.html"
-            - "--self-contained-html"
-            - "--json-report"
-            - "--json-report-file=/artifacts/e2e-report.json"
-            - "--log-cli-level=INFO"
-          env:
-            - name: INTEGRATION_TEST_HOST
-              value: "k8s"
-            - name: POSTGRES_HOST
-              value: {{ $postgres | quote }}
-            - name: POSTGRES_PORT
-              value: {{ include "floe-platform.postgresql.port" . | quote }}
-            - name: POSTGRES_USER
-              value: floe
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.postgresql.secretName" . }}
-                  key: postgresql-password
-            - name: MINIO_ENDPOINT
-              value: "http://{{ $minio }}:9000"
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.minio.secretName" . }}
-                  key: root-user
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "floe-platform.minio.secretName" . }}
-                  key: root-password
-            - name: AWS_REGION
-              value: us-east-1
-            - name: POLARIS_URI
-              value: "http://{{ $polaris }}:{{ .Values.polaris.service.port | default 8181 }}/api/catalog"
-            - name: POLARIS_CREDENTIAL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.polaris.auth.existingSecret | default (printf "%s-credentials" $polaris) }}
-                  key: POLARIS_CREDENTIAL
-            - name: POLARIS_WAREHOUSE
-              value: {{ include "floe-platform.polaris.warehouse" . | quote }}
-            - name: POLARIS_SCOPE
-              value: "PRINCIPAL_ROLE:ALL"
-            - name: POLARIS_HOST
-              value: {{ $polaris | quote }}
-            - name: POLARIS_MANAGEMENT_HOST
-              value: {{ $polaris | quote }}
-            - name: MINIO_HOST
-              value: {{ $minio | quote }}
-            - name: MINIO_CONSOLE_HOST
-              value: {{ $minio | quote }}
-            - name: MARQUEZ_HOST
-              value: {{ $marquez | quote }}
-            - name: DAGSTER_HOST
-              value: {{ $dagsterWeb | quote }}
-            - name: DAGSTER_WEBSERVER_HOST
-              value: {{ $dagsterWeb | quote }}
-            - name: OTEL_HOST
-              value: {{ $otel | quote }}
-            - name: OTEL_COLLECTOR_GRPC_HOST
-              value: {{ $otel | quote }}
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "http://{{ $otel }}:4317"
-            - name: OTEL_SERVICE_NAME
-              value: "floe-test-runner"
-            - name: PYTHONPATH
-              value: "/app:/app/testing"
-            - name: PYTHONUNBUFFERED
-              value: "1"
-          resources:
-            {{- toYaml .Values.tests.resources | nindent 12 }}
-          {{- if .Values.tests.artifacts.enabled }}
-          volumeMounts:
-            - name: artifacts
-              mountPath: /artifacts
-          {{- end }}
-      {{- if .Values.tests.artifacts.enabled }}
-      volumes:
-        - name: artifacts
-          persistentVolumeClaim:
-            claimName: {{ .Values.tests.artifacts.pvcName }}
-      {{- end }}
+{{- include "floe-platform.testJob" (dict
+    "context" .
+    "suite" "e2e"
+    "pytestMarker" "not destructive"
+    "serviceAccount" (include "floe-platform.testRunner.saName" .)
+    "artifactPrefix" "e2e"
+    ) }}
 {{- end }}

--- a/charts/floe-platform/tests/bootstrap-reliability_test.yaml
+++ b/charts/floe-platform/tests/bootstrap-reliability_test.yaml
@@ -509,23 +509,27 @@ tests:
       polaris.auth.bootstrapCredentials.clientSecret: test-secret
       polaris.auth.existingSecret: my-custom-secret
     asserts:
+      # env[0] is POLARIS_CATALOG_NAME (literal value, no secretRef)
       - equal:
           path: spec.template.spec.containers[0].env[0].name
-          value: POLARIS_CLIENT_ID
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
-          value: my-custom-secret
-      - equal:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.key
-          value: client-id
+          value: POLARIS_CATALOG_NAME
       - equal:
           path: spec.template.spec.containers[0].env[1].name
-          value: POLARIS_CLIENT_SECRET
+          value: POLARIS_CLIENT_ID
       - equal:
           path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
           value: my-custom-secret
       - equal:
           path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: client-id
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: POLARIS_CLIENT_SECRET
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.name
+          value: my-custom-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.key
           value: client-secret
 
   - it: should use generated secret name when existingSecret is not set
@@ -534,12 +538,15 @@ tests:
       polaris.bootstrap.enabled: true
       polaris.auth.bootstrapCredentials.clientSecret: test-secret
     asserts:
+      # env[1] is POLARIS_CLIENT_ID (env[0] is POLARIS_CATALOG_NAME literal value)
       - matchRegex:
-          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
           pattern: ".*-polaris-credentials$"
 
   # --- S3 env var count ---
-  - it: should have 4 env vars when S3 storage is enabled
+  # Counts include POLARIS_CATALOG_NAME (env[0]) + POLARIS_CLIENT_ID/SECRET (env[1..2])
+  # + optional S3_ACCESS_KEY/SECRET_KEY when S3 storage is enabled.
+  - it: should have 5 env vars when S3 storage is enabled
     set:
       polaris.enabled: true
       polaris.bootstrap.enabled: true
@@ -549,9 +556,9 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers[0].env
-          count: 4
+          count: 5
 
-  - it: should have 2 env vars when S3 storage is disabled
+  - it: should have 3 env vars when S3 storage is disabled
     set:
       polaris.enabled: true
       polaris.bootstrap.enabled: true
@@ -560,4 +567,4 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers[0].env
-          count: 2
+          count: 3

--- a/charts/floe-platform/tests/bootstrap_grants_test.yaml
+++ b/charts/floe-platform/tests/bootstrap_grants_test.yaml
@@ -283,10 +283,17 @@ tests:
         - CATALOG_MANAGE_CONTENT
       polaris.auth.bootstrapCredentials.clientSecret: test-secret
     asserts:
-      # CATALOG_NAME shell var is set from Go template value
+      # POLARIS_CATALOG_NAME env var carries the Go template value (env[0])
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: POLARIS_CATALOG_NAME
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: my-special-catalog
+      # Shell script aliases CATALOG_NAME from the env var
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'CATALOG_NAME="my-special-catalog"'
+          pattern: 'CATALOG_NAME="\$POLARIS_CATALOG_NAME"'
 
   # --- Input validation ---
   - it: should validate grant variable names against shell metacharacters

--- a/tests/contract/test_test_infra_chart_integrity.py
+++ b/tests/contract/test_test_infra_chart_integrity.py
@@ -40,6 +40,15 @@ from typing import Any, cast
 import pytest
 import yaml
 
+# Regex for extracting `floe-platform-*` identifier tokens out of env var
+# string values (e.g. POLARIS_URI="http://floe-platform-polaris:8181/..."
+# should extract "floe-platform-polaris"). Used by AC-1 to catch hardcoded
+# hostnames that don't match any rendered resource. Trailing dots/colons
+# are excluded by the character class. Matches DNS label tokens of the
+# form `floe-platform-<component>[-<suffix>…]`.
+_FULLNAME_PREFIX = "floe-platform-"
+_ENV_VALUE_IDENT_PATTERN = re.compile(r"floe-platform-[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]")
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHART_DIR = REPO_ROOT / "charts" / "floe-platform"
 VALUES_TEST = CHART_DIR / "values-test.yaml"
@@ -172,11 +181,19 @@ def test_test_jobs_reference_only_chart_rendered_identifiers(
     """Every name a test Job references must be produced by the chart.
 
     Walks every rendered Job whose `test-type` label is set, collects the
-    `serviceAccountName`, every `secretRef.name`, and every
-    `secretKeyRef.name`. Asserts each identifier is the metadata.name of
-    another resource produced by the same render. Catches the regression
-    where someone hardcodes a Service or Secret name that doesn't actually
-    exist in the deployed release.
+    `serviceAccountName`, every `secretRef.name`, every `secretKeyRef.name`,
+    AND every `floe-platform-*` identifier token extracted from `env[*].value`
+    strings (e.g. POLARIS_URI="http://floe-platform-polaris:8181/..." yields
+    "floe-platform-polaris"). Asserts each identifier is the metadata.name
+    of another resource produced by the same render. Catches two regression
+    classes:
+
+    1. Hardcoded Service/Secret name in a `secretRef` that doesn't resolve.
+    2. Hardcoded hostname literal in a plain-value env var (e.g. someone
+       writes `POSTGRES_HOST: "floe-platform-postgres-wrong"` instead of
+       calling the helper). Without the env-value walker, that literal
+       lands in a live Job and manifests as a runtime DNS failure days
+       later in CI — this test catches it at render time.
     """
     rendered_names = {_name(d) for d in tests_enabled_render if _name(d)}
 
@@ -189,6 +206,10 @@ def test_test_jobs_reference_only_chart_rendered_identifiers(
     )
 
     referenced: set[str] = set()
+    # Separate set for env-value-extracted tokens so the failure message
+    # can point at the actual offender instead of saying "something in
+    # env values".
+    env_value_tokens: list[tuple[str, str, str]] = []  # (job, env_name, token)
     for job in test_jobs:
         pod = _pod_spec(job)
         sa = pod.get("serviceAccountName")
@@ -213,6 +234,17 @@ def test_test_jobs_reference_only_chart_rendered_identifiers(
                             ref_name = cast("dict[str, Any]", config_ref).get("name")
                             if isinstance(ref_name, str) and ref_name:
                                 referenced.add(ref_name)
+                    # Scan plain-value strings for embedded `floe-platform-*`
+                    # identifiers. Must run even when valueFrom is set (no
+                    # `elif`) because a single env entry can only have one
+                    # of value/valueFrom, but readers mustn't conflate
+                    # them — belt and braces.
+                    value = entry.get("value")
+                    env_name = entry.get("name")
+                    if isinstance(value, str) and isinstance(env_name, str):
+                        for match in _ENV_VALUE_IDENT_PATTERN.finditer(value):
+                            token = match.group(0)
+                            env_value_tokens.append((_name(job), env_name, token))
             env_from_list = container.get("envFrom") or []
             if isinstance(env_from_list, list):
                 for entry_any in cast("list[Any]", env_from_list):
@@ -225,6 +257,21 @@ def test_test_jobs_reference_only_chart_rendered_identifiers(
                             ref_name = cast("dict[str, Any]", ref).get("name")
                             if isinstance(ref_name, str) and ref_name:
                                 referenced.add(ref_name)
+        # Volumes: walk `persistentVolumeClaim.claimName` so a future
+        # hardcoded PVC name (bypassing `$context.Values.tests.artifacts.pvcName`)
+        # fails at render time instead of at Job-scheduling time when
+        # kubelet can't mount a non-existent PVC.
+        volumes = pod.get("volumes") or []
+        if isinstance(volumes, list):
+            for vol_any in cast("list[Any]", volumes):
+                if not isinstance(vol_any, dict):
+                    continue
+                vol: dict[str, Any] = cast("dict[str, Any]", vol_any)
+                pvc = vol.get("persistentVolumeClaim") or {}
+                if isinstance(pvc, dict):
+                    claim_name = cast("dict[str, Any]", pvc).get("claimName")
+                    if isinstance(claim_name, str) and claim_name:
+                        referenced.add(claim_name)
 
     # External references (e.g. third-party operator-managed secrets like
     # the bitnami postgres / minio secrets) are produced by subcharts. Those
@@ -236,6 +283,22 @@ def test_test_jobs_reference_only_chart_rendered_identifiers(
         f"the chart render: {missing}. Either the chart helper is wrong, "
         f"or someone hardcoded a name. Rendered names: "
         f"{sorted(rendered_names)[:10]}…"
+    )
+
+    # Validate env-value-extracted tokens against the same rendered-names
+    # set. A token that isn't a rendered metadata.name is a hardcoded
+    # hostname — drift in disguise.
+    unresolved_tokens: list[str] = [
+        f"{job}: env {env_name}={token}"
+        for job, env_name, token in env_value_tokens
+        if token not in rendered_names
+    ]
+    assert not unresolved_tokens, (
+        f"AC-1 violation: test Jobs have `floe-platform-*` literals in "
+        f"env[*].value that do NOT resolve to any rendered resource "
+        f"(prefix {_FULLNAME_PREFIX!r}). These are hardcoded hostnames — "
+        f"use a chart helper instead. Offenders:\n"
+        + "\n".join(f"  - {line}" for line in unresolved_tokens)
     )
 
 
@@ -330,14 +393,18 @@ def test_warehouse_name_single_source_of_truth(
 
 
 def _extract_bootstrap_catalog_names(docs: list[dict[str, Any]]) -> set[str]:
-    """Find the catalog name(s) the polaris-bootstrap Job creates.
+    """Read the catalog name from the bootstrap Job's POLARIS_CATALOG_NAME env var.
 
-    The bootstrap Job embeds the catalog name in a shell script in the
-    container `command`. We grep that script for the `"name": "..."` line
-    inside the catalog JSON payload — robust to script-format tweaks as
-    long as the JSON object retains a `"name"` field.
+    The bootstrap Job declares a POLARIS_CATALOG_NAME env var sourced from
+    the `floe-platform.polaris.warehouse` helper. The shell script reads
+    this env var, never a template literal. That makes the K8s API surface
+    the single source of truth — no regex-scanning shell bodies, no
+    first-match-wins brittleness.
+
+    A missing POLARIS_CATALOG_NAME env var on the bootstrap Job is itself
+    a contract violation: the caller is expected to fail AC-3 with an
+    actionable error instead of silently returning an empty set.
     """
-    pattern = re.compile(r'"name"\s*:\s*"([^"]+)"')
     names: set[str] = set()
     for doc in docs:
         if _kind(doc) != "Job":
@@ -345,21 +412,18 @@ def _extract_bootstrap_catalog_names(docs: list[dict[str, Any]]) -> set[str]:
         if "polaris-bootstrap" not in _name(doc):
             continue
         for container in _containers(_pod_spec(doc)):
-            cmd = container.get("command") or []
-            args = container.get("args") or []
-            blobs: list[str] = []
-            for blob in (*cmd, *args) if isinstance(cmd, list) and isinstance(args, list) else []:
-                if isinstance(blob, str):
-                    blobs.append(blob)
-            for blob in blobs:
-                # The bootstrap script wraps the catalog payload in a JSON
-                # object whose first `"name"` field is the catalog name.
-                # We pick the first match per blob to avoid catalog-role
-                # name collisions.
-                match = pattern.search(blob)
-                if match:
-                    names.add(match.group(1))
-                    break
+            env_list = container.get("env") or []
+            if not isinstance(env_list, list):
+                continue
+            for entry_any in cast("list[Any]", env_list):
+                if not isinstance(entry_any, dict):
+                    continue
+                entry: dict[str, Any] = cast("dict[str, Any]", entry_any)
+                if entry.get("name") != "POLARIS_CATALOG_NAME":
+                    continue
+                value = entry.get("value")
+                if isinstance(value, str) and value:
+                    names.add(value)
     return names
 
 


### PR DESCRIPTION
## Summary

Make Kubernetes identifier drift between the Helm chart, raw test manifests, and CI shell scripts **structurally impossible**. Every identifier (Service, Secret, ServiceAccount, Job, namespace, cluster name) now flows from a single source of truth — either a chart helper or a `FLOE_*` env var exported by `testing/ci/common.sh`. A new contract-tier tripwire test asserts this invariant on every CI run.

- **Chart is the source of truth**: test Jobs and RBAC moved from `testing/k8s/{jobs,rbac}/` into `charts/floe-platform/templates/tests/`. Raw manifests deleted.
- **Shell scripts source `common.sh`**: every `testing/ci/test-*.sh` resolves identifiers via helpers; no literal `floe-platform-` strings outside `common.sh`.
- **Contract tripwire**: `tests/contract/test_test_infra_chart_integrity.py` parses the rendered chart and fails CI if any Job references an identifier not produced by the chart.
- **Post-review tech debt resolved** (commit `362977f`): `polaris.credentialSecretName` helper extracted (7 inline sites replaced), catalog name hardened to flow via `POLARIS_CATALOG_NAME` env var (replaces fragile shell-body regex), AC-1 walker extended to `env[*].value`, and shared `_test-job.tpl` partial extracted (95% duplication between job-e2e.yaml / job-e2e-destructive.yaml eliminated).

## Acceptance Criteria

| AC  | Title                                                               | Status | Evidence |
|-----|---------------------------------------------------------------------|--------|----------|
| AC-1  | Test Job manifests live only in the chart                         | PASS   | contract test `test_test_jobs_reference_only_chart_rendered_identifiers` |
| AC-2  | Test Jobs gated by `tests.enabled`                                 | PASS   | contract test `test_tests_disabled_renders_no_test_resources` |
| AC-3  | Single source of truth for warehouse name                          | PASS   | contract test `test_warehouse_name_flows_from_single_values_key` |
| AC-4  | RBAC manifests live only in the chart                              | PASS   | contract test `test_rbac_renders_from_chart_templates` + `test_rbac_least_privilege.py` |
| AC-5  | Shell scripts resolve identifiers through `common.sh`              | PASS   | contract test `test_ci_scripts_source_common_sh_only` |
| AC-6  | `common.sh` provides a tested rendering helper                     | PASS   | integration test (bash subshell fixture) |
| AC-7  | Dead `test-runner.yaml` and directories deleted                    | PASS   | contract test `test_dead_manifest_paths_do_not_exist` |
| AC-8  | `TEST_SUITE=integration` path removed or repointed                 | PASS   | integration test |
| AC-9  | `fullnameOverride` preserved and respected by `floe_service_name`  | PASS   | contract test `test_fullname_override_preserved` |
| AC-10 | `make test-e2e` reaches test-run without name-resolution errors    | DEFERRED (e2e tier — validated in-cluster) |
| AC-11 | New contract test runs in gate-build and covers AC 1-9             | PASS   | `tests/contract/test_test_infra_chart_integrity.py` — 11 tests pass |

## Blast Radius

**Touched** (systemic — test infrastructure surface):
- `charts/floe-platform/templates/tests/` (new) — 4 files: `job-e2e.yaml`, `job-e2e-destructive.yaml`, `_test-job.tpl`, RBAC
- `charts/floe-platform/templates/_helpers.tpl` — new `polaris.credentialSecretName`, `testRunner.saName`, `testRunnerDestructive.saName` helpers
- `charts/floe-platform/templates/job-polaris-bootstrap.yaml` — catalog name via `POLARIS_CATALOG_NAME` env var; credential secret via helper
- `charts/floe-platform/templates/deployment-polaris.yaml` — 3 inline credential secret sites via helper
- `testing/ci/common.sh` (new) — single source of truth for `FLOE_*` variables and rendering helpers
- `testing/ci/test-*.sh` — migrated to source `common.sh`
- `testing/k8s/jobs/` and `testing/k8s/rbac/` — **deleted**
- `tests/contract/test_test_infra_chart_integrity.py` (new, 697 lines) — tripwire
- `tests/contract/test_rbac_least_privilege.py` — adapted to chart-rendered RBAC
- `charts/floe-platform/tests/{bootstrap-reliability,bootstrap_grants}_test.yaml` — index shifts for new env var

**Not changed**: Polaris bootstrap HTTP logic, Dagster subchart, `fullnameOverride` value, non-test CI workflows.

## Gate Results

| Gate     | Status | Notes |
|----------|--------|-------|
| build    | PASS   | `.specwright/work/test-infra-drift-elimination/evidence/build-report.md` |
| tests    | PASS   | 15/15 contract tests pass; 147/147 helm unittest tests pass |
| security | PASS   | `.specwright/work/test-infra-drift-elimination/evidence/security-report.md` |
| wiring   | PASS   | `.specwright/work/test-infra-drift-elimination/evidence/wiring-report.md` |
| spec     | PASS   | `.specwright/work/test-infra-drift-elimination/evidence/spec-report.md` |

## Test plan

- [ ] CI: `make test-unit` runs and the new `test_test_infra_chart_integrity.py` suite passes
- [ ] CI: helm lint + helm unittest pass on `charts/floe-platform`
- [ ] Manual: `helm template floe-platform charts/floe-platform -f charts/floe-platform/values-test.yaml --set tests.enabled=true` renders both test Jobs and RBAC without error
- [ ] Manual: `make test-e2e` on a deployed Kind cluster launches the test Job and reaches Running state (AC-10 smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)