### PR TITLE
ci: add dormant e2e workflow gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
               - 'uv.lock'
               - 'Makefile'
               - 'Dockerfile*'
+              - '**/Dockerfile*'
               - '.github/workflows/ci.yml'
               - '.github/workflows/e2e.yml'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: e2e-${{ github.ref }}
@@ -42,7 +43,7 @@ jobs:
               - 'charts/**'
               - 'testing/**'
               - 'plugins/**'
-              - 'floe-core/**'
+              - 'packages/floe-core/**'
               - 'tests/**'
               - 'pyproject.toml'
               - 'uv.lock'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
     # Phase E1: keep the workflow dormant until Units A-D have landed and the
     # end-to-end path is ready to serve as a real CI gate.
     #
-    # Phase E2 replacement:
+    # Phase E2 activation contract (arm in a follow-on PR):
     # if: |
     #   github.event_name == 'merge_group' ||
     #   github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,139 @@
+# End-to-end validation gate for infrastructure-affecting changes.
+#
+# Phase E1 ships the workflow dormant with `if: false` on the e2e job so
+# GitHub validates the workflow shape without running the expensive Kind path.
+# Phase E2 replaces that guard with the trigger expression recorded below.
+
+name: E2E
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION_DEFAULT: "3.10"
+  UV_CACHE_DIR: /tmp/.uv-cache
+
+jobs:
+  changed-files:
+    name: Changed Files
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Filter infra changes
+        id: filter
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3.0.3
+        with:
+          filters: |
+            infra:
+              - 'charts/**'
+              - 'testing/**'
+              - 'plugins/**'
+              - 'floe-core/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Makefile'
+              - 'Dockerfile*'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/e2e.yml'
+
+  e2e:
+    name: e2e
+    needs: [changed-files]
+    # Phase E1: keep the workflow dormant until Units A-D have landed and the
+    # end-to-end path is ready to serve as a real CI gate.
+    #
+    # Phase E2 replacement:
+    # if: |
+    #   github.event_name == 'merge_group' ||
+    #   github.event_name == 'workflow_dispatch' ||
+    #   contains(github.event.pull_request.labels.*.name, 'run-e2e') ||
+    #   needs.changed-files.outputs.infra == 'true'
+    if: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f  # v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Set up Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1
+        with:
+          cluster_name: floe-test
+          version: v0.24.0
+          node_image: kindest/node:v1.31.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4
+        with:
+          version: v3.16.0
+
+      - name: Pre-pull and load heavy images into Kind
+        run: |
+          for img in \
+            apache/polaris:1.2.0-incubating \
+            bitnami/postgresql:16.3.0-debian-12-r19 \
+            minio/minio:RELEASE.2024-09-13T20-26-02Z \
+            jaegertracing/all-in-one:1.60; do
+            docker pull "$img"
+            kind load docker-image "$img" --name floe-test
+          done
+
+      - name: Deploy floe-platform
+        run: ./testing/k8s/setup-cluster.sh
+        env:
+          SKIP_MONITORING: "true"
+
+      - name: Run E2E (standard + destructive)
+        run: make test-e2e-full
+        env:
+          IMAGE_LOAD_METHOD: kind
+
+      - name: Collect debug artifacts on failure
+        if: failure()
+        run: |
+          kubectl get pods,jobs,events -A -o wide || true
+          kubectl logs -n floe-test -l app.kubernetes.io/component=test-runner --tail=200 || true
+          kubectl logs -n floe-test deployment/floe-platform-polaris --tail=100 || true
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: e2e-results
+          path: |
+            test-artifacts/
+            /tmp/floe-*.log
+            e2e-results.xml
+            e2e-destructive-results.xml
+          if-no-files-found: warn
+          retention-days: 7

--- a/testing/ci/test-specwright-unit.sh
+++ b/testing/ci/test-specwright-unit.sh
@@ -19,6 +19,7 @@ cd "${PROJECT_ROOT}"
 uv run pytest -q \
     testing/tests/unit/test_polaris_fixture.py \
     testing/tests/unit/test_ci_workflows.py \
