### PR TITLE
ci(charts): align helm release signing workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -192,6 +192,13 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
+      - name: Login Cosign to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push charts to OCI registry
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -168,6 +168,7 @@ jobs:
     needs: build
     permissions:
       packages: write
+      id-token: write
     steps:
       - name: Download chart artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -179,6 +180,9 @@ jobs:
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.14.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3
 
       - name: Login to GHCR
         env:
@@ -204,6 +208,19 @@ jobs:
           echo ""
           echo "Install with:"
           echo "  helm install floe oci://${REGISTRY_PATH}/floe-platform --version ${VERSION}"
+
+      - name: Sign OCI charts
+        continue-on-error: true
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for chart_name in floe-platform floe-jobs; do
+            chart_ref="${REGISTRY_PATH}/${chart_name}:${VERSION}"
+            echo "Signing ${chart_ref}..."
+            if ! cosign sign --yes "${chart_ref}"; then
+              echo "WARNING: Failed to sign ${chart_name}" >&2
+            fi
+          done
 
   # ============================================================
   # Stage 4: Create GitHub Release

--- a/testing/ci/test-specwright-unit.sh
+++ b/testing/ci/test-specwright-unit.sh
@@ -22,6 +22,7 @@ uv run pytest -q \
     testing/tests/unit/test_e2e_workflow.py \
     testing/tests/unit/test_pvc_ownership_contract.py \
     testing/tests/unit/test_pvc_runner_contract.py \
+    tests/unit/test_helm_release_workflow.py \
     tests/unit/test_helm_bootstrap_template.py \
     tests/unit/test_specwright_integration_wrapper.py \
     tests/unit/test_helm_values_rbac.py \

--- a/tests/unit/test_helm_release_workflow.py
+++ b/tests/unit/test_helm_release_workflow.py
@@ -54,8 +54,18 @@ def test_publish_oci_job_grants_id_token_and_package_permissions() -> None:
 def test_publish_oci_installs_cosign_before_signing() -> None:
     """Cosign is installed before the workflow attempts to sign chart refs."""
     install_step = _step_named("Install Cosign")
-    assert install_step["uses"].startswith("sigstore/cosign-installer@")
+    cosign_login_step = _step_named("Login Cosign to GHCR")
+    assert (
+        install_step["uses"]
+        == "sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da"
+    )
+    assert (
+        cosign_login_step["uses"]
+        == "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9"
+    )
+    assert cosign_login_step["with"]["registry"] == "ghcr.io"
     assert _step_index("Install Cosign") < _step_index("Sign OCI charts")
+    assert _step_index("Login Cosign to GHCR") < _step_index("Sign OCI charts")
 
 
 @pytest.mark.requirement("AC-3")
@@ -70,4 +80,5 @@ def test_publish_oci_signs_expected_chart_refs_after_push_as_best_effort() -> No
     run_script = sign_step["run"]
     assert "${REGISTRY_PATH}/${chart_name}:${VERSION}" in run_script
     assert "floe-platform floe-jobs" in run_script
+    assert 'echo "WARNING: Failed to sign ${chart_name}" >&2' in run_script
     assert "${REGISTRY}/${REGISTRY_PATH}" not in run_script

--- a/tests/unit/test_helm_release_workflow.py
+++ b/tests/unit/test_helm_release_workflow.py
@@ -56,12 +56,10 @@ def test_publish_oci_installs_cosign_before_signing() -> None:
     install_step = _step_named("Install Cosign")
     cosign_login_step = _step_named("Login Cosign to GHCR")
     assert (
-        install_step["uses"]
-        == "sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da"
+        install_step["uses"] == "sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da"
     )
     assert (
-        cosign_login_step["uses"]
-        == "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9"
+        cosign_login_step["uses"] == "docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9"
     )
     assert cosign_login_step["with"]["registry"] == "ghcr.io"
     assert _step_index("Install Cosign") < _step_index("Sign OCI charts")

