### PR TITLE
docs: refresh public Flux GitOps examples and guide

### DIFF
--- a/charts/examples/flux/helmrelease.yaml
+++ b/charts/examples/flux/helmrelease.yaml
@@ -1,153 +1,68 @@
 # Flux HelmRelease for floe-platform
 #
-# This template deploys floe-platform using Flux CD's HelmRelease CRD.
-# Requires Flux v2 with the helm-controller and source-controller.
-#
-# Prerequisites:
-#   1. Flux v2 installed in the cluster
-#   2. HelmRepository or GitRepository source configured
-#   3. Namespace created (or use spec.install.createNamespace)
+# This example consumes the published chart from `ocirepository.yaml`.
+# Keep the HelmRelease, compiled values ConfigMap, and override Secret in the
+# same namespace so `valuesFrom` can resolve them cleanly.
 #
 # Usage:
-#   1. Update spec.chart.spec.sourceRef to point to your chart source
-#   2. Update spec.values or spec.valuesFrom as needed
-#   3. Apply: kubectl apply -f helmrelease.yaml
+#   1. Apply `ocirepository.yaml` in `flux-system`
+#   2. Generate compiled values with:
+#        floe platform compile \
+#          --spec floe.yaml \
+#          --manifest manifest.yaml \
+#          --output-format configmap \
+#          --configmap-name floe-compiled-values \
+#          --namespace flux-system
+#   3. Commit the rendered ConfigMap and an optional Secret named
+#      `floe-platform-overrides` beside this HelmRelease
 #
-# Requirements:
-# - 9b-FR-072: Flux HelmRelease template
+# Notes:
+# - The chart version knob lives in `ocirepository.yaml` under `spec.ref.tag`
+#   or `spec.ref.semver`
+# - `targetNamespace` is where the chart installs workloads; it is separate
+#   from the `flux-system` namespace that stores the source and values objects
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: floe
-  namespace: flux-system
-spec:
-  interval: 5m
-  url: https://your-org.github.io/floe-charts
-  # For OCI registry:
-  # type: oci
-  # url: oci://ghcr.io/your-org/charts
----
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: floe-platform-dev
+  name: floe-platform
   namespace: flux-system
-  labels:
-    app.kubernetes.io/name: floe-platform
-    app.kubernetes.io/instance: floe-dev
-    app.kubernetes.io/managed-by: flux
 spec:
-  # Release configuration
+  interval: 10m
   releaseName: floe
   targetNamespace: floe-dev
-
-  # Chart reference
-  chart:
-    spec:
-      chart: floe-platform
-      version: ">=1.0.0"
-      sourceRef:
-        kind: HelmRepository
-        name: floe
-        namespace: flux-system
-      # Reconciliation interval for chart updates
-      interval: 5m
-
-  # Reconciliation interval
-  interval: 10m
-
-  # Installation configuration
+  chartRef:
+    kind: OCIRepository
+    name: floe-platform
+    namespace: flux-system
   install:
-    # Create namespace if it doesn't exist
     createNamespace: true
-    # Remediation on install failure
     remediation:
       retries: 3
-    # Timeout for install
     timeout: 10m
-
-  # Upgrade configuration
   upgrade:
-    # Remediation on upgrade failure
+    cleanupOnFail: true
     remediation:
       retries: 3
-      # Rollback on upgrade failure
       remediateLastFailure: true
-    # Clean up old releases
-    cleanupOnFail: true
-    # Timeout for upgrade
     timeout: 10m
-
-  # Rollback configuration
-  rollback:
-    # Timeout for rollback
-    timeout: 5m
-    # Clean up on rollback
-    cleanupOnFail: true
-
-  # Uninstall configuration
-  uninstall:
-    # Keep history on uninstall
-    keepHistory: false
-    # Timeout for uninstall
-    timeout: 5m
-
-  # Values configuration
+  valuesFrom:
+    - kind: ConfigMap
+      name: floe-compiled-values
+      valuesKey: values.yaml
+    - kind: Secret
+      name: floe-platform-overrides
+      valuesKey: values.yaml
+      optional: true
   values:
     global:
       environment: dev
-
     namespace:
       name: floe-dev