+    testing/tests/unit/test_e2e_workflow.py \
     testing/tests/unit/test_pvc_ownership_contract.py \
     testing/tests/unit/test_pvc_runner_contract.py \
     tests/unit/test_helm_bootstrap_template.py \

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -1,0 +1,284 @@
+"""Structural validation for the dormant Phase E1 E2E workflow.
+
+These tests parse ``.github/workflows/e2e.yml`` directly so the CI gate can be
+validated without needing GitHub Actions infrastructure, Kind, or Helm CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+E2E_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "e2e.yml"
+
+CHECKOUT_SHA = "34e114876b0b11c390a56381ad16ebd13914f8d5"
+SETUP_PYTHON_SHA = "a26af69be951a213d495a4c3e4e4022e16d87065"
+SETUP_UV_SHA = "e4db8464a088ece1b920f60402e813ea4de65b8f"
+SETUP_HELM_SHA = "1a275c3b69536ee54be43f2070a358922e12c8d4"
+KIND_ACTION_SHA = "a1b0e391336a6ee6713a0583f8c6240d70863de3"
+PATHS_FILTER_SHA = "d1c1ffe0248fe513906c8e24db8ea791d46f8590"
+UPLOAD_ARTIFACT_SHA = "ea165f8d65b6e75b540449e92b4886f43607fa02"
+
+
+def _load_workflow() -> dict[str, Any]:
+    """Return the parsed E2E workflow YAML."""
+
+    assert E2E_WORKFLOW.exists(), f"Expected E2E workflow at {E2E_WORKFLOW}"
+    workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict), "Workflow YAML must parse to a mapping."
+    return workflow
+
+
+def _workflow_triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the workflow trigger mapping, handling YAML 1.1 ``on`` parsing."""
+
+    triggers = workflow.get("on", workflow.get(True, {}))
+    assert isinstance(triggers, dict), "Workflow triggers must parse to a mapping."
+    return triggers
+
+
+def _job(workflow: dict[str, Any], job_name: str) -> dict[str, Any]:
+    """Return one named job from the workflow."""
+
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict), "Workflow jobs must parse to a mapping."
+    assert job_name in jobs, f"Missing '{job_name}' job. Found jobs: {list(jobs.keys())}"
+    job = jobs[job_name]
+    assert isinstance(job, dict), f"Job '{job_name}' must parse to a mapping."
+    return job
+
+
+def _job_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the step list for one job."""
+
+    steps = job.get("steps", [])
+    assert isinstance(steps, list), "Workflow job steps must be a list."
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step_by_name(job: dict[str, Any], name: str) -> dict[str, Any]:
+    """Return one step by its ``name`` field."""
+
+    steps = _job_steps(job)
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(
+        f"Missing step named '{name}'. Found: {[step.get('name') for step in steps]}"
+    )
+
+
+def _uses_ref(step: dict[str, Any]) -> str:
+    """Return the ``uses`` field for one step."""
+
+    uses = step.get("uses")
+    assert isinstance(uses, str) and uses, f"Step must declare a non-empty uses: {step}"
+    return uses
+
+
+class TestE2EWorkflowPhaseE1:
+    """Static validation for Unit E Phase E1 workflow structure."""
+
+    @pytest.mark.requirement("AC-1")
+    def test_workflow_exists_with_required_triggers(self) -> None:
+        """The workflow must exist and declare the Phase E1 trigger surface."""
+
+        workflow = _load_workflow()
+        triggers = _workflow_triggers(workflow)
+
+        pull_request = triggers.get("pull_request")
+        assert isinstance(pull_request, dict), "pull_request trigger must be configured."
+        assert pull_request.get("types") == ["opened", "synchronize", "reopened", "labeled"], (
+            "pull_request trigger must handle opened, synchronize, reopened, and labeled."
+        )
+        assert "merge_group" in triggers, "merge_group trigger must be declared."
+        assert "workflow_dispatch" in triggers, "workflow_dispatch trigger must be declared."
+
+    @pytest.mark.requirement("AC-2")
+    def test_e2e_job_is_dormant_in_phase_e1(self) -> None:
+        """Phase E1 must land with the real E2E job disabled."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+
+        assert e2e.get("if") is False, "Phase E1 must ship with `if: false` on the e2e job."
+
+    @pytest.mark.requirement("AC-3")
+    def test_changed_files_job_exports_infra_filter_output(self) -> None:
+        """The changed-files job must expose the infra filter output to ``needs``."""
+
+        workflow = _load_workflow()
+        changed_files = _job(workflow, "changed-files")
+        outputs = changed_files.get("outputs", {})
+
+        assert outputs.get("infra") == "${{ steps.filter.outputs.infra }}", (
+            "changed-files job must export steps.filter.outputs.infra as the infra output."
+        )
+
+        filter_step = _step_by_name(changed_files, "Filter infra changes")
+        assert _uses_ref(filter_step) == f"dorny/paths-filter@{PATHS_FILTER_SHA}", (
+            "changed-files job must pin dorny/paths-filter to a full commit SHA."
+        )
+
+        filters = filter_step.get("with", {}).get("filters")
+        assert isinstance(filters, str) and filters.strip(), (
+            "paths-filter step must define filters."
+        )
+
+        for expected_path in [
+            "charts/**",
+            "testing/**",
+            "plugins/**",
+            "floe-core/**",
+            "tests/**",
+            "pyproject.toml",
+            "uv.lock",
+            "Makefile",
+            "Dockerfile*",
+            ".github/workflows/ci.yml",
+            ".github/workflows/e2e.yml",
+        ]:
+            assert expected_path in filters, f"Missing infra filter path '{expected_path}'."
+
+        e2e = _job(workflow, "e2e")
+        assert e2e.get("needs") == ["changed-files"], "e2e job must depend on changed-files."
+
+    @pytest.mark.requirement("AC-5")
+    def test_workflow_has_non_cancelling_ref_scoped_concurrency(self) -> None:
+        """Concurrency must serialize by ref without cancelling in-flight E2E runs."""
+
+        workflow = _load_workflow()
+        concurrency = workflow.get("concurrency", {})
+
+        assert concurrency.get("group") == "e2e-${{ github.ref }}", (
+            "Workflow concurrency group must scope E2E runs to the current ref."
+        )
+        assert concurrency.get("cancel-in-progress") is False, (
+            "Workflow must not cancel in-progress E2E runs."
+        )
+
+    @pytest.mark.requirement("AC-6")
+    def test_e2e_job_pins_kind_and_helm_versions(self) -> None:
+        """Kind creation and Helm setup must be pinned for reproducibility."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+
+        kind_step = _step_by_name(e2e, "Set up Kind")
+        assert _uses_ref(kind_step) == f"helm/kind-action@{KIND_ACTION_SHA}", (
+            "Kind setup must pin helm/kind-action to a full commit SHA."
+        )
+        assert kind_step.get("with", {}).get("version") == "v0.24.0", (
+            "Kind setup must pin the Kind version."
+        )
+        assert kind_step.get("with", {}).get("node_image") == "kindest/node:v1.31.0", (
+            "Kind setup must pin the node image."
+        )
+
+        helm_step = _step_by_name(e2e, "Set up Helm")
+        assert _uses_ref(helm_step) == f"azure/setup-helm@{SETUP_HELM_SHA}", (
+            "Helm setup must pin azure/setup-helm to a full commit SHA."
+        )
+        assert helm_step.get("with", {}).get("version") == "v3.16.0", (
+            "Helm setup must pin Helm 3.16 explicitly."
+        )
+
+    @pytest.mark.requirement("AC-7")
+    def test_e2e_job_preloads_heavy_images_into_kind(self) -> None:
+        """The workflow must pre-pull and kind-load heavy images before deploy."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+        preload_step = _step_by_name(e2e, "Pre-pull and load heavy images into Kind")
+        run = preload_step.get("run", "")
+
+        assert isinstance(run, str) and run.strip(), "Preload step must define a run script."
+
+        for image in [
+            "apache/polaris:1.2.0-incubating",
+            "bitnami/postgresql:16.3.0-debian-12-r19",
+            "minio/minio:RELEASE.2024-09-13T20-26-02Z",
+            "jaegertracing/all-in-one:1.60",
+        ]:
+            assert image in run, f"Preload step must include pinned image '{image}'."
+
+        assert 'docker pull "$img"' in run, "Preload step must pre-pull each heavy image."
+        assert 'kind load docker-image "$img" --name floe-test' in run, (
+            "Preload step must load each heavy image into the floe-test Kind cluster."
+        )
+
+    @pytest.mark.requirement("AC-8")
+    def test_e2e_job_collects_failure_diagnostics_and_uploads_artifacts(self) -> None:
+        """The workflow must collect debug info on failure and upload artifacts always."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+
+        failure_step = _step_by_name(e2e, "Collect debug artifacts on failure")
+        assert failure_step.get("if") == "failure()", (
+            "Failure diagnostics step must only run when the job fails."
+        )
+        failure_run = failure_step.get("run", "")
+        assert isinstance(failure_run, str) and failure_run.strip(), (
+            "Failure diagnostics step must define a run script."
+        )
+        for command in [
+            "kubectl get pods,jobs,events -A -o wide",
+            "kubectl logs -n floe-test -l app.kubernetes.io/component=test-runner --tail=200",
+            "kubectl logs -n floe-test deployment/floe-platform-polaris --tail=100",
+        ]:
+            assert command in failure_run, f"Failure diagnostics step missing '{command}'."
+
+        upload_step = _step_by_name(e2e, "Upload test artifacts")
+        assert upload_step.get("if") == "always()", "Artifact upload must run unconditionally."
+        assert _uses_ref(upload_step) == f"actions/upload-artifact@{UPLOAD_ARTIFACT_SHA}", (
+            "Artifact upload must pin actions/upload-artifact to a full commit SHA."
+        )
+        upload_with = upload_step.get("with", {})
+        assert upload_with.get("name") == "e2e-results", (
+            "Artifact upload must use the e2e-results artifact name."
+        )
+        upload_path = upload_with.get("path", "")
+        assert isinstance(upload_path, str) and upload_path.strip(), (
+            "Artifact upload must define a non-empty path list."
+        )
+        for artifact_path in ["test-artifacts/", "/tmp/floe-*.log"]:
+            assert artifact_path in upload_path, f"Artifact upload must include '{artifact_path}'."
+
+    @pytest.mark.requirement("AC-9")
+    def test_e2e_job_has_timeout_and_expected_core_steps(self) -> None:
+        """The e2e job must have the expected timeout and execution steps."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+
+        assert e2e.get("timeout-minutes") == 30, "e2e job must use timeout-minutes: 30."
+
+        expected_uses = {
+            "actions/checkout": CHECKOUT_SHA,
+            "actions/setup-python": SETUP_PYTHON_SHA,
+            "astral-sh/setup-uv": SETUP_UV_SHA,
+        }
+        for step_name, action_prefix in {
+            "Checkout code": "actions/checkout",
+            "Set up Python": "actions/setup-python",
+            "Install uv": "astral-sh/setup-uv",
+        }.items():
+            step = _step_by_name(e2e, step_name)
+            assert _uses_ref(step) == f"{action_prefix}@{expected_uses[action_prefix]}", (
+                f"Step '{step_name}' must pin {action_prefix} to the repo-standard SHA."
+            )
+
+        assert _step_by_name(e2e, "Install dependencies").get("run") == "uv sync --all-extras --dev"
+        assert (
+            _step_by_name(e2e, "Deploy floe-platform").get("run")
+            == "./testing/k8s/setup-cluster.sh"
+        )
+        assert (
+            _step_by_name(e2e, "Run E2E (standard + destructive)").get("run")
+            == "make test-e2e-full"
+        )

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -2,18 +2,21 @@
 
 These tests parse ``.github/workflows/e2e.yml`` directly so the CI gate can be
 validated without needing GitHub Actions infrastructure, Kind, or Helm CLI.