--- a/tests/unit/test_helm_release_workflow.py
+++ b/tests/unit/test_helm_release_workflow.py
@@ -1,0 +1,73 @@
+"""Structural tests for the Helm release workflow signing alignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "helm-release.yaml"
+
+
+def _load_workflow() -> dict[str, Any]:
+    """Load the Helm release workflow definition."""
+    return yaml.safe_load(_WORKFLOW_PATH.read_text())
+
+
+def _publish_oci_job() -> dict[str, Any]:
+    """Return the publish-oci job configuration."""
+    workflow = _load_workflow()
+    return workflow["jobs"]["publish-oci"]
+
+
+def _publish_oci_steps() -> list[dict[str, Any]]:
+    """Return the publish-oci steps."""
+    return _publish_oci_job()["steps"]
+
+
+def _step_index(step_name: str) -> int:
+    """Return the index of a named publish-oci step."""
+    for index, step in enumerate(_publish_oci_steps()):
+        if step.get("name") == step_name:
+            return index
+    raise AssertionError(f"publish-oci step not found: {step_name}")
+
+
+def _step_named(step_name: str) -> dict[str, Any]:
+    """Return a named publish-oci step."""
+    return _publish_oci_steps()[_step_index(step_name)]
+
+
+@pytest.mark.requirement("AC-1")
+def test_publish_oci_job_grants_id_token_and_package_permissions() -> None:
+    """publish-oci grants the OIDC and GHCR permissions needed for keyless signing."""
+    permissions = _publish_oci_job()["permissions"]
+    assert permissions["packages"] == "write"
+    assert permissions["id-token"] == "write"
+
+
+@pytest.mark.requirement("AC-2")
+@pytest.mark.requirement("AC-5")
+def test_publish_oci_installs_cosign_before_signing() -> None:
+    """Cosign is installed before the workflow attempts to sign chart refs."""
+    install_step = _step_named("Install Cosign")
+    assert install_step["uses"].startswith("sigstore/cosign-installer@")
+    assert _step_index("Install Cosign") < _step_index("Sign OCI charts")
+
+
+@pytest.mark.requirement("AC-3")
+@pytest.mark.requirement("AC-4")
+@pytest.mark.requirement("AC-5")
+def test_publish_oci_signs_expected_chart_refs_after_push_as_best_effort() -> None:
+    """Signing runs after helm push, uses the pushed refs, and stays best-effort."""
+    sign_step = _step_named("Sign OCI charts")
+    assert _step_index("Push charts to OCI registry") < _step_index("Sign OCI charts")
+    assert sign_step["continue-on-error"] is True
+
+    run_script = sign_step["run"]
+    assert "${REGISTRY_PATH}/${chart_name}:${VERSION}" in run_script
+    assert "floe-platform floe-jobs" in run_script
+    assert "${REGISTRY}/${REGISTRY_PATH}" not in run_script


### PR DESCRIPTION
## Summary

This PR aligns the Helm OCI release workflow with the repo's existing signing posture by adding a thin, best-effort Cosign step after chart publication.

## Approval Lineage

- Design approval is recorded from `/sw-plan`, but the recorded artifact hash no longer validates under a protocol-style recompute against the current design artifact set.
- Unit approval for `unit-c-helm-release-signing` is recorded from `/sw-build`, but its recorded artifact hash also no longer validates under the same recompute.
- The shared Specwright approval helper referenced by the protocol is not present in this local install, so approval lineage should be treated as stale/unverified rather than silently trusted.

## What Changed

- Updated `.github/workflows/helm-release.yaml` so `publish-oci` grants `id-token: write`, installs pinned Cosign tooling, and signs the published GHCR chart refs after `helm push`.
- Added `tests/unit/test_helm_release_workflow.py`, a structural parser test that guards the `publish-oci` permissions, ordering, chart-ref construction, and best-effort signing behavior.
- No Python OCI signing code, CLI artifact-push logic, docs, or Flux example manifests changed in this unit.

## Why The Agent Implemented It This Way

- The change stays at the workflow-configuration layer because this unit is explicitly structural.
- The sign step builds refs from `${REGISTRY_PATH}/${chart_name}:${VERSION}` so the workflow signs the same GHCR paths it just pushed, without repeating the stale-branch bug that prepended `ghcr.io` twice.
- `continue-on-error: true` keeps signing best-effort so chart publication does not become brittle before the repo is ready to harden release signing.

## Acceptance Criteria

- `AC-1` PASS
  - Implementation: `.github/workflows/helm-release.yaml:169-171`
  - Test: `tests/unit/test_helm_release_workflow.py:45-49`
  - Proof: `publish-oci` grants both `packages: write` and `id-token: write`.
- `AC-2` WARN
  - Implementation: `.github/workflows/helm-release.yaml:184-185`
  - Test: `tests/unit/test_helm_release_workflow.py:54-58`
  - Proof: workflow installs Cosign before signing, but the current test only checks the `sigstore/cosign-installer@` prefix and does not prove the ref stays pinned to an immutable SHA.
- `AC-3` PASS
  - Implementation: `.github/workflows/helm-release.yaml:212-221`
  - Test: `tests/unit/test_helm_release_workflow.py:64-72`
  - Proof: the sign step uses `${REGISTRY_PATH}/${chart_name}:${VERSION}` and explicitly rejects `${REGISTRY}/${REGISTRY_PATH}`.
- `AC-4` WARN
  - Implementation: `.github/workflows/helm-release.yaml:212-221`
  - Test: `tests/unit/test_helm_release_workflow.py:64-72`
  - Proof: implementation is best-effort and logs per-chart failures, but the test does not currently assert that the warning logging remains present.
- `AC-5` PASS
  - Implementation: `tests/unit/test_helm_release_workflow.py:44-73`
  - Test execution: direct verify run `uv run pytest tests/unit/test_helm_release_workflow.py -q` (`3 passed`)
  - Proof: structural workflow coverage exists for permissions, order, ref construction, and best-effort behavior.

## Spec Conformance

- PASS: AC-1, AC-3, AC-5 have implementation and test evidence.
- WARN: AC-2 and AC-4 are implemented correctly, but the current test evidence is weaker than the criterion text.

## Gate Summary

| Gate | Verdict | Findings (B/W/I) |
|---|---|---|
| build | PASS | 0 / 0 / 2 |
| tests | WARN | 0 / 3 / 0 |
| security | PASS | 0 / 0 / 1 |
| wiring | PASS | 0 / 0 / 1 |
| semantic | PASS | 0 / 0 / 1 |
| spec | WARN | 0 / 2 / 0 |

Build / verification evidence:
- `make typecheck` PASS
- `./testing/ci/test-specwright-unit.sh` PASS (`117 passed`)
- `./testing/ci/test-specwright-integration.sh` SKIP (no integration profile matched this change surface)
- `uv run pytest tests/unit/test_helm_release_workflow.py -q` PASS (`3 passed`)

## Remaining Attention

- Tighten `tests/unit/test_helm_release_workflow.py:56-58` so the Cosign installer assertion proves the workflow stays pinned to an immutable ref.
- Extend `tests/unit/test_helm_release_workflow.py:66-72` so the failed-signing warning logging is asserted, not just the best-effort flag and ref shape.
- Fix `testing/ci/test-specwright-unit.sh:19-28`; the configured Specwright unit wrapper currently omits `tests/unit/test_helm_release_workflow.py`, so the repo's standard verify unit tier did not execute the new test without an explicit direct run.

## Evidence

Specwright work artifacts are running in `clone-local` mode, so reviewer-usable approval, rationale, conformance, and gate summaries are fully inlined above instead of depending on local-only paths.

Local audit artifact references retained in the worktree:
- `.git/specwright/work/flux-gitops-consolidation/units/unit-c-helm-release-signing/review-packet.md`
- `.git/specwright/work/flux-gitops-consolidation/units/unit-c-helm-release-signing/stage-report.md`
- `.git/specwright/work/flux-gitops-consolidation/units/unit-c-helm-release-signing/evidence/`