-      create: false  # Flux creates it via install.createNamespace
-
-    dagster:
-      enabled: true
-
-    polaris:
-      enabled: true
-
-    postgresql:
-      enabled: true
-
-    minio:
-      enabled: true
-
-    networkPolicy:
-      enabled: false
-
-  # External values sources (optional)
-  # valuesFrom:
-  #   - kind: ConfigMap
-  #     name: floe-values
-  #     valuesKey: values.yaml
-  #   - kind: Secret
-  #     name: floe-secrets
-  #     valuesKey: secrets.yaml
-
-  # Depends on other HelmReleases (optional)
-  # dependsOn:
-  #   - name: cert-manager
-  #     namespace: cert-manager
-
-  # Post-install/upgrade hooks (optional)
-  # postRenderers:
-  #   - kustomize:
-  #       patches:
-  #         - target:
-  #             kind: Deployment
-  #             name: dagster-webserver
-  #           patch: |
-  #             - op: add
-  #               path: /spec/template/metadata/annotations/custom
-  #               value: annotation
-
-  # Drift detection
+      create: false
   driftDetection:
     mode: enabled
     ignore:
-      # Ignore replica count changes (may be controlled by HPA)
       - paths:
           - /spec/replicas
         target:

--- a/charts/examples/flux/helmrelease.yaml
+++ b/charts/examples/flux/helmrelease.yaml
@@ -54,6 +54,8 @@ spec:
       name: floe-platform-overrides
       valuesKey: values.yaml
       optional: true
+  # Inline values intentionally override matching keys from valuesFrom.
+  # Keep only environment-local knobs here; put shared compiled values in the ConfigMap.
   values:
     global:
       environment: dev

--- a/charts/examples/flux/kustomization.yaml
+++ b/charts/examples/flux/kustomization.yaml
@@ -1,192 +1,49 @@
 # Flux Kustomization for floe-platform
 #
-# This template orchestrates the deployment of floe-platform using
-# Flux CD's Kustomization CRD for GitOps-based management.
+# This Kustomization represents the surrounding GitOps repository layout for a
+# single environment. Keep the public deployment path GitRepository-driven even
+# though the chart itself is pulled from OCI.
 #
-# Directory structure expected:
+# Recommended environment tree:
 #   clusters/
-#     production/
-#       floe-platform/
-#         kustomization.yaml (this file)
-#         helmrelease.yaml
-#     staging/
+#     dev/
 #       floe-platform/
 #         kustomization.yaml
+#         ocirepository.yaml
 #         helmrelease.yaml
+#         compiled-values-configmap.yaml   # from `floe platform compile --output-format configmap`
+#         secret.enc.yaml                  # Age/SOPS-encrypted override values
+#         external-secrets.yaml            # Alternative to in-repo encrypted secrets
 #
-# Prerequisites:
-#   1. Flux v2 installed in the cluster
-#   2. GitRepository source configured pointing to this repo
-#
-# Usage:
-#   1. Place this file in your clusters/<env>/floe-platform/ directory
-#   2. Update spec.sourceRef to point to your GitRepository
-#   3. Flux will automatically reconcile
-#
-# Requirements:
-# - 9b-FR-072: Flux Kustomization template
+# Notes:
+# - The compiled ConfigMap belongs beside the HelmRelease so `valuesFrom` reads
+#   from the same namespace as the HelmRelease (`flux-system` in this example)
+# - Age/SOPS is the default encrypted-secret pattern for in-repo secrets
+# - External Secrets Operator is the recommended alternative when your secret
+#   source of truth lives outside Git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: floe-platform
+  name: floe-platform-dev
   namespace: flux-system
 spec:
-  # Reconciliation interval
   interval: 10m
-
-  # Retry interval on failure
   retryInterval: 2m
-
-  # Timeout for apply operations
   timeout: 5m
-
-  # Source reference (GitRepository or OCIRepository)
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: floe-config
     namespace: flux-system
-
-  # Path to kustomize overlay or resources
   path: ./clusters/dev/floe-platform