+They also verify that the workflow contract remains wired into the repo's fast
+Specwright unit command.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 E2E_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "e2e.yml"
+FAST_UNIT_SLICE = REPO_ROOT / "testing" / "ci" / "test-specwright-unit.sh"
 
 CHECKOUT_SHA = "34e114876b0b11c390a56381ad16ebd13914f8d5"
 SETUP_PYTHON_SHA = "a26af69be951a213d495a4c3e4e4022e16d87065"
@@ -24,24 +27,32 @@ PATHS_FILTER_SHA = "d1c1ffe0248fe513906c8e24db8ea791d46f8590"
 UPLOAD_ARTIFACT_SHA = "ea165f8d65b6e75b540449e92b4886f43607fa02"
 
 
-def _load_workflow() -> dict[str, Any]:
+def _load_workflow() -> dict[object, Any]:
     """Return the parsed E2E workflow YAML."""
 
     assert E2E_WORKFLOW.exists(), f"Expected E2E workflow at {E2E_WORKFLOW}"
     workflow = yaml.safe_load(E2E_WORKFLOW.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict), "Workflow YAML must parse to a mapping."
-    return workflow
+    return cast(dict[object, Any], workflow)
 
 
-def _workflow_triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+def _workflow_text() -> str:
+    """Return the raw workflow text for comment-level contract checks."""
+
+    return E2E_WORKFLOW.read_text(encoding="utf-8")
+
+
+def _workflow_triggers(workflow: dict[object, Any]) -> dict[str, Any]:
     """Return the workflow trigger mapping, handling YAML 1.1 ``on`` parsing."""
 
