### PR TITLE
fix(e2e): resolve test runner infra gaps blocking E2E pass rate

### DIFF
--- a/charts/floe-platform/templates/_helpers.tpl
+++ b/charts/floe-platform/templates/_helpers.tpl
@@ -195,6 +195,15 @@ OTel Collector component name.
 {{- end }}
 
 {{/*
+Jaeger query service name.
+Jaeger subchart uses Release.Name as its prefix (not fullnameOverride),
+so service names follow the pattern: {Release.Name}-jaeger-query.
+*/}}
+{{- define "floe-platform.jaeger.queryName" -}}
+{{- printf "%s-jaeger-query" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Marquez component name.
 */}}
 {{- define "floe-platform.marquez.fullname" -}}

--- a/charts/floe-platform/templates/tests/_test-job.tpl
+++ b/charts/floe-platform/templates/tests/_test-job.tpl
@@ -46,7 +46,7 @@ Fields:
 {{- $dagsterWeb := include "floe-platform.dagster.webserverName" $context }}
 {{- $marquez := include "floe-platform.marquez.fullname" $context }}
 {{- $otel := include "floe-platform.otel.fullname" $context }}
-{{- $jaegerQuery := printf "%s-jaeger-query" (include "floe-platform.fullname" $context) }}
+{{- $jaegerQuery := include "floe-platform.jaeger.queryName" $context }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -74,6 +74,8 @@ spec:
         - name: test-runner
           image: "{{ $context.Values.tests.image.repository }}:{{ $context.Values.tests.image.tag }}"
           imagePullPolicy: {{ $context.Values.tests.image.pullPolicy }}
+          # pytest writes .pyc caches, html reports, and json-report files
+          # to /app during execution — readOnlyRootFilesystem is not practical.
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -82,7 +84,6 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
             runAsUser: 1000
-          command: ["/app/.venv/bin/pytest"]
           args:
             - "--tb=short"
             - "-v"
@@ -170,16 +171,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-            - name: uv-cache
-              mountPath: /home/floe/.cache/uv
             {{- if $context.Values.tests.artifacts.enabled }}
             - name: artifacts
               mountPath: /artifacts
             {{- end }}
       volumes:
         - name: tmp
-          emptyDir: {}
-        - name: uv-cache
           emptyDir: {}
         {{- if $context.Values.tests.artifacts.enabled }}
         - name: artifacts

--- a/charts/floe-platform/templates/tests/_test-job.tpl
+++ b/charts/floe-platform/templates/tests/_test-job.tpl
@@ -46,6 +46,7 @@ Fields:
 {{- $dagsterWeb := include "floe-platform.dagster.webserverName" $context }}
 {{- $marquez := include "floe-platform.marquez.fullname" $context }}
 {{- $otel := include "floe-platform.otel.fullname" $context }}
+{{- $jaegerQuery := printf "%s-jaeger-query" (include "floe-platform.fullname" $context) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -78,9 +79,10 @@ spec:
             capabilities:
               drop:
               - ALL
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             runAsNonRoot: true
             runAsUser: 1000
+          command: ["/app/.venv/bin/pytest"]
           args:
             - "--tb=short"
             - "-v"
@@ -147,6 +149,10 @@ spec:
               value: {{ $dagsterWeb | quote }}
             - name: DAGSTER_WEBSERVER_HOST
               value: {{ $dagsterWeb | quote }}
+            - name: JAEGER_QUERY_HOST
+              value: {{ $jaegerQuery | quote }}
+            - name: JAEGER_URL
+              value: "http://{{ $jaegerQuery }}:16686"
             - name: OTEL_HOST
               value: {{ $otel | quote }}
             - name: OTEL_COLLECTOR_GRPC_HOST

--- a/charts/floe-platform/values-test.yaml
+++ b/charts/floe-platform/values-test.yaml
@@ -116,6 +116,19 @@ dagster:
           tag: latest
           pullPolicy: Never
         imagePullPolicy: Never
+        # Run pods execute dbt which writes to /app/demo/*/target/ and other
+        # project directories. readOnlyRootFilesystem is not practical for
+        # ephemeral run pods — too many write paths to enumerate with subPath.
+        runK8sConfig:
+          containerConfig:
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              runAsNonRoot: true
+              runAsUser: 1000
+              capabilities:
+                drop:
+                  - ALL
   # Enable user deployments to allow workspace.yaml to be mounted
   # Even with no actual code locations, this enables the workspace file mount
   dagster-user-deployments:

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -87,13 +87,14 @@ ENV PYTHONPATH=/app:/app/testing
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Default test command
-ENTRYPOINT ["uv", "run", "pytest"]
+# Default test command — use .venv/bin/pytest directly to avoid uv sync
+# writes that fail with readOnlyRootFilesystem: true in K8s
+ENTRYPOINT ["/app/.venv/bin/pytest"]
 CMD ["--tb=short", "-v"]
 
 # Health check (verify pytest is available)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD uv run python -c "import pytest; print(pytest.__version__)"
+    CMD /app/.venv/bin/python -c "import pytest; print(pytest.__version__)"
 
 # Labels
 LABEL org.opencontainers.image.title="floe-test-runner"

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -87,8 +87,8 @@ ENV PYTHONPATH=/app:/app/testing
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Default test command — use .venv/bin/pytest directly to avoid uv sync
-# writes that fail with readOnlyRootFilesystem: true in K8s
+# Default test command — invoke pytest directly from the venv to avoid
+# uv sync writes that fail under readOnlyRootFilesystem in K8s pods
 ENTRYPOINT ["/app/.venv/bin/pytest"]
 CMD ["--tb=short", "-v"]
 


### PR DESCRIPTION
## Summary

- **Add Jaeger service env vars** to test job template — tests were resolving `jaeger-query` instead of the Helm-prefixed `floe-platform-jaeger-query`, causing 27 test errors
- **Set `readOnlyRootFilesystem: false`** for Dagster run launcher pods in test environments — dbt writes to many project directories that can't be enumerated with subPath mounts
- **Switch test runner from `uv run pytest` to direct `.venv/bin/pytest`** — `uv run` performs a sync that writes to `.venv`, incompatible with read-only filesystem

E2E pass rate improved from **78.9% (243/308)** to **92.5% (285/308)** on Hetzner DevPod cluster.

## Test plan

- [x] Verified Jaeger env vars render correctly with `helm template`
- [x] Verified Dagster run pods now have `readOnlyRootFilesystem: false` (checked via `kubectl get pod -o jsonpath`)
- [x] Ran full E2E suite on Hetzner DevPod: 285 passed, 16 failed, 7 errors (7 min)
- [ ] Remaining 23 failures are pre-existing issues (code bugs, Docker image gaps, test design) — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)