-
-  # Prune resources no longer in source
-  prune: true
-
-  # Wait for resources to be ready
-  wait: true
-
-  # Force apply (use with caution)
-  force: false
-
-  # Target namespace for resources without explicit namespace
-  targetNamespace: floe-dev
-
-  # Health checks for deployed resources
-  healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-dagster-webserver
-      namespace: floe-dev
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-dagster-daemon
-      namespace: floe-dev
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-polaris
-      namespace: floe-dev
-
-  # Patches to apply (optional)
-  # patches:
-  #   - patch: |
-  #       - op: replace
-  #         path: /spec/values/global/environment
-  #         value: dev
-  #     target:
-  #       kind: HelmRelease
-  #       name: floe-platform-dev
-
-  # Decryption for SOPS-encrypted secrets (optional)
-  # decryption:
-  #   provider: sops
-  #   secretRef:
-  #     name: sops-gpg
-
-  # Post-build variable substitution (optional)
-  # postBuild:
-  #   substitute:
-  #     ENVIRONMENT: dev
-  #     CLUSTER_NAME: dev-cluster
-  #   substituteFrom:
-  #     - kind: ConfigMap
-  #       name: cluster-vars
-  #     - kind: Secret
-  #       name: cluster-secrets
-
-  # Dependencies - wait for these before reconciling
-  # dependsOn:
-  #   - name: infrastructure
-  #     namespace: flux-system
-
----
-# Example: Multi-environment setup with Kustomization per environment
-#
-# Base HelmRelease that other environments inherit from
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: floe-platform-base
-  namespace: flux-system
-spec:
-  interval: 10m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./charts/examples/flux
-  prune: false
-  # Base doesn't apply directly, just defines resources
-  suspend: true
----
-# Staging environment
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: floe-platform-staging
-  namespace: flux-system
-spec:
-  interval: 10m
-  retryInterval: 2m
-  timeout: 5m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./clusters/staging/floe-platform
   prune: true
   wait: true
-  targetNamespace: floe-staging
   healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-dagster-webserver
-      namespace: floe-staging
-  postBuild:
-    substitute:
-      ENVIRONMENT: staging
----
-# Production environment (with manual gating)
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: floe-platform-prod
-  namespace: flux-system
-spec:
-  interval: 30m  # Less frequent for production
-  retryInterval: 5m
-  timeout: 10m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-  path: ./clusters/prod/floe-platform
-  prune: false  # Don't auto-prune in production
-  wait: true
-  targetNamespace: floe-prod
-  healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-dagster-webserver
-      namespace: floe-prod
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-dagster-daemon
-      namespace: floe-prod
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: floe-polaris
-      namespace: floe-prod
-  postBuild:
-    substitute:
-      ENVIRONMENT: prod
-  # Production requires the staging deployment to be healthy
-  dependsOn:
-    - name: floe-platform-staging
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: floe-platform
+      namespace: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/charts/examples/flux/ocirepository.yaml
+++ b/charts/examples/flux/ocirepository.yaml
@@ -1,0 +1,30 @@
+# Flux OCIRepository for floe-platform
+#
+# This source tracks the published floe-platform Helm chart in GHCR.
+# Keep this resource in the same namespace as the HelmRelease that consumes it.
+#
+# Usage:
+#   1. Update spec.ref.tag (or ref.semver) to the chart version you want to deploy
+#   2. Apply this manifest before the companion HelmRelease
+#   3. Optionally enable Flux OCI verification once you have matching trust policy
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: floe-platform
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: oci://ghcr.io/obsidian-owl/charts/floe-platform
+  ref:
+    tag: "0.1.0"
+  # Alternative version knob:
+  # ref:
+  #   semver: ">=0.1.0"
+  #
+  # Optional Cosign verification for tag-triggered chart releases:
+  # verify:
+  #   provider: cosign
+  #   matchOIDCIdentity:
+  #     - issuer: "^https://token.actions.githubusercontent.com$"
+  #       subject: "^https://github.com/Obsidian-Owl/floe/.github/workflows/helm-release.yaml@refs/tags/.+$"