-    triggers = workflow.get("on", workflow.get(True, {}))
+    triggers = workflow.get("on")
+    if triggers is None and True in workflow:
+        triggers = workflow[True]
     assert isinstance(triggers, dict), "Workflow triggers must parse to a mapping."
-    return triggers
+    return cast(dict[str, Any], triggers)
 
 
-def _job(workflow: dict[str, Any], job_name: str) -> dict[str, Any]:
+def _job(workflow: dict[object, Any], job_name: str) -> dict[str, Any]:
     """Return one named job from the workflow."""
 
     jobs = workflow.get("jobs", {})
@@ -49,7 +60,7 @@ def _job(workflow: dict[str, Any], job_name: str) -> dict[str, Any]:
     assert job_name in jobs, f"Missing '{job_name}' job. Found jobs: {list(jobs.keys())}"
     job = jobs[job_name]
     assert isinstance(job, dict), f"Job '{job_name}' must parse to a mapping."
-    return job
+    return cast(dict[str, Any], job)
 
 
 def _job_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
@@ -146,6 +157,29 @@ class TestE2EWorkflowPhaseE1:
 
         e2e = _job(workflow, "e2e")
         assert e2e.get("needs") == ["changed-files"], "e2e job must depend on changed-files."
+
+    @pytest.mark.requirement("AC-4")
+    def test_phase_e2_activation_contract_is_recorded_inline(self) -> None:
+        """Phase E1 must keep the exact future Phase E2 condition discoverable inline."""
+
+        workflow = _load_workflow()
+        e2e = _job(workflow, "e2e")
+        workflow_text = _workflow_text()
+
+        assert e2e.get("if") is False, "Phase E1 must keep the live e2e job dormant."
+        assert "# Phase E2 activation contract (arm in a follow-on PR):" in workflow_text, (
+            "Workflow must explain where the future arming condition lives."
+        )
+        for expected_line in [
+            "# if: |",
+            "#   github.event_name == 'merge_group' ||",
+            "#   github.event_name == 'workflow_dispatch' ||",
+            "#   contains(github.event.pull_request.labels.*.name, 'run-e2e') ||",
+            "#   needs.changed-files.outputs.infra == 'true'",
+        ]:
+            assert expected_line in workflow_text, (
+                f"Workflow must keep the Phase E2 activation line '{expected_line}'."
+            )
 
     @pytest.mark.requirement("AC-5")
     def test_workflow_has_non_cancelling_ref_scoped_concurrency(self) -> None:
@@ -281,4 +315,15 @@ class TestE2EWorkflowPhaseE1:
         assert (
             _step_by_name(e2e, "Run E2E (standard + destructive)").get("run")
             == "make test-e2e-full"
+        )
+
+    @pytest.mark.requirement("AC-10")
+    def test_workflow_contract_is_wired_into_fast_specwright_unit_slice(self) -> None:
+        """The workflow contract test must stay in the configured fast unit command."""
+
+        assert FAST_UNIT_SLICE.exists(), f"Expected fast unit command at {FAST_UNIT_SLICE}"
+        script_text = FAST_UNIT_SLICE.read_text(encoding="utf-8")
+
+        assert "testing/tests/unit/test_e2e_workflow.py" in script_text, (
+            "Fast Specwright unit command must include the workflow contract test."
         )

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -154,6 +154,7 @@ class TestE2EWorkflowPhaseE1:
             "uv.lock",
             "Makefile",
             "Dockerfile*",
+            "**/Dockerfile*",
             ".github/workflows/ci.yml",
             ".github/workflows/e2e.yml",
         ]:
@@ -316,7 +317,10 @@ class TestE2EWorkflowPhaseE1:
                 f"Step '{step_name}' must pin {action_prefix} to the repo-standard SHA."
             )
 
-        assert _step_by_name(e2e, "Install dependencies").get("run") == "uv sync --all-extras --dev", (
+        assert (
+            _step_by_name(e2e, "Install dependencies").get("run")
+            == "uv sync --all-extras --dev"
+        ), (
             "Install dependencies step must run 'uv sync --all-extras --dev'."
         )
         assert (

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -318,11 +318,8 @@ class TestE2EWorkflowPhaseE1:
             )
 
         assert (
-            _step_by_name(e2e, "Install dependencies").get("run")
-            == "uv sync --all-extras --dev"
-        ), (
-            "Install dependencies step must run 'uv sync --all-extras --dev'."
-        )
+            _step_by_name(e2e, "Install dependencies").get("run") == "uv sync --all-extras --dev"
+        ), "Install dependencies step must run 'uv sync --all-extras --dev'."
         assert (
             _step_by_name(e2e, "Deploy floe-platform").get("run")
             == "./testing/k8s/setup-cluster.sh"

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -100,6 +100,7 @@ class TestE2EWorkflowPhaseE1:
 
         workflow = _load_workflow()
         triggers = _workflow_triggers(workflow)
+        permissions = workflow.get("permissions")
 
         pull_request = triggers.get("pull_request")
         assert isinstance(pull_request, dict), "pull_request trigger must be configured."
@@ -108,6 +109,9 @@ class TestE2EWorkflowPhaseE1:
         )
         assert "merge_group" in triggers, "merge_group trigger must be declared."
         assert "workflow_dispatch" in triggers, "workflow_dispatch trigger must be declared."