--- a/charts/floe-platform/README.md
+++ b/charts/floe-platform/README.md
@@ -214,63 +214,16 @@ See [Dagster Helm Chart](https://docs.dagster.io/deployment/guides/kubernetes/de
 
 ### ArgoCD
 
-Use the provided ArgoCD templates for GitOps deployment:
-
-```bash
-# Single environment
-kubectl apply -f charts/examples/argocd/application.yaml
-
-# Multi-environment with ApplicationSet
-kubectl apply -f charts/examples/argocd/applicationset.yaml
-```
-
-The ApplicationSet template includes:
-- Progressive rollout (dev → qa → staging → prod)
-- Automated sync for non-prod, manual for prod
-- Retry policies with exponential backoff
-- Drift detection and self-healing
+Start with the public examples in [charts/examples/argocd/](../examples/argocd/).
+They stay focused on the operator entry points and avoid duplicating the chart
+README with a second full GitOps walkthrough.
 
 ### Flux CD
 
-Use the provided Flux templates for GitOps deployment:
-
-```bash
-# Apply HelmRelease
-kubectl apply -f charts/examples/flux/helmrelease.yaml
-
-# Apply Kustomization for environment orchestration
-kubectl apply -f charts/examples/flux/kustomization.yaml
-```
-
-The Flux templates include:
-- HelmRepository and HelmRelease CRDs
-- Kustomization with health checks
-- Drift detection with configurable ignore paths
-- SOPS decryption support (optional)
-- Dependency ordering between environments
-
-### GitOps Best Practices
-
-1. **Repository Structure**:
-   ```
-   clusters/
-     dev/
-       floe-platform/
-         kustomization.yaml
-         helmrelease.yaml
-     staging/
-       floe-platform/
-         kustomization.yaml
-         helmrelease.yaml
-     prod/
-       floe-platform/
-         kustomization.yaml
-         helmrelease.yaml
-   ```
-
-2. **Secrets Management**: Use SOPS, Sealed Secrets, or External Secrets Operator
-3. **Progressive Delivery**: Deploy to dev first, then staging, then production
-4. **Health Checks**: Configure health checks for critical deployments
+Use the public Flux examples in [charts/examples/flux/](../examples/flux/).
+For the supported operator workflow, including the compile-to-ConfigMap flow,
+OCI chart source, version knob, and `valuesFrom` integration, follow the
+dedicated [GitOps with Flux guide](../../docs/guides/deployment/gitops-flux.md).
 
 ## Upgrade Guide
 

--- a/docs/guides/deployment/gitops-flux.md
+++ b/docs/guides/deployment/gitops-flux.md
@@ -1,0 +1,136 @@
+# GitOps with Flux
+
+This guide describes the supported public Flux workflow for `floe-platform`.
+The public path is:
+
+1. Track the published chart with `charts/examples/flux/ocirepository.yaml`
+2. Deploy it with `charts/examples/flux/helmrelease.yaml`
+3. Keep those manifests in a GitRepository-driven environment overlay like
+   `charts/examples/flux/kustomization.yaml`
+4. Generate compiled values into a ConfigMap and layer environment-specific
+   overrides through `valuesFrom`
+
+## Public Inputs and Knobs
+
+These are the operator-facing controls for the public Flux path:
+
+| Knob | Default | Why it matters |
+|------|---------|----------------|
+| Chart OCI reference | `oci://ghcr.io/obsidian-owl/charts/floe-platform` | Public release source tracked by Flux |
+| Chart version knob | `spec.ref.tag` or `spec.ref.semver` in `ocirepository.yaml` | Controls which published chart version Flux pulls |
+| ConfigMap name | `floe-compiled-values` | Name used by `valuesFrom` for compiled values |
+| ConfigMap namespace | omitted by default | For Flux, set it to the same namespace as the HelmRelease |
+| HelmRelease namespace | `flux-system` in the example | Namespace that stores the source, HelmRelease, ConfigMap, and Secret |
+| Workload target namespace | `floe-dev` in the example | Namespace where the chart installs platform workloads |
+| Secret override name | `floe-platform-overrides` | Optional second `valuesFrom` layer for environment-specific overrides |
+
+## Recommended Repository Layout
+
+Keep the environment overlay in Git even though the chart itself is pulled from
+OCI:
+
+```text
+clusters/
+  dev/
+    floe-platform/
+      kustomization.yaml
+      ocirepository.yaml
+      helmrelease.yaml
+      compiled-values-configmap.yaml
+      secret.enc.yaml
+```
+
+- `compiled-values-configmap.yaml` is rendered by `floe platform compile`
+- `secret.enc.yaml` is the default Age/SOPS-encrypted secret example
+- If your secrets source of truth lives outside Git, replace the encrypted
+  secret with an External Secrets Operator manifest and keep the same
+  `valuesFrom` contract
+
+## Generate the Compiled Values ConfigMap
+
+`floe platform compile` supports a public ConfigMap output mode.
+
+```bash
+floe platform compile \
+  --spec floe.yaml \
+  --manifest manifest.yaml \
+  --output-format configmap \
+  --output clusters/dev/floe-platform/compiled-values-configmap.yaml \
+  --configmap-name floe-compiled-values \
+  --namespace flux-system
+```
+
+Important details:
+
+- `--output-format configmap` switches the CLI to ConfigMap output
+- `--configmap-name` defaults to `floe-compiled-values`; override it if you
+  need multiple releases in the same namespace
+- `--namespace` is optional in the CLI, but for Flux you should set it to the
+  same namespace as the HelmRelease so `valuesFrom` resolves the ConfigMap
+  without surprises
+- If you omit `--output`, the default path is `target/floe-compiled-values.yaml`
+
+## Track the Published Chart
+
+The public chart reference is:
+
+```text
+oci://ghcr.io/obsidian-owl/charts/floe-platform
+```
+
+Set the version you want Flux to consume in `ocirepository.yaml`:
+
+```yaml
+spec:
+  ref:
+    tag: "0.1.0"
+```
+
+Use `ref.tag` for an exact chart version pin. Use `ref.semver` if you want a
+range-based update policy.
+
+## Wire valuesFrom for ConfigMap and Secret Data
+
+The supported public `valuesFrom` pattern is:
+
+```yaml
+spec:
+  valuesFrom:
+    - kind: ConfigMap
+      name: floe-compiled-values
+      valuesKey: values.yaml
+    - kind: Secret
+      name: floe-platform-overrides
+      valuesKey: values.yaml
+      optional: true
+```
+
+This layering keeps the generated platform values and the environment-specific
+secret overrides separate:
+
+- The ConfigMap carries compiled non-secret values
+- The Secret carries environment-specific sensitive overrides
+- Both objects live in the same namespace as the HelmRelease
+
+## Secret Management Options
+
+The public examples assume Age/SOPS as the default in-repo encrypted-secret
+workflow:
+
+```yaml
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+```
+
+If you do not want encrypted secrets in Git, keep the same `valuesFrom` Secret
+contract and generate that Secret with External Secrets Operator instead.
+
+## Example Entry Points
+
+- OCI source example: [charts/examples/flux/ocirepository.yaml](../../../charts/examples/flux/ocirepository.yaml)
+- HelmRelease example: [charts/examples/flux/helmrelease.yaml](../../../charts/examples/flux/helmrelease.yaml)
+- Kustomization example: [charts/examples/flux/kustomization.yaml](../../../charts/examples/flux/kustomization.yaml)
+- Helm install guide: [kubernetes-helm.md](./kubernetes-helm.md)

--- a/docs/guides/deployment/index.md
+++ b/docs/guides/deployment/index.md
@@ -17,6 +17,7 @@ This document describes deployment architecture for floe, covering the separatio
 | [Two-Layer Model](two-layer-model.md) | Platform Services vs Pipeline Jobs |
 | [Local Development](local-development.md) | Local (uv) and Docker Compose setup |
 | [Kubernetes Helm](kubernetes-helm.md) | Helm chart structure and installation |
+| [GitOps with Flux](gitops-flux.md) | Public Flux operator workflow for OCI chart releases and compiled values |
 | [Production](production.md) | HA, scaling, monitoring, backups |
 | [Data Mesh](data-mesh.md) | Federated Data Mesh deployment topology |
 
@@ -41,6 +42,7 @@ This document describes deployment architecture for floe, covering the separatio
 
 ### Production Deployment
 - [Kubernetes Helm](kubernetes-helm.md) - Deploy to Kubernetes
+- [GitOps with Flux](gitops-flux.md) - Deploy with Flux using the public OCI chart path
 - [Production](production.md) - Production-ready configuration
 - [Data Mesh](data-mesh.md) - Multi-domain enterprise deployment
 

--- a/tests/unit/test_flux_public_examples.py
+++ b/tests/unit/test_flux_public_examples.py
@@ -1,0 +1,141 @@
+"""Structural tests for the public Flux examples and operator docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_FLUX_DIR = _REPO_ROOT / "charts" / "examples" / "flux"
+_OCI_REPOSITORY_PATH = _FLUX_DIR / "ocirepository.yaml"
+_HELMRELEASE_PATH = _FLUX_DIR / "helmrelease.yaml"
+_KUSTOMIZATION_PATH = _FLUX_DIR / "kustomization.yaml"
+_README_PATH = _REPO_ROOT / "charts" / "floe-platform" / "README.md"
+_GUIDE_PATH = _REPO_ROOT / "docs" / "guides" / "deployment" / "gitops-flux.md"
+_PUBLIC_STORY_PATHS = (
+    _OCI_REPOSITORY_PATH,
+    _HELMRELEASE_PATH,
+    _KUSTOMIZATION_PATH,
+    _README_PATH,
+    _GUIDE_PATH,
+)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a single-document YAML file."""
+    assert path.exists(), f"File not found: {path}"
+    docs = list(yaml.safe_load_all(path.read_text()))
+    assert len(docs) == 1, f"Expected one YAML document in {path}, got {len(docs)}"
+    return docs[0]
+
+
+def _section(markdown_path: Path, heading: str) -> str:
+    """Extract a markdown section body by heading."""
+    content = markdown_path.read_text()
+    marker = f"## {heading}\n"
+    start = content.index(marker) + len(marker)
+    remainder = content[start:]
+    next_heading = remainder.find("\n## ")
+    if next_heading == -1:
+        return remainder.strip()
+    return remainder[:next_heading].strip()
+
+
+@pytest.mark.requirement("AC-1")
+def test_public_flux_examples_include_ocirepository() -> None:
+    """The public example set includes a first-class OCIRepository source."""
+    doc = _load_yaml(_OCI_REPOSITORY_PATH)
+
+    assert doc["apiVersion"] == "source.toolkit.fluxcd.io/v1"
+    assert doc["kind"] == "OCIRepository"
+    assert doc["metadata"]["name"] == "floe-platform"
+    assert doc["metadata"]["namespace"] == "flux-system"
+    assert doc["spec"]["url"] == "oci://ghcr.io/obsidian-owl/charts/floe-platform"
+    assert "ref" in doc["spec"], "OCIRepository should expose an explicit chart version knob"
+
+
+@pytest.mark.requirement("AC-2")
+def test_public_helmrelease_uses_ga_api_oci_source_and_values_from() -> None:
+    """The public HelmRelease points at OCIRepository and external values data."""
+    doc = _load_yaml(_HELMRELEASE_PATH)
+
+    assert doc["apiVersion"] == "helm.toolkit.fluxcd.io/v2"
+    assert doc["kind"] == "HelmRelease"
+    assert "chartRef" in doc["spec"]
+    assert "chart" not in doc["spec"], "OCI-based public example should use chartRef"
+
+    chart_ref = doc["spec"]["chartRef"]
+    assert chart_ref["kind"] == "OCIRepository"
+    assert chart_ref["name"] == "floe-platform"
+    assert chart_ref["namespace"] == "flux-system"
+
+    values_from = doc["spec"]["valuesFrom"]
+    assert [entry["kind"] for entry in values_from] == ["ConfigMap", "Secret"]
+    assert values_from[0]["name"] == "floe-compiled-values"
+    assert values_from[0]["valuesKey"] == "values.yaml"
+    assert values_from[1]["name"] == "floe-platform-overrides"
+    assert values_from[1]["valuesKey"] == "values.yaml"
+
+
+@pytest.mark.requirement("AC-3")
+def test_public_kustomization_documents_gitops_layout_and_secret_strategies() -> None:
+    """The public Kustomization keeps GitRepository orchestration and explains the layout."""
+    doc = _load_yaml(_KUSTOMIZATION_PATH)
+    content = _KUSTOMIZATION_PATH.read_text()
+
+    assert doc["apiVersion"] == "kustomize.toolkit.fluxcd.io/v1"
+    assert doc["kind"] == "Kustomization"
+    assert doc["spec"]["sourceRef"]["kind"] == "GitRepository"
+    assert doc["spec"]["sourceRef"]["name"] == "floe-config"
+    assert doc["spec"]["path"] == "./clusters/dev/floe-platform"
+    assert "compiled-values-configmap.yaml" in content
+    assert "Age/SOPS" in content
+    assert "External Secrets Operator" in content
+
+
+@pytest.mark.requirement("AC-4")
+def test_chart_readme_flux_section_is_pointer_only() -> None:
+    """The chart README points operators at the public examples and guide."""
+    section = _section(_README_PATH, "GitOps Deployment")
+
+    assert "charts/examples/flux/" in section
+    assert "docs/guides/deployment/gitops-flux.md" in section
+    assert "charts/floe-platform/flux" not in section
+    assert "HelmRepository" not in section
+
+
+@pytest.mark.requirement("AC-5")
+def test_gitops_flux_guide_exposes_user_facing_knobs() -> None:
+    """The dedicated guide documents the public ConfigMap and chart controls."""
+    content = _GUIDE_PATH.read_text()
+
+    assert "--output-format configmap" in content
+    assert "--configmap-name" in content
+    assert "floe-compiled-values" in content
+    assert "--namespace" in content
+    assert "same namespace as the HelmRelease" in content
+    assert "flux-system" in content
+    assert "oci://ghcr.io/obsidian-owl/charts/floe-platform" in content
+    assert "ref.tag" in content or "ref.semver" in content
+    assert "valuesFrom" in content
+    assert "ConfigMap" in content
+    assert "Secret" in content
+
+
+@pytest.mark.requirement("AC-6")
+def test_public_flux_story_does_not_regress_to_legacy_paths_or_api_versions() -> None:
+    """The public docs and examples stay off the old public story."""
+    legacy_terms = (
+        "HelmRepository",
+        "helm.toolkit.fluxcd.io/v2beta2",
+        "charts/floe-platform/flux",
+    )
+
+    for path in _PUBLIC_STORY_PATHS:
+        assert path.exists(), f"Expected public story file to exist: {path}"
+        content = path.read_text()
+        for term in legacy_terms:
+            assert term not in content, f"Unexpected legacy term {term!r} in {path}"

--- a/tests/unit/test_flux_public_examples.py
+++ b/tests/unit/test_flux_public_examples.py
@@ -29,6 +29,7 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     assert path.exists(), f"File not found: {path}"
     docs = list(yaml.safe_load_all(path.read_text()))
     assert len(docs) == 1, f"Expected one YAML document in {path}, got {len(docs)}"
+    assert isinstance(docs[0], dict), f"Expected a YAML mapping in {path}, got {type(docs[0])}"
     return docs[0]
 
 
@@ -36,7 +37,10 @@ def _section(markdown_path: Path, heading: str) -> str:
     """Extract a markdown section body by heading."""
     content = markdown_path.read_text()
     marker = f"## {heading}\n"
-    start = content.index(marker) + len(marker)
+    try:
+        start = content.index(marker) + len(marker)
+    except ValueError:
+        pytest.fail(f"Heading '## {heading}' not found in {markdown_path}")
     remainder = content[start:]
     next_heading = remainder.find("\n## ")
     if next_heading == -1:
@@ -131,6 +135,7 @@ def test_public_flux_story_does_not_regress_to_legacy_paths_or_api_versions() ->
     legacy_terms = (
         "HelmRepository",
         "helm.toolkit.fluxcd.io/v2beta2",
+        "source.toolkit.fluxcd.io/v1beta2",
         "charts/floe-platform/flux",
     )
 


### PR DESCRIPTION
## Summary

Refresh the public Flux operator story so it matches what the repo actually supports today:

- add a standalone public `OCIRepository` example for the released chart
- move the public `HelmRelease` example to Flux v2 + `chartRef.kind: OCIRepository`
- document the GitRepository-driven environment overlay, compile-to-ConfigMap flow, and secret layering in one canonical guide
- reduce the chart README to pointers so the public path stops drifting from implementation
- add a structural anti-drift suite over the public YAML and Markdown surface

## Approval Lineage

- Design approval recorded via `/sw-plan` on `2026-04-22T00:14:42Z`
- Unit-spec approval recorded via `/sw-build` for `unit-d-public-flux-gitops-docs` on `2026-04-22T08:53:14Z`
- Reviewer attention: this local Specwright install cannot run the canonical approval-hash helper, and `plan.md` was extended after approval with `Discovered Behaviors` / `As-Built Notes`, so treat the unit-spec approval as present in the ledger but likely stale until those notes are accepted

## What Changed

- `charts/examples/flux/ocirepository.yaml`: new public OCI source example for the released chart
- `charts/examples/flux/helmrelease.yaml`: public Flux v2 `HelmRelease` using `OCIRepository` and ConfigMap/Secret `valuesFrom`
- `charts/examples/flux/kustomization.yaml`: GitRepository-driven environment overlay with compiled ConfigMap placement, Age/SOPS, and External Secrets guidance
- `charts/floe-platform/README.md`: GitOps section reduced to public entry-point pointers
- `docs/guides/deployment/gitops-flux.md`: dedicated operator-facing Flux guide exposing the user knobs directly
- `docs/guides/deployment/index.md`: guide linked from deployment navigation
- `tests/unit/test_flux_public_examples.py`: structural anti-drift coverage for the public story

## Why The Agent Implemented It This Way

- The public operator surface is now explicitly separated from the internal Kind/CI fixture path so the repo does not maintain two competing GitOps stories.
- The public examples were collapsed to one authoritative OCI source, one `HelmRelease`, and one environment `Kustomization` so operators see the supported path without stale alternatives.
- The chart README was turned into a pointer surface because it is a landing page, not a second GitOps manual.
- The dedicated guide exposes the compile-to-ConfigMap, namespace, and chart-version knobs directly so end users do not need to dig through code to find them.
- The guardrail for this unit is a parser-plus-text anti-drift suite over the real YAML and Markdown artifacts, because this unit is about documentation and example correctness rather than runtime behavior.

## Acceptance Criteria

| Criterion | Status | Evidence |
|---|---|---|
| AC-1 Public example set includes an `OCIRepository` and no longer teaches `HelmRepository` | PASS | Impl: `charts/examples/flux/ocirepository.yaml:11-20` Test: `tests/unit/test_flux_public_examples.py:47-57` |
| AC-2 Public HelmRelease uses Flux v2, the OCI source, and the ConfigMap/Secret `valuesFrom` pattern | PASS | Impl: `charts/examples/flux/helmrelease.yaml:25-56` Test: `tests/unit/test_flux_public_examples.py:60-80` |
| AC-3 Public Kustomization documents the GitRepository overlay, compiled ConfigMap placement, Age/SOPS, and ESO alternative | PASS | Impl: `charts/examples/flux/kustomization.yaml:3-23,25-49` Test: `tests/unit/test_flux_public_examples.py:83-96` |
| AC-4 Chart README is pointer-only and no longer teaches the old public path | PASS | Impl: `charts/floe-platform/README.md:223-226` Test: `tests/unit/test_flux_public_examples.py:99-107` |
| AC-5 Dedicated guide exposes the user-facing compile and OCI knobs | PASS | Impl: `docs/guides/deployment/gitops-flux.md:13-25,49-71,73-105`; `docs/guides/deployment/index.md:19-20,45` Test: `tests/unit/test_flux_public_examples.py:110-125` |
| AC-6 Fast structural anti-drift tests guard against regression to the old public story | PASS | Impl/Test: `tests/unit/test_flux_public_examples.py:128-141` |

## Spec Conformance

- `gate-spec` passed all six unit acceptance criteria.
- Final-unit behavioral integration criteria also passed:
  - IC-B1 compile-to-ConfigMap output aligns with the public `valuesFrom` contract
  - IC-B2 internal test fixtures remain GitRepository-based while the public examples remain OCIRepository-based
  - IC-B3 guide, examples, and release workflow now tell one internally consistent operator story

## Gate Summary

| Gate | Verdict |
|---|---|
| build | PASS |
| tests | WARN |
| security | PASS |
| wiring | PASS |
| semantic | PASS |
| spec | PASS |
| deliverable verification (inline) | WARN |

## Remaining Attention

- `testing/ci/test-specwright-unit.sh` does not yet include `tests/unit/test_flux_public_examples.py`, so the new public anti-drift suite is not part of the default fast wrapper yet
- `.specwright/config.json` does not yet define `commands.test:e2e` for the final multi-unit deliverable check
- Approval lineage for this unit should be reviewed in light of the post-approval `plan.md` notes

## Evidence

Reviewer-usable proof is inlined above because this repo is using clone-local Specwright work artifacts.

Key executed checks:
- `make typecheck` → PASS
- `./testing/ci/test-specwright-unit.sh` → PASS (`120 passed`)
- `./testing/ci/test-specwright-integration.sh` → PASS/INFO (`No targeted Specwright integration suite matched the current change surface`)
- `uv run pytest tests/unit/test_flux_public_examples.py -q` → PASS (`6 passed`)
- `uv run pytest tests/unit/test_flux_manifests.py -q` → PASS (`22 passed`)