+        assert permissions == {"contents": "read", "pull-requests": "read"}, (
+            "Workflow permissions must grant contents: read and pull-requests: read."
+        )
 
     @pytest.mark.requirement("AC-2")
     def test_e2e_job_is_dormant_in_phase_e1(self) -> None:
@@ -144,7 +148,7 @@ class TestE2EWorkflowPhaseE1:
             "charts/**",
             "testing/**",
             "plugins/**",
-            "floe-core/**",
+            "packages/floe-core/**",
             "tests/**",
             "pyproject.toml",
             "uv.lock",
@@ -280,7 +284,12 @@ class TestE2EWorkflowPhaseE1:
         assert isinstance(upload_path, str) and upload_path.strip(), (
             "Artifact upload must define a non-empty path list."
         )
-        for artifact_path in ["test-artifacts/", "/tmp/floe-*.log"]:
+        for artifact_path in [
+            "test-artifacts/",
+            "/tmp/floe-*.log",
+            "e2e-results.xml",
+            "e2e-destructive-results.xml",
+        ]:
             assert artifact_path in upload_path, f"Artifact upload must include '{artifact_path}'."
 
     @pytest.mark.requirement("AC-9")
@@ -307,15 +316,17 @@ class TestE2EWorkflowPhaseE1:
                 f"Step '{step_name}' must pin {action_prefix} to the repo-standard SHA."
             )
 
-        assert _step_by_name(e2e, "Install dependencies").get("run") == "uv sync --all-extras --dev"
+        assert _step_by_name(e2e, "Install dependencies").get("run") == "uv sync --all-extras --dev", (
+            "Install dependencies step must run 'uv sync --all-extras --dev'."
+        )
         assert (
             _step_by_name(e2e, "Deploy floe-platform").get("run")
             == "./testing/k8s/setup-cluster.sh"
-        )
+        ), "Deploy step must run './testing/k8s/setup-cluster.sh'."
         assert (
             _step_by_name(e2e, "Run E2E (standard + destructive)").get("run")
             == "make test-e2e-full"
-        )
+        ), "E2E run step must invoke 'make test-e2e-full'."
 
     @pytest.mark.requirement("AC-10")
     def test_workflow_contract_is_wired_into_fast_specwright_unit_slice(self) -> None:


### PR DESCRIPTION
## Summary
- Adds the Phase E1 dormant `.github/workflows/e2e.yml` surface so the repo gains a real E2E workflow contract without arming it prematurely.
- Pins the workflow contract in `testing/tests/unit/test_e2e_workflow.py` and keeps it inside the fast host-side Specwright slice via `testing/ci/test-specwright-unit.sh`.
- Records the exact future Phase E2 activation logic inline beside the dormant gate so the arming step is discoverable in the workflow file itself.

## Approval Lineage
- Design approval is `STALE`: recorded hash `sha256:a46c2b0bc1991624d5167b10ad732a29dab3909d51e526f93bcc8331609a47a0`, current design artifact hash `sha256:5fda653a54e5427dca41c8592d2530dc85634e6e7deae2a1e692fcf2c8761ba9`.
- Current Unit E `unit-spec` approval is `APPROVED` from `/sw-build` at `2026-04-21T04:56:37Z` with artifact hash `sha256:ee9245afeda4a59819ec005bb3b19c38ebc76efef5d49f604e95b237e80fbf6e`.

## What Changed
- Added `.github/workflows/e2e.yml` with the Phase E1 dormant `e2e` job, merge-queue / manual / PR trigger surface, pinned tool versions, image preloading, failure diagnostics, artifact upload, and the inline Phase E2 activation contract.
- Added `testing/tests/unit/test_e2e_workflow.py` to lock down the workflow shape, dormant gate, future arming condition, concurrency, version pinning, image preload list, diagnostics, artifact handling, timeout, and fast-slice wiring.
- Added the workflow contract test to `testing/ci/test-specwright-unit.sh` so future workflow edits stay under the repo-managed fast verification path.

## Why The Agent Implemented It This Way
- Unit E can only prove the Phase E1 branch-local slice honestly on this branch; GitHub-hosted registration and the later live Phase E2 arming run are operational follow-ons, not branch-local proofs.
- Keeping the future trigger expression inline in the workflow is a long-term developer experience choice: engineers can discover the exact activation logic in code instead of hunting through design artifacts.
- The contract test is deliberately host-side and deterministic so workflow drift is caught early without needing a full GitHub-hosted run.

## Acceptance Criteria
- `AC-1 PASS` — `.github/workflows/e2e.yml` declares `pull_request`, `merge_group`, and `workflow_dispatch`; enforced by `TestE2EWorkflow.test_workflow_exists_with_required_triggers`.
- `AC-2 PASS` — the Phase E1 `e2e` job stays dormant with `if: false`; enforced by `TestE2EWorkflow.test_e2e_job_is_dormant_in_phase_e1`.
- `AC-3 PASS` — `changed-files` uses `dorny/paths-filter@v3`, exports `infra`, and passes it to `needs.changed-files.outputs.infra`; enforced by `TestE2EWorkflow.test_changed_files_job_exports_infra_filter_output`.
- `AC-4 PASS` — the exact Phase E2 activation contract is recorded inline beside the dormant gate; enforced by `TestE2EWorkflow.test_phase_e2_activation_contract_is_recorded_inline`.
- `AC-5 PASS` — concurrency is ref-scoped and does not cancel in progress; enforced by `TestE2EWorkflow.test_workflow_has_non_cancelling_ref_scoped_concurrency`.
- `AC-6 PASS` — Kind and Helm setup is pinned to explicit versions; enforced by `TestE2EWorkflow.test_e2e_job_pins_kind_and_helm_versions`.
- `AC-7 PASS` — heavy images are pre-pulled and kind-loaded; enforced by `TestE2EWorkflow.test_e2e_job_preloads_heavy_images_into_kind`.
- `AC-8 PASS` — failure diagnostics and artifact upload are present; enforced by `TestE2EWorkflow.test_e2e_job_collects_failure_diagnostics_and_uploads_artifacts`.
- `AC-9 PASS` — the job timeout is 30 minutes and the execution path stays on `make test-e2e-full`; enforced by `TestE2EWorkflow.test_e2e_job_has_timeout_and_expected_core_steps`.
- `AC-10 PASS` — the workflow contract stays inside the fast Specwright unit slice; enforced by `TestE2EWorkflow.test_workflow_contract_is_wired_into_fast_specwright_unit_slice` and `testing/ci/test-specwright-unit.sh`.

## Spec Conformance
- `gate-spec` passed and mapped every active Unit E acceptance criterion (`AC-1` through `AC-10`) to implementation and test evidence in `.github/workflows/e2e.yml`, `testing/tests/unit/test_e2e_workflow.py`, and `testing/ci/test-specwright-unit.sh`.
- Because this is the final work unit, deliverable verification also reconciled behavioral `IC-B1` through `IC-B5` against the already shipped A/B/C/D proof set, plus a fresh rerun of `uv run pytest -q tests/integration/test_unit_c_devpod_flux_boundary.py`.

## Gate Summary
- `gate-build`: `PASS`
- `gate-tests`: `PASS`
- `gate-security`: `PASS`
- `gate-wiring`: `PASS`
- `gate-semantic`: `PASS`
- `gate-spec`: `PASS`
- Deliverable verification: `WARN` because `.specwright/config.json` does not yet define `commands.test:e2e` for a fresh configured E2E replay during `/sw-verify`.

## Remaining Attention
- Design approval lineage is stale and remains reviewer-visible process debt.
- `.specwright/config.json` still lacks a configured `commands.test:e2e` replay path for final-unit deliverable verification.
- Operational follow-ons remain pending by design: GitHub Actions registration on merge, the later Phase E2 arming PR, and the branch-protection flip after three green `main` runs.

## Evidence Links
- `.github/workflows/e2e.yml`
- `testing/tests/unit/test_e2e_workflow.py`
- `testing/ci/test-specwright-unit.sh`
