### PR TITLE
[codex] Harden validation lanes and demo image wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ DEVPOD_DEVCONTAINER=.devcontainer/hetzner/devcontainer.json
 DEVPOD_K8S_API_PORT=26443
 # Remote repo root inside the DevPod workspace (matches the default devcontainer)
 DEVPOD_REMOTE_WORKDIR=/workspace
+# Optional manifest override for local/test runners; defaults to demo/manifest.yaml
+FLOE_MANIFEST_PATH=
+# Optional demo image repository override for local/Kind validation
+FLOE_DEMO_IMAGE_REPOSITORY=
+# Optional demo image tag override; blank uses the repo-derived default tag helper
+FLOE_DEMO_IMAGE_TAG=
 # Docker config mode for public image pulls (`isolated` avoids broken helper proxies)
 FLOE_PUBLIC_DOCKER_CONFIG_MODE=isolated
 # Optional DOCKER_CONFIG directory for public image pulls; blank uses a temp config

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -55,7 +55,7 @@ flowchart TB
 | Job | Purpose | Speed |
 |-----|---------|-------|
 | **lint-typecheck** | ruff + mypy --strict | ~30s |
-| **security** | bandit + pip-audit | ~30s |
+| **security** | bandit + uv-secure | ~30s |
 | **unit-tests** | pytest across Python versions | ~60s |
 | **contract-tests** | Cross-package schema validation | ~20s |
 | **traceability** | Requirement marker coverage | ~10s |
@@ -136,14 +136,16 @@ make setup-hooks
 ```
 
 > **Note**: This installs hooks for pre-commit code quality checks and Cognee knowledge sync.
+> It also sets a repo-local `core.hooksPath`, so these hooks still run if you use a
+> global hooks manager elsewhere.
 > Run again after `pre-commit install` to restore hooks.
 
 ### What Runs Locally
 
 | Hook | When | Checks |
 |------|------|--------|
-| **Pre-commit** | `git commit` | ruff, formatting, bandit, yaml |
-| **Pre-push** | `git push` | mypy --strict, unit tests |
+| **Pre-commit** | `git commit` | ruff autofix, formatting, secrets, file hygiene, bandit, yaml |
+| **Pre-push** | `git push` | ruff check, `ruff format --check`, mypy, dbt version validation, bandit, uv-secure, unit tests, contract tests, traceability |
 
 ### Reproduce CI Locally
 

--- a/.github/actions/uv-security-audit/action.yml
+++ b/.github/actions/uv-security-audit/action.yml
@@ -13,36 +13,4 @@ runs:
     - name: Run vulnerability audit
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
-        # Centralized vulnerability ignores (update ONE place):
-        # - GHSA-5j53-63w8-8625: fastapi-users OAuth/CSRF (not used)
-        # - GHSA-7gcm-g887-7qv7: protobuf DoS (transitive, no fix)
-
-        IGNORE_VULNS="GHSA-5j53-63w8-8625,GHSA-7gcm-g887-7qv7"
-
-        echo "Running uv-secure with ignores: $IGNORE_VULNS"
-
-        output=$(uv run uv-secure --no-check-uv-tool --ignore-vulns "$IGNORE_VULNS" . 2>&1) || {
-          exit_code=$?
-          echo "$output"
-
-          # Exit code 2 = warnings (not blocking)
-          if [ $exit_code -eq 2 ]; then
-            echo "::warning::uv-secure returned warnings (exit code 2)"
-            exit 0
-          fi
-
-          # Exit code 3 = tool crash, check if actual vulns
-          if [ $exit_code -eq 3 ]; then
-            if echo "$output" | grep -q "Vulnerable:" && ! echo "$output" | grep -q "Vulnerable: 0"; then
-              echo "::error::Vulnerabilities detected"
-              exit 1
-            else
-              echo "::warning::uv-secure crashed but no vulnerabilities reported"
-              exit 0
-            fi
-          fi
-
-          exit $exit_code
-        }
-        echo "$output"
+      run: ./testing/ci/uv-security-audit.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,34 +87,7 @@ jobs:
           echo "No problematic hardcoded sleeps found"
 
       - name: Validate dbt version requirements
-        run: |
-          echo "Validating dbt plugin version requirements..."
-
-          # Check floe-dbt-core requires dbt-core>=1.6,<2.0 (NFR-003)
-          CORE_DEP=$(grep -E '"dbt-core.*"' plugins/floe-dbt-core/pyproject.toml || true)
-          if [[ -z "$CORE_DEP" ]]; then
-            echo "ERROR: floe-dbt-core must depend on dbt-core" >&2
-            exit 1
-          fi
-          if ! echo "$CORE_DEP" | grep -qE '>=1\.6.*<2\.0'; then
-            echo "ERROR: floe-dbt-core must require dbt-core>=1.6,<2.0" >&2
-            echo "Current: $CORE_DEP" >&2
-            echo "Required: dbt-core>=1.6,<2.0 (NFR-003)" >&2
-            exit 1
-          fi
-          echo "✓ floe-dbt-core: $CORE_DEP"
-
-          # Check floe-dbt-fusion requires dbt Fusion CLI >=1.0 (NFR-004)
-          # Note: Fusion is a CLI binary, not a Python dependency
-          # We validate the detection module checks for version >=1.0
-          FUSION_CHECK=$(grep -E 'MIN_FUSION_VERSION|>=.*1\.0' plugins/floe-dbt-fusion/src/floe_dbt_fusion/detection.py || true)
-          if [[ -z "$FUSION_CHECK" ]]; then
-            echo "WARNING: Could not verify Fusion version check in detection.py" >&2
-          else
-            echo "✓ floe-dbt-fusion: Fusion version check found"
-          fi
-
-          echo "dbt version requirements validated"
+        run: ./testing/ci/validate-dbt-version-requirements.sh
 
   # ============================================================
   # Stage 1b: Security Scanning (Bandit + pip-audit)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 #
 # Quality Bar Alignment:
 # - Pre-commit: Fast checks (<5s) - linting, formatting, secrets, sleep detection
-# - Pre-push: Thorough checks - mypy, tests, traceability (matches CI)
+# - Pre-push: CI-aligned validation - lint, format, type, security, tests, traceability
 
 default_language_version:
   python: python3
@@ -47,34 +47,42 @@ repos:
     hooks:
       # Trailing whitespace
       - id: trailing-whitespace
+        stages: [pre-commit]
 
       # End of file newline
       - id: end-of-file-fixer
+        stages: [pre-commit]
         exclude: \.omc/
 
       # YAML syntax (exclude Helm templates - Go template syntax not parseable)
       - id: check-yaml
+        stages: [pre-commit]
         args: [--unsafe]  # Allow custom tags
         exclude: ^charts/.*templates/
 
       # Large files
       - id: check-added-large-files
+        stages: [pre-commit]
         args: [--maxkb=1000]
 
       # Merge conflict markers
       - id: check-merge-conflict
+        stages: [pre-commit]
 
       # Debug statements
       - id: debug-statements
+        stages: [pre-commit]
 
       # Case conflicts (important for cross-platform)
       - id: check-case-conflict
+        stages: [pre-commit]
 
   # Security scanning
   - repo: https://github.com/PyCQA/bandit
     rev: 1.9.3
     hooks:
       - id: bandit
+        stages: [pre-commit]
         args: [-c, pyproject.toml]
         additional_dependencies: ["bandit[toml]"]
         exclude: ^(tests/|packages/.*/tests/|plugins/.*/tests/|\.claude/|devtools/|testing/)
@@ -153,6 +161,14 @@ repos:
         stages: [pre-push]
         pass_filenames: false
 
+      # Validate dbt dependency/version contracts (matches CI exactly)
+      - id: dbt-version-contracts
+        name: dbt version requirements
+        entry: ./testing/ci/validate-dbt-version-requirements.sh
+        language: script
+        stages: [pre-push]
+        pass_filenames: false
+
       # Security: Bandit static analysis (matches CI)
       - id: bandit-security
         name: bandit (security scan)
@@ -163,55 +179,28 @@ repos:
         pass_filenames: false
 
       # Security: Vulnerability audit (matches CI)
-      # Ignores documented false positives (see pyproject.toml for justification)
-      # GHSA-hm8f-75xx-w2vr: sigstore <4.2.0 - mitigated by network isolation (Epic 8B)
-      # GHSA-2q4j-m29v-hq73: pypdf in devtools/agent-memory - internal tool only
-      # GHSA-wp53-j4wj-2cfg: python-multipart in devtools/agent-memory - internal tool only
-      # GHSA-cfh3-3jmp-rvhc: pillow in devtools/agent-memory - cognee pins <12.0, internal tool
-      # GHSA-w8v5-vhqr-4h9v: diskcache in devtools/agent-memory - no fix available, internal tool
-      # GHSA-vp96-hxj8-p424: pyOpenSSL 25.3.0 - fix in 26.0.0, transitive dep via pyiceberg
-      # GHSA-5pwr-322w-8jr4: pyOpenSSL 25.3.0 - fix in 26.0.0, transitive dep via pyiceberg
       - id: uv-secure
         name: uv-secure (vulnerability audit)
-        entry: bash -c 'IGNORES=$(grep -v "^#" .vuln-ignore 2>/dev/null | grep -v "^$" | paste -sd "," -); uv run --no-sync uv-secure --no-check-uv-tool ${IGNORES:+--ignore-vulns "$IGNORES"} .'
-        language: system
-        stages: [pre-push]
-        pass_filenames: false
-
-      # Security: pip-audit (matches CI - catches CVEs from PyPI advisory DB)
-      - id: pip-audit
-        name: pip-audit (CVE check)
-        entry: bash -c 'uv run --no-sync pip-audit --strict 2>/dev/null || echo "pip-audit not installed, skipping" >&2'
-        language: system
-        stages: [pre-push]
-        pass_filenames: false
-
-      # Architecture boundary enforcement
-      - id: import-linter
-        name: import-linter (architecture)
-        entry: uv run --no-sync lint-imports
-        language: system
+        entry: ./testing/ci/uv-security-audit.sh
+        language: script
         types: [python]
         stages: [pre-push]
         pass_filenames: false
 
       # Unit tests (all packages - matches CI)
-      # Uses --ignore-glob to handle missing directories gracefully
-      # Must match CI's test-unit.sh behavior: only tests/unit/ directories
       - id: pytest-unit
         name: pytest (unit tests + coverage)
-        entry: bash -c 'uv run --no-sync pytest packages/ plugins/ --ignore-glob="**/integration/**" --ignore-glob="**/e2e/**" --ignore-glob="**/tests/contract/**" -v --tb=short -x --cov=packages --cov=plugins --cov-fail-under=80'
-        language: system
+        entry: ./testing/ci/test-unit.sh
+        language: script
         types: [python]
         stages: [pre-push]
         pass_filenames: false
 
       # Contract tests (cross-package validation - matches CI)
-      # Includes both root-level and package-level contract tests
       - id: pytest-contract
         name: pytest (contract tests)
-        entry: bash -c 'uv run --no-sync pytest tests/contract/ packages/*/tests/contract/ --ignore-glob="**/tests/contract/__pycache__/**" -v --tb=short -x 2>/dev/null || uv run --no-sync pytest tests/contract/ -v --tb=short -x'
-        language: system
+        entry: ./testing/ci/test-contract.sh
+        language: script
         types: [python]
         stages: [pre-push]
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ make setup-hooks
 make check
 ```
 
+`make setup-hooks` also sets a repo-local `core.hooksPath`, so floe's hooks still
+run even if you use a global hook manager in other repositories.
+
 ### Running Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,8 @@ helm-test: ## Run Helm tests (requires deployed release, RELEASE=name, NAMESPACE
 .PHONY: helm-install-dev
 helm-install-dev: helm-deps ## Install floe-platform for development
 	@echo "Installing floe-platform for development..."
-	@uv run floe platform deploy --env dev --chart charts/floe-platform
+	@uv run floe platform deploy --env dev --chart charts/floe-platform \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall floe-platform (NAMESPACE=ns required)
@@ -277,7 +278,8 @@ helm-integration-test: helm-deps ## Run Helm integration tests in Kind cluster
 	@# Install charts via floe platform deploy
 	@echo "Installing floe-platform chart..."
 	@uv run floe platform deploy --env dev --chart charts/floe-platform \
-		--namespace floe-test --timeout 5m
+		--namespace floe-test --timeout 5m \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@# Run Helm tests
 	@echo "Running Helm tests..."
 	@helm test floe-platform --namespace floe-test --timeout 5m
@@ -286,7 +288,8 @@ helm-integration-test: helm-deps ## Run Helm integration tests in Kind cluster
 .PHONY: helm-install-test
 helm-install-test: helm-deps ## Install floe-platform with test values (requires Kind cluster)
 	@echo "Installing floe-platform with test configuration..."
-	@uv run floe platform deploy --env test --chart charts/floe-platform
+	@uv run floe platform deploy --env test --chart charts/floe-platform \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@echo "Installing floe-jobs with test configuration..."
 	@helm upgrade --install floe-jobs-test charts/floe-jobs \
 		--namespace floe-test \
@@ -297,7 +300,8 @@ helm-install-test: helm-deps ## Install floe-platform with test values (requires
 .PHONY: helm-upgrade-test
 helm-upgrade-test: helm-deps ## Upgrade floe-platform test installation
 	@echo "Upgrading floe-platform test installation..."
-	@uv run floe platform deploy --env test --chart charts/floe-platform
+	@uv run floe platform deploy --env test --chart charts/floe-platform \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@helm upgrade floe-jobs-test charts/floe-jobs \
 		--namespace floe-test \
 		--values charts/floe-jobs/values-test.yaml \
@@ -330,6 +334,18 @@ helm-test-infra: ## Verify test infrastructure is healthy
 
 .PHONY: compile-demo build-demo-image demo demo-local demo-stop
 
+DEMO_MANIFEST ?= demo/manifest.yaml
+DEMO_IMAGE_REPOSITORY ?= floe-dagster-demo
+DEMO_IMAGE_TAG ?= $(shell python3 testing/ci/resolve-demo-image-ref.py --field tag)
+DEMO_IMAGE_REF ?= $(DEMO_IMAGE_REPOSITORY):$(DEMO_IMAGE_TAG)
+DEMO_IMAGE_HELM_SET_ARGS = \
+	--set dagster.dagsterWebserver.image.repository=$(DEMO_IMAGE_REPOSITORY) \
+	--set dagster.dagsterWebserver.image.tag=$(DEMO_IMAGE_TAG) \
+	--set dagster.dagsterDaemon.image.repository=$(DEMO_IMAGE_REPOSITORY) \
+	--set dagster.dagsterDaemon.image.tag=$(DEMO_IMAGE_TAG) \
+	--set dagster.runLauncher.config.k8sRunLauncher.image.repository=$(DEMO_IMAGE_REPOSITORY) \
+	--set dagster.runLauncher.config.k8sRunLauncher.image.tag=$(DEMO_IMAGE_TAG)
+
 compile-demo: ## Compile dbt models and generate Dagster definitions for all demo products
 	@echo "Compiling dbt models for all demo products..."
 	@# Local-only defaults for dbt compile — real environments must override via env vars.
@@ -349,7 +365,7 @@ compile-demo: ## Compile dbt models and generate Dagster definitions for all dem
 		echo "Generating definitions for $$product..."; \
 		uv run floe platform compile \
 			--spec demo/$$product/floe.yaml \
-			--manifest demo/manifest.yaml \
+			--manifest $(DEMO_MANIFEST) \
 			--output demo/$$product/compiled_artifacts.json \
 			--generate-definitions || exit 1; \
 	done
@@ -374,31 +390,34 @@ DOCKER_PLATFORM ?= linux/amd64
 # - Reads plugins section, maps each to package name via convention + exception map
 # - Only includes packages that exist in the workspace (packages/ or plugins/)
 # - Always includes floe-core (all plugins depend on it) and floe-dbt-core (demo products need it)
-DEMO_PLUGINS := $(shell .venv/bin/python -c "from pathlib import Path; import yaml, os; m = yaml.safe_load(Path('demo/manifest.yaml').read_text()); plugins = m.get('plugins', {}); nm = dict(x.split(':') for x in '$(PLUGIN_NAME_MAP)'.split() if ':' in x); names = set(['floe-core', 'floe-dbt-core']); [names.add(nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type',''))) for k,v in plugins.items() if os.path.isdir('packages/'+nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type',''))) or os.path.isdir('plugins/'+nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type','')))]; print(' '.join(sorted(names)))")
+DEMO_PLUGINS := $(shell .venv/bin/python -c "from pathlib import Path; import yaml, os; m = yaml.safe_load(Path('$(DEMO_MANIFEST)').read_text()); plugins = m.get('plugins', {}); nm = dict(x.split(':') for x in '$(PLUGIN_NAME_MAP)'.split() if ':' in x); names = set(['floe-core', 'floe-dbt-core']); [names.add(nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type',''))) for k,v in plugins.items() if os.path.isdir('packages/'+nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type',''))) or os.path.isdir('plugins/'+nm.get(v.get('type',''), 'floe-'+k+'-'+v.get('type','')))]; print(' '.join(sorted(names)))")
 
 build-demo-image: compile-demo ## Build Dagster demo Docker image and load to Kind
 	@echo "Building Dagster demo Docker image..."
 	@echo "  Plugins: $(DEMO_PLUGINS)"
 	@echo "  Platform: $(DOCKER_PLATFORM)"
+	@echo "  Image: $(DEMO_IMAGE_REF)"
 	@scripts/with-public-docker-config.sh docker build -f docker/dagster-demo/Dockerfile \
 		--build-arg FLOE_PLUGINS="$(DEMO_PLUGINS)" \
 		--platform $(DOCKER_PLATFORM) \
-		-t floe-dagster-demo:latest .
+		-t $(DEMO_IMAGE_REF) .
 	@echo "Loading image to Kind cluster..."
-	@kind load docker-image floe-dagster-demo:latest --name $${KIND_CLUSTER_NAME:-floe-test}
+	@bash -lc 'source testing/ci/common.sh && floe_kind_evict_image "$(DEMO_IMAGE_REF)" "$${KIND_CLUSTER_NAME:-floe-test}"'
+	@kind load docker-image $(DEMO_IMAGE_REF) --name $${KIND_CLUSTER_NAME:-floe-test}
 	@echo "Demo image built and loaded to Kind successfully!"
 
 demo: ## Deploy demo via DevPod (requires running DevPod workspace)
 	@echo "=== Starting floe Platform Demo (DevPod) ==="
 	@scripts/devpod-ensure-ready.sh
 	@echo "Building demo image inside DevPod..."
-	@devpod ssh "$(DEVPOD_WORKSPACE)" -- "cd /workspace && make build-demo-image"
+	@devpod ssh "$(DEVPOD_WORKSPACE)" -- "cd /workspace && FLOE_DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY) FLOE_DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG) make build-demo-image"
 	@echo "Updating Helm chart dependencies..."
 	@helm dependency update charts/floe-platform
 	@echo "Deploying Helm chart via tunneled kubectl..."
 	@KUBECONFIG=$(HOME)/.kube/devpod-floe.config uv run floe platform deploy \
 		--env dev --chart ./charts/floe-platform \
-		--values ./charts/floe-platform/values-demo.yaml
+		--values ./charts/floe-platform/values-demo.yaml \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@echo "Starting port-forwards..."
 	@if [ -f .demo-pids ]; then \
 		kill $$(cat .demo-pids) 2>/dev/null || true; \
@@ -439,7 +458,8 @@ demo-local: build-demo-image ## Deploy demo locally (requires local Kind cluster
 	$(MAKE) kind-up
 	@echo "Installing floe-platform Helm chart with demo overrides..."
 	@uv run floe platform deploy --env dev --chart ./charts/floe-platform \
-		--values ./charts/floe-platform/values-demo.yaml
+		--values ./charts/floe-platform/values-demo.yaml \
+		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@echo "=== Demo Ready ==="
 	@echo "Dagster UI:    http://localhost:3000"
 	@echo "Polaris:       http://localhost:8181"

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,7 +47,9 @@ make check
 
 ## K8s-Native Testing
 
-**All integration and E2E tests run in Kubernetes** (Kind cluster locally, managed K8s in CI/prod).
+**Integration tests and deployed-product validation lanes run in Kubernetes.**
+Host-side validation still exists for bootstrap/admin workflows and repo-aware
+checks that cannot run correctly from inside an in-cluster test Job.
 
 ### Why K8s-Native?
 
@@ -65,7 +67,10 @@ make check
 | Unit | Host (`uv run pytest`) | None (mocks only) |
 | Contract | Host (`uv run pytest`) | None |
 | **Integration** | **Kind cluster (K8s)** | Polaris, PostgreSQL, S3 (LocalStack) |
-| **E2E** | **Kind cluster (K8s)** | Full platform stack |
+| **E2E bootstrap** | **Host (local machine or DevPod workspace)** | Real `helm`, `kubectl`, cluster access |
+| **E2E platform_blackbox** | **Kind cluster (K8s Job)** | Full deployed platform stack |
+| **E2E developer_workflow** | **Host (local machine or DevPod workspace)** | Repo metadata (`.git`, `.gitignore`, `.vuln-ignore`) plus any required tools |
+| **E2E destructive** | **Kind cluster (K8s Job, gated)** | Full deployed platform stack with disruptive operations |
 
 ---
 
@@ -119,30 +124,59 @@ tests/
 | **Unit** | `tests/unit/` | Host (pytest, fast) | None (mocks) | None |
 | **Contract** | `tests/contract/` | Host (pytest, fast) | None | `@pytest.mark.contract` |
 | **Integration** | `tests/integration/` | Kind (K8s) | Real services | `@pytest.mark.integration`<br>`@pytest.mark.requirement()` |
-| **E2E** | `tests/e2e/` | Kind (K8s) | Full platform | `@pytest.mark.e2e`<br>`@pytest.mark.requirement()` |
+| **E2E** | `tests/e2e/` | Host or Kind, depending on validation lane | Varies by lane | `@pytest.mark.e2e`<br>lane marker (`bootstrap`, `platform_blackbox`, `developer_workflow`, `destructive`)<br>`@pytest.mark.requirement()` |
 
 ---
 
 ## Running Tests
 
-### E2E Tests (DevPod — Default)
+### Validation Lanes
 
-E2E tests default to running against a DevPod workspace on Hetzner:
+- `contract`: host-side structural and cross-package validation
+- `bootstrap`: host-side admin/deployment validation with real `helm` and `kubectl`
+- `platform_blackbox`: standard in-cluster product validation under least-privilege RBAC
+- `developer_workflow`: host-side repo-aware checks (`.git`, `.gitignore`, `.vuln-ignore`)
+- `destructive`: gated in-cluster disruptive validation after standard product pass
+
+### E2E Validation (DevPod + Hetzner or local Kind)
+
+`tests/e2e` is no longer a single execution lane. The standard deployed-product
+lane runs in-cluster, while bootstrap/admin and repo-aware checks run host-side
+in the local environment or inside the DevPod workspace.
 
 ```bash
-# E2E tests via DevPod (default — requires running workspace)
+# Standard deployed-product validation in-cluster
 make test-e2e
 
-# E2E tests locally (requires local Kind cluster)
-make test-e2e-local
+# Full lane orchestration: bootstrap -> platform_blackbox -> developer_workflow -> destructive
+make test-e2e-full
+
+# Legacy host port-forwarded runner
+make test-e2e-host
+
+# Run host-side lanes directly
+./testing/ci/test-bootstrap-validation.sh
+./testing/ci/test-developer-workflow.sh
 ```
 
-`make test-e2e` calls `scripts/devpod-ensure-ready.sh` to validate the workspace is running and the K8s API tunnel is established, then runs tests with `KUBECONFIG=~/.kube/devpod-floe.config`. The test script (`testing/ci/test-e2e.sh`) creates its own kubectl port-forwards through the tunneled K8s API — no SSH service tunnels needed.
+`make test-e2e` runs `testing/ci/test-e2e-cluster.sh`, which submits the
+standard `platform_blackbox and not destructive` suite as a Kubernetes Job.
+When `DEVPOD_WORKSPACE` is set and the current kube context is not already
+usable, the runner validates the DevPod workspace and reuses the synced
+`~/.kube/devpod-floe.config`. Otherwise it runs against the current local Kind
+cluster.
 
-If you don't have a DevPod workspace, start one first:
+`make test-e2e-full` runs `testing/ci/test-e2e-full.sh`, which executes the
+host-side `bootstrap` lane first, then the standard in-cluster
+`platform_blackbox` lane, always runs the host-side `developer_workflow` lane,
+and only runs the gated `destructive` lane after bootstrap + platform success
+unless `FORCE_DESTRUCTIVE=true`.
+
+If you use DevPod on Hetzner, start the workspace before running the validation
+flow:
 ```bash
 make devpod-up     # Create/start workspace on Hetzner
-make test-e2e      # Run E2E tests
+make test-e2e-full # Run the full validation flow
 make devpod-stop   # Stop workspace when done (preserves disk)
 ```
 
@@ -414,10 +448,12 @@ This runs automatically on workspace start and is idempotent.
 
 ### Running Tests Remotely
 
-From your **local machine** (not inside DevPod), the default targets use the remote cluster:
+From your **local machine** (not inside DevPod), the lane runners can target the
+remote DevPod Kind cluster:
 
 ```bash
-make test-e2e           # E2E tests via DevPod (validates workspace, tunnels kubectl)
+make test-e2e           # Standard in-cluster platform_blackbox lane
+make test-e2e-full      # Full multi-lane validation flow
 make demo               # Deploy demo via DevPod with port-forwards
 make demo-stop          # Stop demo port-forwards
 ```
@@ -426,7 +462,9 @@ Inside the DevPod workspace (via `make devpod-ssh`), tests run against the local
 
 ```bash
 make test-unit          # Unit tests (no K8s needed)
-make test-e2e-local     # E2E tests against local Kind
+make test-e2e           # Standard in-cluster platform_blackbox lane
+./testing/ci/test-bootstrap-validation.sh
+./testing/ci/test-developer-workflow.sh
 make test               # All tests
 ```
 
@@ -856,7 +894,11 @@ Available markers (defined in `pyproject.toml`):
 | `slow` | Tests taking > 1 second | `@pytest.mark.slow` |
 | `integration` | Require external services (K8s) | `@pytest.mark.integration` |
 | `contract` | Cross-package validation | `@pytest.mark.contract` |
-| `e2e` | End-to-end pipeline tests | `@pytest.mark.e2e` |
+| `e2e` | End-to-end validation tests | `@pytest.mark.e2e` |
+| `bootstrap` | Host-side bootstrap/admin validation | `@pytest.mark.bootstrap` |
+| `platform_blackbox` | Standard in-cluster product validation | `@pytest.mark.platform_blackbox` |
+| `developer_workflow` | Host-side repo-aware validation | `@pytest.mark.developer_workflow` |
+| `destructive` | In-cluster disruptive validation | `@pytest.mark.destructive` |
 | `requirement` | Links test to requirement | `@pytest.mark.requirement("9c-FR-001")` |
 
 ### Running by Marker
@@ -870,6 +912,15 @@ uv run pytest -m integration -v
 
 # Only contract tests
 uv run pytest -m contract -v
+
+# Only host-side bootstrap validation
+uv run pytest tests/e2e -m bootstrap -v
+
+# Only host-side developer workflow validation
+uv run pytest tests/e2e -m developer_workflow -v
+
+# Only standard in-cluster product validation
+uv run pytest tests/e2e -m platform_blackbox -v
 
 # Exclude integration and slow
 uv run pytest -m "not integration and not slow" -v
@@ -1003,4 +1054,6 @@ kubectl wait --for=condition=ready pod -l app=polaris --timeout=120s
 
 ---
 
-**Remember**: All integration and E2E tests run in Kubernetes for production parity. Use `/sw-verify` before every PR.
+**Remember**: Keep product validation in Kubernetes, keep bootstrap and
+repo-aware checks in their host-side lanes, and use `/sw-verify` before every
+PR.

--- a/charts/floe-platform/templates/tests/_test-job.tpl
+++ b/charts/floe-platform/templates/tests/_test-job.tpl
@@ -100,6 +100,8 @@ spec:
           env:
             - name: INTEGRATION_TEST_HOST
               value: "k8s"
+            - name: FLOE_MANIFEST_PATH
+              value: "/app/demo/manifest.yaml"
             - name: POSTGRES_HOST
               value: {{ $postgres | quote }}
             - name: POSTGRES_PORT

--- a/charts/floe-platform/templates/tests/job-e2e.yaml
+++ b/charts/floe-platform/templates/tests/job-e2e.yaml
@@ -17,7 +17,7 @@ Only rendered when .Values.tests.enabled is true. Apply via:
 {{- include "floe-platform.testJob" (dict
     "context" .
     "suite" "e2e"
-    "pytestMarker" "not destructive"
+    "pytestMarker" "platform_blackbox and not destructive"
     "serviceAccount" (include "floe-platform.testRunner.saName" .)
     "artifactPrefix" "e2e"
     ) }}

--- a/charts/floe-platform/values-demo.yaml
+++ b/charts/floe-platform/values-demo.yaml
@@ -13,6 +13,11 @@
 global:
   environment: demo
 
+dagsterDemoImage: &dagsterDemoImage
+  repository: floe-dagster-demo
+  tag: latest
+  pullPolicy: Never
+
 # Override fullname to decouple service names from Helm release name
 fullnameOverride: floe-platform
 
@@ -45,9 +50,7 @@ dagster:
   dagsterWebserver:
     replicaCount: 1
     image:
-      repository: floe-dagster-demo
-      tag: latest
-      pullPolicy: Never
+      <<: *dagsterDemoImage
     resources:
       requests:
         cpu: 100m
@@ -60,9 +63,7 @@ dagster:
   dagsterDaemon:
     enabled: true
     image:
-      repository: floe-dagster-demo
-      tag: latest
-      pullPolicy: Never
+      <<: *dagsterDemoImage
     resources:
       requests:
         cpu: 100m
@@ -80,9 +81,7 @@ dagster:
     config:
       k8sRunLauncher:
         image:
-          repository: floe-dagster-demo
-          tag: latest
-          pullPolicy: Never
+          <<: *dagsterDemoImage
         imagePullPolicy: Never
         # Resources for run pods (light for demo)
         resources:

--- a/charts/floe-platform/values-dev.yaml
+++ b/charts/floe-platform/values-dev.yaml
@@ -17,6 +17,11 @@ global:
   imagePullSecrets: []
   storageClass: ""
 
+dagsterDemoImage: &dagsterDemoImage
+  repository: floe-dagster-demo
+  tag: latest
+  pullPolicy: Never
+
 # Override fullname to decouple service names from Helm release name
 fullnameOverride: floe-platform
 
@@ -46,9 +51,7 @@ dagster:
     config:
       k8sRunLauncher:
         image:
-          repository: floe-dagster-demo
-          tag: latest
-          pullPolicy: Never
+          <<: *dagsterDemoImage
         imagePullPolicy: Never
         resources:
           requests:

--- a/charts/floe-platform/values-test.yaml
+++ b/charts/floe-platform/values-test.yaml
@@ -29,6 +29,11 @@ global:
     # compatibility, and the newer Bitnami chart blocks renders without this.
     allowInsecureImages: true
 
+dagsterDemoImage: &dagsterDemoImage
+  repository: floe-dagster-demo
+  tag: latest
+  pullPolicy: Never
+
 # =============================================================================
 # Namespace Configuration
 # =============================================================================
@@ -74,9 +79,7 @@ dagster:
   dagsterWebserver:
     replicaCount: 1
     image:
-      repository: floe-dagster-demo
-      tag: latest
-      pullPolicy: Never
+      <<: *dagsterDemoImage
     service:
       type: ClusterIP
       port: 3000
@@ -100,9 +103,7 @@ dagster:
         memory: 1536Mi
   dagsterDaemon:
     image:
-      repository: floe-dagster-demo
-      tag: latest
-      pullPolicy: Never
+      <<: *dagsterDemoImage
     resources:
       requests:
         cpu: 100m
@@ -117,9 +118,7 @@ dagster:
     config:
       k8sRunLauncher:
         image:
-          repository: floe-dagster-demo
-          tag: latest
-          pullPolicy: Never
+          <<: *dagsterDemoImage
         imagePullPolicy: Never
         # Run pods execute dbt which writes to /app/demo/*/target/ and other
         # project directories. readOnlyRootFilesystem is not practical for
@@ -180,7 +179,9 @@ polaris:
       secretKey: "minioadmin123"  # pragma: allowlist secret
   bootstrap:
     enabled: true
-    catalogName: "floe-e2e"
+    # Keep the test platform aligned with demo/manifest.yaml so the deployed
+    # platform simulates the same user-configured catalog contract.
+    catalogName: "floe-demo"
     defaultBaseLocation: "s3://floe-iceberg"
     allowedLocations:
       - "s3://floe-iceberg"

--- a/demo/manifest.yaml
+++ b/demo/manifest.yaml
@@ -51,6 +51,7 @@ plugins:
       oauth2:
         client_id: demo-admin
         client_secret: demo-secret  # pragma: allowlist secret
+        scope: PRINCIPAL_ROLE:ALL
         token_url: http://floe-platform-polaris:8181/api/catalog/v1/oauth/tokens
 
   # Storage: MinIO S3-compatible storage for demo

--- a/docs/superpowers/plans/2026-04-23-contract-layer-hard-reset.md
+++ b/docs/superpowers/plans/2026-04-23-contract-layer-hard-reset.md
@@ -1,0 +1,2071 @@
+# Contract Layer Hard Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a broad, generation-first contract layer that makes shared service, execution, runtime, and machine-output facts canonical in `floe-core`.
+
+**Architecture:** Add bounded contract domains under `floe_core.contracts`, then migrate consumers so charts, test fixtures, shell scripts, runtime schemas, and CLI JSON outputs consume contract-owned bindings. Split validation into contract, bootstrap, platform-blackbox, and developer-workflow boundaries so red builds classify cleanly.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, pytest, Click, Bash, Helm templates, Kubernetes-native test runners.
+
+---
+
+## Scope Check
+
+This plan covers one connected migration: shared operational facts move into a generation-first contract layer, and existing consumers become adapters. The runtime enum, machine-output schema, topology, execution, chart, shell, and test-boundary changes are intentionally kept together because partial migration would leave two competing sources of truth alive.
+
+## File Structure
+
+Create contract domains in `packages/floe-core/src/floe_core/contracts/`:
+
+- `errors.py`: contract-specific exception types used by all domains.
+- `runtime.py`: runtime enum and constant contracts, starting with OCI auth modes.
+- `schemas.py`: machine-readable output contract registry for JSON payloads.
+- `topology.py`: canonical platform service identity, default ports, and Helm service-name rendering.
+- `execution.py`: execution context model and service env binding generation.
+- `emit.py`: CLI-style emitter for shell exports, service names, and Helm test-runner env fragments.
+
+Modify existing consumers:
+
+- `packages/floe-core/src/floe_core/contracts/__init__.py`: export the new contract layer without breaking existing ODCS contract generator imports.
+- `packages/floe-core/src/floe_core/schemas/oci.py`: use the runtime contract enum as the public `AuthType`.
+- `packages/floe-core/src/floe_core/cli/rbac/audit.py`: validate JSON output against machine-output contracts.
+- `packages/floe-core/src/floe_core/cli/rbac/diff.py`: validate JSON output against machine-output contracts.
+- `packages/floe-core/src/floe_core/cli/network/audit.py`: validate JSON output against machine-output contracts.
+- `packages/floe-core/src/floe_core/cli/network/diff.py`: validate JSON output against machine-output contracts.
+- `testing/fixtures/services.py`: derive service ports and hosts from topology and execution contracts.
+- `testing/ci/common.sh`: ask `floe_core.contracts.emit` for canonical defaults and service names.
+- `testing/ci/test-e2e.sh`: remove locally authored service-name precomputation.
+- `charts/floe-platform/templates/tests/_contract-env.generated.tpl`: generated Helm env helper.
+- `charts/floe-platform/templates/tests/_test-job.tpl`: include the generated env helper instead of maintaining its own env table.
+- `pyproject.toml`: add validation-boundary markers and include contract tests in top-level test flow.
+- `Makefile`: wire `test-contract` into normal validation.
+- `scripts/check-architecture-drift`: block newly duplicated service literals outside contract-owned files.
+
+Add and modify tests:
+
+- `packages/floe-core/tests/unit/contracts/test_runtime_contracts.py`
+- `packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py`
+- `packages/floe-core/tests/unit/contracts/test_topology_contracts.py`
+- `packages/floe-core/tests/unit/contracts/test_execution_contracts.py`
+- `packages/floe-core/tests/unit/contracts/test_emit_contracts.py`
+- `tests/unit/test_e2e_fixture_wiring.py`
+- `tests/unit/test_e2e_runner_chart_contract.py`
+- `tests/unit/test_validation_boundary_markers.py`
+- `tests/contract/test_platform_contract_generated_bindings.py`
+- `packages/floe-core/tests/integration/oci/test_lock_workflow.py`
+
+## Tasks
+
+### Task 1: Runtime Contract And OCI Auth Hard Reset
+
+**Files:**
+
+- Create: `packages/floe-core/src/floe_core/contracts/errors.py`
+- Create: `packages/floe-core/src/floe_core/contracts/runtime.py`
+- Modify: `packages/floe-core/src/floe_core/contracts/__init__.py`
+- Modify: `packages/floe-core/src/floe_core/schemas/oci.py`
+- Modify: `packages/floe-core/tests/integration/oci/test_lock_workflow.py`
+- Test: `packages/floe-core/tests/unit/contracts/test_runtime_contracts.py`
+
+- [ ] **Step 1: Write the failing runtime contract tests**
+
+Create `packages/floe-core/tests/unit/contracts/test_runtime_contracts.py`:
+
+```python
+"""Tests for runtime contract enums."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_oci_auth_type_values_are_canonical() -> None:
+    """OCI auth modes are contract-owned and have no stale NONE alias."""
+    from floe_core.contracts.runtime import OciAuthType, enum_values
+
+    assert enum_values(OciAuthType) == (
+        "anonymous",
+        "basic",
+        "token",
+        "aws-irsa",
+        "azure-managed-identity",
+        "gcp-workload-identity",
+    )
+    assert not hasattr(OciAuthType, "NONE")
+
+
+def test_oci_schema_reuses_runtime_contract_enum() -> None:
+    """The legacy schema import path exposes the contract-owned enum."""
+    from floe_core.contracts.runtime import OciAuthType
+    from floe_core.schemas.oci import AuthType
+
+    assert AuthType is OciAuthType
+    assert AuthType.ANONYMOUS.value == "anonymous"
+
+
+def test_invalid_contract_enum_name_has_clear_error() -> None:
+    """Runtime contract lookup fails with a contract-specific error."""
+    from floe_core.contracts.errors import ContractViolationError
+    from floe_core.contracts.runtime import runtime_enum
+
+    with pytest.raises(ContractViolationError, match="Unknown runtime enum"):
+        runtime_enum("missing.enum")
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/contracts/test_runtime_contracts.py -v
+```
+
+Expected: FAIL because `floe_core.contracts.runtime` and `floe_core.contracts.errors` do not exist.
+
+- [ ] **Step 3: Add contract-specific exceptions**
+
+Create `packages/floe-core/src/floe_core/contracts/errors.py`:
+
+```python
+"""Contract-layer exception types.
+
+These errors make contract, adapter, and execution-context failures distinct
+from generic runtime exceptions.
+"""
+
+from __future__ import annotations
+
+
+class ContractError(ValueError):
+    """Base class for contract-layer failures."""
+
+
+class ContractGenerationError(ContractError):
+    """Raised when canonical contract facts cannot produce valid bindings."""
+
+
+class ContractViolationError(ContractError):
+    """Raised when a consumer violates a canonical contract."""
+
+
+class ExecutionContextMismatch(ContractViolationError):
+    """Raised when code runs under an execution context it was not written for."""
+```
+
+- [ ] **Step 4: Add the runtime contract domain**
+
+Create `packages/floe-core/src/floe_core/contracts/runtime.py`:
+
+```python
+"""Runtime contracts shared across packages and test boundaries."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TypeVar
+
+from floe_core.contracts.errors import ContractViolationError
+
+EnumT = TypeVar("EnumT", bound=Enum)
+
+
+class OciAuthType(str, Enum):
+    """Authentication modes supported by floe OCI registry integrations."""
+
+    ANONYMOUS = "anonymous"
+    BASIC = "basic"
+    TOKEN = "token"
+    AWS_IRSA = "aws-irsa"
+    AZURE_MANAGED_IDENTITY = "azure-managed-identity"
+    GCP_WORKLOAD_IDENTITY = "gcp-workload-identity"
+
+
+_RUNTIME_ENUMS: dict[str, type[Enum]] = {
+    "oci.auth_type": OciAuthType,
+}
+
+
+def enum_values(enum_type: type[EnumT]) -> tuple[str, ...]:
+    """Return stable string values for a runtime enum."""
+    return tuple(str(member.value) for member in enum_type)
+
+
+def runtime_enum(name: str) -> type[Enum]:
+    """Look up a runtime enum by canonical contract name.
+
+    Args:
+        name: Canonical runtime enum name, such as ``"oci.auth_type"``.
+
+    Returns:
+        Enum class registered for the name.
+
+    Raises:
+        ContractViolationError: If the enum name is not registered.
+    """
+    try:
+        return _RUNTIME_ENUMS[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(_RUNTIME_ENUMS))
+        raise ContractViolationError(
+            f"Unknown runtime enum {name!r}; available enums: {available}"
+        ) from exc
+```
+
+- [ ] **Step 5: Export runtime contract symbols**
+
+Modify `packages/floe-core/src/floe_core/contracts/__init__.py` so the import section and `__all__` include the new contract types while preserving `ContractGenerator`:
+
+```python
+from floe_core.contracts.errors import (
+    ContractError,
+    ContractGenerationError,
+    ContractViolationError,
+    ExecutionContextMismatch,
+)
+from floe_core.contracts.generator import ContractGenerator
+from floe_core.contracts.runtime import OciAuthType, enum_values, runtime_enum
+
+__all__ = [
+    "ContractError",
+    "ContractGenerationError",
+    "ContractGenerator",
+    "ContractViolationError",
+    "ExecutionContextMismatch",
+    "OciAuthType",
+    "enum_values",
+    "runtime_enum",
+]
+```
+
+- [ ] **Step 6: Make the OCI schema consume the runtime contract**
+
+Modify `packages/floe-core/src/floe_core/schemas/oci.py`:
+
+1. Add this import near the other `floe_core` imports:
+
+```python
+from floe_core.contracts.runtime import OciAuthType as AuthType
+```
+
+2. Delete the local `class AuthType(str, Enum):` block.
+
+The module must still expose `AuthType` from `floe_core.schemas.oci`, but the object must be `floe_core.contracts.runtime.OciAuthType`.
+
+- [ ] **Step 7: Hard-reset stale integration test auth usage**
+
+Modify `packages/floe-core/tests/integration/oci/test_lock_workflow.py`:
+
+1. Replace every `RegistryAuth(auth_type=AuthType.NONE)` call with:
+
+```python
+RegistryAuth(type=AuthType.ANONYMOUS)
+```
+
+2. Verify there are no remaining stale auth references:
+
+```bash
+rg -n "AuthType\\.NONE|auth_type=AuthType" packages/floe-core/tests/integration/oci/test_lock_workflow.py
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Run runtime and OCI schema tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/contracts/test_runtime_contracts.py packages/floe-core/tests/unit/oci/test_auth.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit runtime contract migration**
+
+Run:
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/contracts/__init__.py \
+  packages/floe-core/src/floe_core/contracts/errors.py \
+  packages/floe-core/src/floe_core/contracts/runtime.py \
+  packages/floe-core/src/floe_core/schemas/oci.py \
+  packages/floe-core/tests/integration/oci/test_lock_workflow.py \
+  packages/floe-core/tests/unit/contracts/test_runtime_contracts.py
+git commit -m "feat: add runtime contract domain"
+```
+
+### Task 2: Machine-Output Schema Contracts
+
+**Files:**
+
+- Create: `packages/floe-core/src/floe_core/contracts/schemas.py`
+- Modify: `packages/floe-core/src/floe_core/contracts/__init__.py`
+- Modify: `packages/floe-core/src/floe_core/cli/rbac/audit.py`
+- Modify: `packages/floe-core/src/floe_core/cli/rbac/diff.py`
+- Modify: `packages/floe-core/src/floe_core/cli/network/audit.py`
+- Modify: `packages/floe-core/src/floe_core/cli/network/diff.py`
+- Test: `packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py`
+- Test: `packages/floe-core/tests/unit/cli/test_cli_rbac_audit.py`
+- Test: `packages/floe-core/tests/unit/cli/test_rbac_diff.py`
+- Test: `packages/floe-core/tests/unit/cli/network/test_audit_command.py`
+- Test: `packages/floe-core/tests/unit/cli/network/test_diff.py`
+
+- [ ] **Step 1: Write failing machine-output contract tests**
+
+Create `packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py`:
+
+```python
+"""Tests for machine-readable output contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_rbac_audit_contract_requires_findings_key() -> None:
+    """RBAC audit JSON must keep the stable findings key."""
+    from floe_core.contracts.schemas import MachineOutputName, contract_for_output
+
+    contract = contract_for_output(MachineOutputName.RBAC_AUDIT)
+
+    assert "findings" in contract.required_keys
+    assert "cluster_name" in contract.required_keys
+
+
+def test_rbac_diff_contract_requires_diffs_key() -> None:
+    """RBAC diff JSON must keep the stable diffs key."""
+    from floe_core.contracts.schemas import MachineOutputName, contract_for_output
+
+    contract = contract_for_output(MachineOutputName.RBAC_DIFF)
+
+    assert "diffs" in contract.required_keys
+    assert "expected_source" in contract.required_keys
+
+
+def test_contract_validation_reports_missing_keys() -> None:
+    """Machine-output validation reports the exact missing keys."""
+    from floe_core.contracts.errors import ContractViolationError
+    from floe_core.contracts.schemas import MachineOutputName, validate_machine_output
+
+    with pytest.raises(ContractViolationError, match="missing required keys: findings"):
+        validate_machine_output(MachineOutputName.NETWORK_AUDIT, {"summary": {}})
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py -v
+```
+
+Expected: FAIL because `floe_core.contracts.schemas` does not exist.
+
+- [ ] **Step 3: Add the machine-output contract domain**
+
+Create `packages/floe-core/src/floe_core/contracts/schemas.py`:
+
+```python
+"""Machine-readable output contracts for CLI and adapter payloads."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from floe_core.contracts.errors import ContractViolationError
+
+
+class MachineOutputName(str, Enum):
+    """Registered machine-readable output payloads."""
+
+    RBAC_AUDIT = "rbac.audit"
+    RBAC_DIFF = "rbac.diff"
+    NETWORK_AUDIT = "network.audit"
+    NETWORK_DIFF = "network.diff"
+
+
+class JsonOutputContract(BaseModel):
+    """Stable contract for a JSON payload emitted by a CLI or adapter."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: MachineOutputName = Field(..., description="Canonical output contract name")
+    required_keys: tuple[str, ...] = Field(..., description="Keys that must be present")
+    stable_keys: tuple[str, ...] = Field(..., description="Keys consumers may rely on")
+
+    def validate_payload(self, payload: dict[str, Any]) -> None:
+        """Validate a payload against the contract.
+
+        Args:
+            payload: JSON-ready dictionary to validate.
+
+        Raises:
+            ContractViolationError: If a required key is absent.
+        """
+        missing = [key for key in self.required_keys if key not in payload]
+        if missing:
+            missing_text = ", ".join(missing)
+            raise ContractViolationError(
+                f"{self.name.value} output missing required keys: {missing_text}"
+            )
+
+
+_CONTRACTS: dict[MachineOutputName, JsonOutputContract] = {
+    MachineOutputName.RBAC_AUDIT: JsonOutputContract(
+        name=MachineOutputName.RBAC_AUDIT,
+        required_keys=(
+            "generated_at",
+            "cluster_name",
+            "namespaces",
+            "service_accounts",
+            "findings",
+            "total_service_accounts",
+            "total_roles",
+            "total_role_bindings",
+            "floe_managed_count",
+        ),
+        stable_keys=("generated_at", "cluster_name", "findings"),
+    ),
+    MachineOutputName.RBAC_DIFF: JsonOutputContract(
+        name=MachineOutputName.RBAC_DIFF,
+        required_keys=(
+            "generated_at",
+            "expected_source",
+            "actual_source",
+            "diffs",
+            "added_count",
+            "removed_count",
+            "modified_count",
+        ),
+        stable_keys=("generated_at", "expected_source", "actual_source", "diffs"),
+    ),
+    MachineOutputName.NETWORK_AUDIT: JsonOutputContract(
+        name=MachineOutputName.NETWORK_AUDIT,
+        required_keys=("namespaces", "policies", "findings", "summary"),
+        stable_keys=("namespaces", "policies", "findings", "summary"),
+    ),
+    MachineOutputName.NETWORK_DIFF: JsonOutputContract(
+        name=MachineOutputName.NETWORK_DIFF,
+        required_keys=("expected", "actual", "diffs", "summary"),
+        stable_keys=("diffs", "summary"),
+    ),
+}
+
+
+def contract_for_output(name: MachineOutputName) -> JsonOutputContract:
+    """Return the machine-output contract for a registered payload."""
+    return _CONTRACTS[name]
+
+
+def validate_machine_output(name: MachineOutputName, payload: dict[str, Any]) -> None:
+    """Validate a JSON-ready output payload against its contract."""
+    contract_for_output(name).validate_payload(payload)
+```
+
+- [ ] **Step 4: Export schema contract symbols**
+
+Modify `packages/floe-core/src/floe_core/contracts/__init__.py`:
+
+```python
+from floe_core.contracts.schemas import (
+    JsonOutputContract,
+    MachineOutputName,
+    contract_for_output,
+    validate_machine_output,
+)
+```
+
+Add these names to `__all__`:
+
+```python
+"JsonOutputContract",
+"MachineOutputName",
+"contract_for_output",
+"validate_machine_output",
+```
+
+- [ ] **Step 5: Validate RBAC audit JSON output before printing**
+
+Modify `packages/floe-core/src/floe_core/cli/rbac/audit.py`:
+
+1. Add imports:
+
+```python
+import json
+
+from floe_core.contracts.schemas import MachineOutputName, validate_machine_output
+```
+
+2. Replace the JSON branch in `_output_report` with:
+
+```python
+    if output_format == "json":
+        payload = report.model_dump(mode="json")
+        validate_machine_output(MachineOutputName.RBAC_AUDIT, payload)
+        click.echo(json.dumps(payload, indent=2))
+        return
+```
+
+- [ ] **Step 6: Validate RBAC diff JSON output before printing**
+
+Modify `packages/floe-core/src/floe_core/cli/rbac/diff.py`:
+
+1. Add imports:
+
+```python
+import json
+
+from floe_core.contracts.schemas import MachineOutputName, validate_machine_output
+```
+
+2. Replace the JSON output branch with:
+
+```python
+        if output_format == "json":
+            payload = diff_result.model_dump(mode="json")
+            validate_machine_output(MachineOutputName.RBAC_DIFF, payload)
+            click.echo(json.dumps(payload, indent=2))
+        else:
+            _output_diff_as_text(diff_result)
+```
+
+- [ ] **Step 7: Validate network audit JSON output before printing**
+
+Modify `packages/floe-core/src/floe_core/cli/network/audit.py`:
+
+1. Add import:
+
+```python
+from floe_core.contracts.schemas import MachineOutputName, validate_machine_output
+```
+
+2. Replace the JSON branch in `_output_report` with:
+
+```python
+    if output_format == "json":
+        import json
+
+        validate_machine_output(MachineOutputName.NETWORK_AUDIT, report)
+        click.echo(json.dumps(report, indent=2))
+        return
+```
+
+- [ ] **Step 8: Normalize network diff JSON shape and validate it**
+
+Modify `packages/floe-core/src/floe_core/cli/network/diff.py`:
+
+1. Add import:
+
+```python
+from floe_core.contracts.schemas import MachineOutputName, validate_machine_output
+```
+
+2. In the JSON output branch, build a stable payload:
+
+```python
+        if output_format.lower() == "json":
+            import json
+
+            payload = {
+                "expected": expected_policies,
+                "actual": deployed_policies,
+                "diffs": diff_result.get("diffs", []),
+                "summary": diff_result.get("summary", {}),
+            }
+            validate_machine_output(MachineOutputName.NETWORK_DIFF, payload)
+            click.echo(json.dumps(payload, indent=2))
+        else:
+            _output_diff_as_text(diff_result)
+```
+
+- [ ] **Step 9: Run output contract tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py \
+  packages/floe-core/tests/unit/cli/test_cli_rbac_audit.py \
+  packages/floe-core/tests/unit/cli/test_rbac_diff.py \
+  packages/floe-core/tests/unit/cli/network/test_audit_command.py \
+  packages/floe-core/tests/unit/cli/network/test_diff.py \
+  -v
+```
+
+Expected: PASS. Update any failing CLI JSON assertion in the listed tests so it asserts contract-owned keys from `MachineOutputName` payloads rather than locally invented keys.
+
+- [ ] **Step 10: Commit machine-output contracts**
+
+Run:
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/contracts/__init__.py \
+  packages/floe-core/src/floe_core/contracts/schemas.py \
+  packages/floe-core/src/floe_core/cli/rbac/audit.py \
+  packages/floe-core/src/floe_core/cli/rbac/diff.py \
+  packages/floe-core/src/floe_core/cli/network/audit.py \
+  packages/floe-core/src/floe_core/cli/network/diff.py \
+  packages/floe-core/tests/unit/contracts/test_machine_output_contracts.py \
+  packages/floe-core/tests/unit/cli/test_cli_rbac_audit.py \
+  packages/floe-core/tests/unit/cli/test_rbac_diff.py \
+  packages/floe-core/tests/unit/cli/network/test_audit_command.py \
+  packages/floe-core/tests/unit/cli/network/test_diff.py
+git commit -m "feat: add machine output contracts"
+```
+
+### Task 3: Topology And Execution Contracts
+
+**Files:**
+
+- Create: `packages/floe-core/src/floe_core/contracts/topology.py`
+- Create: `packages/floe-core/src/floe_core/contracts/execution.py`
+- Modify: `packages/floe-core/src/floe_core/contracts/__init__.py`
+- Test: `packages/floe-core/tests/unit/contracts/test_topology_contracts.py`
+- Test: `packages/floe-core/tests/unit/contracts/test_execution_contracts.py`
+
+- [ ] **Step 1: Write failing topology tests**
+
+Create `packages/floe-core/tests/unit/contracts/test_topology_contracts.py`:
+
+```python
+"""Tests for platform topology contracts."""
+
+from __future__ import annotations
+
+
+def test_platform_services_include_current_e2e_dependencies() -> None:
+    """The topology contract owns service identities used by E2E tests."""
+    from floe_core.contracts.topology import ComponentId, service_contract, test_runner_services
+
+    assert service_contract(ComponentId.POLARIS).default_port == 8181
+    assert service_contract(ComponentId.POLARIS_MANAGEMENT).default_port == 8182
+    assert service_contract(ComponentId.MINIO).default_port == 9000
+    assert service_contract(ComponentId.DAGSTER_WEBSERVER).default_port == 3000
+    assert service_contract(ComponentId.POSTGRESQL).default_port == 5432
+    assert ComponentId.OCI_REGISTRY not in {service.component_id for service in test_runner_services()}
+
+
+def test_service_names_are_rendered_from_release_name() -> None:
+    """Chart and shell consumers must not hand-author service-name formulas."""
+    from floe_core.contracts.topology import ComponentId, render_service_name
+
+    assert render_service_name(ComponentId.POLARIS, release_name="floe-platform") == (
+        "floe-platform-polaris"
+    )
+    assert render_service_name(ComponentId.DAGSTER_WEBSERVER, release_name="demo") == (
+        "demo-dagster-webserver"
+    )
+```
+
+- [ ] **Step 2: Write failing execution tests**
+
+Create `packages/floe-core/tests/unit/contracts/test_execution_contracts.py`:
+
+```python
+"""Tests for execution context contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_in_cluster_bindings_use_service_names() -> None:
+    """In-cluster bindings use Kubernetes service DNS names."""
+    from floe_core.contracts.execution import ExecutionContext, service_binding
+    from floe_core.contracts.topology import ComponentId
+
+    binding = service_binding(
+        ComponentId.POLARIS,
+        ExecutionContext.IN_CLUSTER,
+        release_name="floe-platform",
+        namespace="floe-test",
+    )
+
+    assert binding.host == "floe-platform-polaris"
+    assert binding.port == 8181
+    assert binding.env == {"POLARIS_HOST": "floe-platform-polaris", "POLARIS_PORT": "8181"}
+
+
+def test_host_bindings_use_localhost_explicitly() -> None:
+    """Host execution is explicit and does not rely on DNS probing."""
+    from floe_core.contracts.execution import ExecutionContext, service_binding
+    from floe_core.contracts.topology import ComponentId
+
+    binding = service_binding(ComponentId.MINIO, ExecutionContext.HOST)
+
+    assert binding.host == "localhost"
+    assert binding.env == {"MINIO_HOST": "localhost", "MINIO_PORT": "9000"}
+
+
+def test_unknown_execution_context_fails_as_contract_violation() -> None:
+    """Invalid execution contexts fail before service helpers run."""
+    from floe_core.contracts.errors import ExecutionContextMismatch
+    from floe_core.contracts.execution import parse_execution_context
+
+    with pytest.raises(ExecutionContextMismatch, match="Unknown execution context"):
+        parse_execution_context("k8s")
+```
+
+- [ ] **Step 3: Run topology and execution tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/contracts/test_topology_contracts.py \
+  packages/floe-core/tests/unit/contracts/test_execution_contracts.py \
+  -v
+```
+
+Expected: FAIL because the topology and execution modules do not exist.
+
+- [ ] **Step 4: Add topology contracts**
+
+Create `packages/floe-core/src/floe_core/contracts/topology.py`:
+
+```python
+"""Canonical platform topology contracts."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from floe_core.contracts.errors import ContractViolationError
+
+DEFAULT_RELEASE_NAME = "floe-platform"
+DEFAULT_NAMESPACE = "floe-test"
+
+
+class ComponentId(str, Enum):
+    """Canonical platform components shared across charts, scripts, and tests."""
+
+    DAGSTER_WEBSERVER = "dagster-webserver"
+    POLARIS = "polaris"
+    POLARIS_MANAGEMENT = "polaris-management"
+    MINIO = "minio"
+    MINIO_CONSOLE = "minio-console"
+    POSTGRESQL = "postgresql"
+    JAEGER_QUERY = "jaeger-query"
+    OTEL_COLLECTOR_GRPC = "otel-collector-grpc"
+    OTEL_COLLECTOR_HTTP = "otel-collector-http"
+    MARQUEZ = "marquez"
+    OCI_REGISTRY = "oci-registry"
+    OCI_REGISTRY_AUTH = "oci-registry-auth"
+
+
+class ServiceContract(BaseModel):
+    """Canonical identity and port contract for a platform service."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    component_id: ComponentId = Field(..., description="Canonical component identifier")
+    chart_component: str = Field(..., description="Helm release suffix for service name")
+    default_port: int = Field(..., ge=1, le=65535, description="Default service port")
+    host_env_var: str = Field(..., description="Environment variable for service host")
+    port_env_var: str = Field(..., description="Environment variable for service port")
+    readiness_path: str | None = Field(default=None, description="HTTP readiness path")
+    expose_to_test_runner: bool = Field(
+        default=True,
+        description="Whether generated Helm test-runner env should expose this service",
+    )
+
+    @property
+    def short_name(self) -> str:
+        """Return the canonical short service name used by Python helpers."""
+        return self.component_id.value
+
+
+_SERVICES: tuple[ServiceContract, ...] = (
+    ServiceContract(
+        component_id=ComponentId.DAGSTER_WEBSERVER,
+        chart_component="dagster-webserver",
+        default_port=3000,
+        host_env_var="DAGSTER_WEBSERVER_HOST",
+        port_env_var="DAGSTER_WEBSERVER_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.POLARIS,
+        chart_component="polaris",
+        default_port=8181,
+        host_env_var="POLARIS_HOST",
+        port_env_var="POLARIS_PORT",
+        readiness_path="/api/catalog/v1/config",
+    ),
+    ServiceContract(
+        component_id=ComponentId.POLARIS_MANAGEMENT,
+        chart_component="polaris",
+        default_port=8182,
+        host_env_var="POLARIS_MANAGEMENT_HOST",
+        port_env_var="POLARIS_MANAGEMENT_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.MINIO,
+        chart_component="minio",
+        default_port=9000,
+        host_env_var="MINIO_HOST",
+        port_env_var="MINIO_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.MINIO_CONSOLE,
+        chart_component="minio",
+        default_port=9001,
+        host_env_var="MINIO_CONSOLE_HOST",
+        port_env_var="MINIO_CONSOLE_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.POSTGRESQL,
+        chart_component="postgresql",
+        default_port=5432,
+        host_env_var="POSTGRES_HOST",
+        port_env_var="POSTGRES_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.JAEGER_QUERY,
+        chart_component="jaeger-query",
+        default_port=16686,
+        host_env_var="JAEGER_QUERY_HOST",
+        port_env_var="JAEGER_QUERY_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.OTEL_COLLECTOR_GRPC,
+        chart_component="otel",
+        default_port=4317,
+        host_env_var="OTEL_COLLECTOR_GRPC_HOST",
+        port_env_var="OTEL_COLLECTOR_GRPC_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.OTEL_COLLECTOR_HTTP,
+        chart_component="otel",
+        default_port=4318,
+        host_env_var="OTEL_COLLECTOR_HTTP_HOST",
+        port_env_var="OTEL_COLLECTOR_HTTP_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.MARQUEZ,
+        chart_component="marquez",
+        default_port=5000,
+        host_env_var="MARQUEZ_HOST",
+        port_env_var="MARQUEZ_PORT",
+    ),
+    ServiceContract(
+        component_id=ComponentId.OCI_REGISTRY,
+        chart_component="oci-registry",
+        default_port=5000,
+        host_env_var="OCI_REGISTRY_HOST",
+        port_env_var="OCI_REGISTRY_PORT",
+        expose_to_test_runner=False,
+    ),
+    ServiceContract(
+        component_id=ComponentId.OCI_REGISTRY_AUTH,
+        chart_component="oci-registry-auth",
+        default_port=5000,
+        host_env_var="OCI_REGISTRY_AUTH_HOST",
+        port_env_var="OCI_REGISTRY_AUTH_PORT",
+        expose_to_test_runner=False,
+    ),
+)
+
+
+def service_contracts() -> tuple[ServiceContract, ...]:
+    """Return all canonical service contracts."""
+    return _SERVICES
+
+
+def test_runner_services() -> tuple[ServiceContract, ...]:
+    """Return services exposed to the Helm test-runner environment."""
+    return tuple(service for service in _SERVICES if service.expose_to_test_runner)
+
+
+def service_contract(component_id: ComponentId) -> ServiceContract:
+    """Return the service contract for a component."""
+    for service in _SERVICES:
+        if service.component_id is component_id:
+            return service
+    raise ContractViolationError(f"Unknown service component: {component_id.value}")
+
+
+def service_contract_by_name(name: str) -> ServiceContract:
+    """Return a service contract by canonical short name."""
+    for service in _SERVICES:
+        if service.short_name == name:
+            return service
+    known = ", ".join(sorted(service.short_name for service in _SERVICES))
+    raise ContractViolationError(f"Unknown service {name!r}; known services: {known}")
+
+
+def render_service_name(
+    component_id: ComponentId,
+    *,
+    release_name: str = DEFAULT_RELEASE_NAME,
+) -> str:
+    """Render a Kubernetes service name from the canonical topology contract."""
+    service = service_contract(component_id)
+    return f"{release_name}-{service.chart_component}"
+```
+
+- [ ] **Step 5: Add execution contracts**
+
+Create `packages/floe-core/src/floe_core/contracts/execution.py`:
+
+```python
+"""Execution-context contracts for platform consumers."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from floe_core.contracts.errors import ExecutionContextMismatch
+from floe_core.contracts.topology import (
+    DEFAULT_NAMESPACE,
+    DEFAULT_RELEASE_NAME,
+    ComponentId,
+    render_service_name,
+    service_contract,
+    service_contracts,
+)
+
+
+class ExecutionContext(str, Enum):
+    """Supported runtime contexts for generated service bindings."""
+
+    IN_CLUSTER = "in-cluster"
+    HOST = "host"
+    DEVPOD = "devpod"
+    DEMO = "demo"
+
+
+class ServiceBinding(BaseModel):
+    """Rendered service binding for one execution context."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    component_id: ComponentId = Field(..., description="Canonical component")
+    context: ExecutionContext = Field(..., description="Execution context")
+    host: str = Field(..., description="Resolved host")
+    port: int = Field(..., ge=1, le=65535, description="Resolved port")
+    env: dict[str, str] = Field(..., description="Environment variables for consumers")
+
+
+def parse_execution_context(raw: str | None) -> ExecutionContext:
+    """Parse an execution context value.
+
+    Args:
+        raw: String value from environment or CLI input.
+
+    Returns:
+        ExecutionContext enum.
+
+    Raises:
+        ExecutionContextMismatch: If the value is missing or unknown.
+    """
+    if raw is None or raw.strip() == "":
+        raise ExecutionContextMismatch(
+            "Execution context is required; set FLOE_EXECUTION_CONTEXT to one of "
+            "in-cluster, host, devpod, demo"
+        )
+    try:
+        return ExecutionContext(raw)
+    except ValueError as exc:
+        allowed = ", ".join(context.value for context in ExecutionContext)
+        raise ExecutionContextMismatch(
+            f"Unknown execution context {raw!r}; allowed contexts: {allowed}"
+        ) from exc
+
+
+def service_binding(
+    component_id: ComponentId,
+    context: ExecutionContext,
+    *,
+    release_name: str = DEFAULT_RELEASE_NAME,
+    namespace: str = DEFAULT_NAMESPACE,
+) -> ServiceBinding:
+    """Render one service binding for a specific execution context."""
+    service = service_contract(component_id)
+    if context is ExecutionContext.IN_CLUSTER:
+        host = render_service_name(component_id, release_name=release_name)
+    elif context in (ExecutionContext.HOST, ExecutionContext.DEVPOD, ExecutionContext.DEMO):
+        host = "localhost"
+    else:
+        raise ExecutionContextMismatch(f"Unsupported execution context: {context.value}")
+
+    env = {
+        service.host_env_var: host,
+        service.port_env_var: str(service.default_port),
+    }
+    return ServiceBinding(
+        component_id=component_id,
+        context=context,
+        host=host,
+        port=service.default_port,
+        env=env,
+    )
+
+
+def service_bindings(
+    context: ExecutionContext,
+    *,
+    release_name: str = DEFAULT_RELEASE_NAME,
+    namespace: str = DEFAULT_NAMESPACE,
+) -> tuple[ServiceBinding, ...]:
+    """Render service bindings for every canonical platform service."""
+    return tuple(
+        service_binding(
+            service.component_id,
+            context,
+            release_name=release_name,
+            namespace=namespace,
+        )
+        for service in service_contracts()
+    )
+```
+
+- [ ] **Step 6: Export topology and execution symbols**
+
+Modify `packages/floe-core/src/floe_core/contracts/__init__.py`:
+
+```python
+from floe_core.contracts.execution import (
+    ExecutionContext,
+    ServiceBinding,
+    parse_execution_context,
+    service_binding,
+    service_bindings,
+)
+from floe_core.contracts.topology import (
+    DEFAULT_NAMESPACE,
+    DEFAULT_RELEASE_NAME,
+    ComponentId,
+    ServiceContract,
+    render_service_name,
+    service_contract,
+    service_contract_by_name,
+    service_contracts,
+    test_runner_services,
+)
+```
+
+Add those names to `__all__`.
+
+- [ ] **Step 7: Run topology and execution tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/contracts/test_topology_contracts.py \
+  packages/floe-core/tests/unit/contracts/test_execution_contracts.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit topology and execution contracts**
+
+Run:
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/contracts/__init__.py \
+  packages/floe-core/src/floe_core/contracts/topology.py \
+  packages/floe-core/src/floe_core/contracts/execution.py \
+  packages/floe-core/tests/unit/contracts/test_topology_contracts.py \
+  packages/floe-core/tests/unit/contracts/test_execution_contracts.py
+git commit -m "feat: add topology and execution contracts"
+```
+
+### Task 4: Python Test Fixture Adapter Migration
+
+**Files:**
+
+- Modify: `testing/fixtures/services.py`
+- Modify: `tests/unit/test_e2e_fixture_wiring.py`
+- Test: `tests/unit/test_e2e_fixture_wiring.py`
+
+- [ ] **Step 1: Add fixture tests that reject socket-based fallback**
+
+Modify `tests/unit/test_e2e_fixture_wiring.py` and add:
+
+```python
+def test_service_default_ports_are_contract_derived() -> None:
+    """E2E service defaults must be derived from topology contracts."""
+    from floe_core.contracts.topology import service_contracts
+    from testing.fixtures.services import SERVICE_DEFAULT_PORTS
+
+    expected = {service.short_name: service.default_port for service in service_contracts()}
+
+    assert SERVICE_DEFAULT_PORTS == expected
+
+
+def test_service_endpoint_requires_explicit_execution_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Service helpers must not silently probe DNS and fall back to localhost."""
+    from floe_core.contracts.errors import ExecutionContextMismatch
+    from testing.fixtures.services import ServiceEndpoint
+
+    monkeypatch.delenv("FLOE_EXECUTION_CONTEXT", raising=False)
+    monkeypatch.delenv("POLARIS_HOST", raising=False)
+
+    endpoint = ServiceEndpoint("polaris")
+
+    with pytest.raises(ExecutionContextMismatch, match="FLOE_EXECUTION_CONTEXT"):
+        _ = endpoint.host
+
+
+def test_service_endpoint_uses_contract_env_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ServiceEndpoint uses contract binding for in-cluster runtime."""
+    from testing.fixtures.services import ServiceEndpoint
+
+    monkeypatch.setenv("FLOE_EXECUTION_CONTEXT", "in-cluster")
+    monkeypatch.setenv("FLOE_RELEASE_NAME", "floe-platform")
+
+    endpoint = ServiceEndpoint("polaris")
+
+    assert endpoint.host == "floe-platform-polaris"
+    assert endpoint.port == 8181
+    assert endpoint.url == "http://floe-platform-polaris:8181"
+```
+
+Ensure the file imports `pytest`:
+
+```python
+import pytest
+```
+
+- [ ] **Step 2: Run fixture tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_e2e_fixture_wiring.py -v
+```
+
+Expected: FAIL because `testing/fixtures/services.py` still owns `SERVICE_DEFAULT_PORTS` and still uses DNS probing.
+
+- [ ] **Step 3: Replace fixture-owned service defaults**
+
+Modify `testing/fixtures/services.py`:
+
+1. Add imports:
+
+```python
+from floe_core.contracts.execution import parse_execution_context, service_binding
+from floe_core.contracts.topology import (
+    DEFAULT_NAMESPACE,
+    DEFAULT_RELEASE_NAME,
+    service_contract_by_name,
+    service_contracts,
+)
+```
+
+2. Replace the current hand-authored `SERVICE_DEFAULT_PORTS` dictionary with:
+
+```python
+SERVICE_DEFAULT_PORTS: dict[str, int] = {
+    service.short_name: service.default_port for service in service_contracts()
+}
+```
+
+- [ ] **Step 4: Replace socket-probing host resolution**
+
+Modify `testing/fixtures/services.py`:
+
+1. Delete the `import socket` line.
+
+2. Replace `_get_effective_host` with:
+
+```python
+def _get_effective_host(service_name: str, namespace: str) -> str:
+    """Determine the effective host for a service from execution contracts."""
+    service = service_contract_by_name(service_name)
+    env_key = service.host_env_var
+    service_host = os.environ.get(env_key)
+    if service_host:
+        return service_host
+
+    context = parse_execution_context(os.environ.get("FLOE_EXECUTION_CONTEXT"))
+    release_name = os.environ.get("FLOE_RELEASE_NAME", DEFAULT_RELEASE_NAME)
+    effective_namespace = namespace or os.environ.get("FLOE_NAMESPACE", DEFAULT_NAMESPACE)
+    binding = service_binding(
+        service.component_id,
+        context,
+        release_name=release_name,
+        namespace=effective_namespace,
+    )
+    return binding.host
+```
+
+3. Delete `_can_resolve_host`.
+
+- [ ] **Step 5: Update service fixture docstring**
+
+Modify the environment-variable section at the top of `testing/fixtures/services.py` to read:
+
+```python
+Environment Variables:
+    FLOE_EXECUTION_CONTEXT: Required execution context for generated bindings.
+        Supported values: "in-cluster", "host", "devpod", "demo".
+    FLOE_RELEASE_NAME: Helm release name for in-cluster service bindings.
+    FLOE_NAMESPACE: Kubernetes namespace for generated bindings.
+    {SERVICE}_HOST: Explicit host override for a contract-defined service.
+```
+
+- [ ] **Step 6: Run fixture adapter tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_e2e_fixture_wiring.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run E2E conftest-focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_e2e_runner_devpod_path.py tests/unit/test_e2e_runner_chart_contract.py -v
+```
+
+Expected: PASS. Replace any remaining `INTEGRATION_TEST_HOST` references in failing tests with `FLOE_EXECUTION_CONTEXT` and one of `in-cluster`, `host`, `devpod`, or `demo`.
+
+- [ ] **Step 8: Commit Python fixture adapter migration**
+
+Run:
+
+```bash
+git add testing/fixtures/services.py tests/unit/test_e2e_fixture_wiring.py
+git commit -m "refactor: derive service fixtures from contracts"
+```
+
+### Task 5: Contract Emitter And Shell Adapter Migration
+
+**Files:**
+
+- Create: `packages/floe-core/src/floe_core/contracts/emit.py`
+- Modify: `testing/ci/common.sh`
+- Modify: `testing/ci/test-e2e.sh`
+- Test: `packages/floe-core/tests/unit/contracts/test_emit_contracts.py`
+- Test: `testing/ci/tests/test_e2e_sh_manifest_wiring.py`
+
+- [ ] **Step 1: Write failing emitter tests**
+
+Create `packages/floe-core/tests/unit/contracts/test_emit_contracts.py`:
+
+```python
+"""Tests for generated contract emitters."""
+
+from __future__ import annotations
+
+
+def test_shell_exports_include_canonical_defaults() -> None:
+    """Shell emit output provides defaults owned by topology contracts."""
+    from floe_core.contracts.emit import render_shell_defaults
+
+    output = render_shell_defaults()
+
+    assert "FLOE_DEFAULT_RELEASE_NAME=floe-platform" in output
+    assert "FLOE_DEFAULT_NAMESPACE=floe-test" in output
+
+
+def test_service_name_command_uses_topology_contract() -> None:
+    """Service-name rendering comes from the topology contract."""
+    from floe_core.contracts.emit import render_service_name_output
+
+    assert render_service_name_output("polaris", "demo") == "demo-polaris\n"
+
+
+def test_helm_env_fragment_contains_execution_context() -> None:
+    """The Helm env fragment includes explicit execution context binding."""
+    from floe_core.contracts.emit import render_helm_test_env_template
+
+    output = render_helm_test_env_template()
+
+    assert 'name: FLOE_EXECUTION_CONTEXT' in output
+    assert 'value: "in-cluster"' in output
+    assert "POLARIS_HOST" in output
+```
+
+- [ ] **Step 2: Run emitter tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/contracts/test_emit_contracts.py -v
+```
+
+Expected: FAIL because `floe_core.contracts.emit` does not exist.
+
+- [ ] **Step 3: Add the contract emitter**
+
+Create `packages/floe-core/src/floe_core/contracts/emit.py`:
+
+```python
+"""Emit generated contract bindings for shell and Helm consumers."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from floe_core.contracts.topology import (
+    DEFAULT_NAMESPACE,
+    DEFAULT_RELEASE_NAME,
+    ComponentId,
+    render_service_name,
+    service_contract_by_name,
+    test_runner_services,
+)
+
+
+def render_shell_defaults() -> str:
+    """Render shell assignments for contract-owned defaults."""
+    lines = [
+        f"FLOE_DEFAULT_RELEASE_NAME={DEFAULT_RELEASE_NAME}",
+        f"FLOE_DEFAULT_NAMESPACE={DEFAULT_NAMESPACE}",
+        "FLOE_DEFAULT_EXECUTION_CONTEXT=host",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_service_name_output(component_name: str, release_name: str) -> str:
+    """Render a service name and trailing newline for shell command use."""
+    service = service_contract_by_name(component_name)
+    return render_service_name(service.component_id, release_name=release_name) + "\n"
+
+
+def _helm_host_helper(component_id: ComponentId) -> str:
+    helper_by_component = {
+        ComponentId.POSTGRESQL: 'include "floe-platform.postgresql.host" $context',
+        ComponentId.POLARIS: 'include "floe-platform.polaris.fullname" $context',
+        ComponentId.POLARIS_MANAGEMENT: 'include "floe-platform.polaris.fullname" $context',
+        ComponentId.MINIO: 'include "floe-platform.minio.fullname" $context',
+        ComponentId.MINIO_CONSOLE: 'include "floe-platform.minio.fullname" $context',
+        ComponentId.MARQUEZ: 'include "floe-platform.marquez.fullname" $context',
+        ComponentId.DAGSTER_WEBSERVER: 'include "floe-platform.dagster.webserverName" $context',
+        ComponentId.JAEGER_QUERY: 'include "floe-platform.jaeger.queryName" $context',
+        ComponentId.OTEL_COLLECTOR_GRPC: 'include "floe-platform.otel.fullname" $context',
+        ComponentId.OTEL_COLLECTOR_HTTP: 'include "floe-platform.otel.fullname" $context',
+    }
+    return helper_by_component[component_id]
+
+
+def render_helm_test_env_template() -> str:
+    """Render the Helm template helper consumed by the test-runner Job."""
+    lines = [
+        '{{- define "floe-platform.testRunner.contractEnv" -}}',
+        "{{- $context := . -}}",
+        "- name: FLOE_EXECUTION_CONTEXT",
+        '  value: "in-cluster"',
+        "- name: FLOE_RELEASE_NAME",
+        "  value: {{ $context.Release.Name | quote }}",
+        "- name: FLOE_NAMESPACE",
+        "  value: {{ $context.Release.Namespace | quote }}",
+    ]
+    for service in test_runner_services():
+        helper = _helm_host_helper(service.component_id)
+        lines.extend(
+            [
+                f"- name: {service.host_env_var}",
+                "  value: {{ " + helper + " | quote }}",
+                f"- name: {service.port_env_var}",
+                f'  value: "{service.default_port}"',
+            ]
+        )
+    lines.append("{{- end -}}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command entry point for contract binding emission."""
+    parser = argparse.ArgumentParser(prog="python -m floe_core.contracts.emit")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    subcommands.add_parser("shell-defaults")
+
+    service_parser = subcommands.add_parser("service-name")
+    service_parser.add_argument("component")
+    service_parser.add_argument("--release-name", default=DEFAULT_RELEASE_NAME)
+
+    subcommands.add_parser("helm-test-env")
+
+    args = parser.parse_args(argv)
+    if args.command == "shell-defaults":
+        print(render_shell_defaults(), end="")
+        return 0
+    if args.command == "service-name":
+        print(render_service_name_output(args.component, args.release_name), end="")
+        return 0
+    if args.command == "helm-test-env":
+        print(render_helm_test_env_template(), end="")
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run emitter tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/contracts/test_emit_contracts.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Make `testing/ci/common.sh` consume emitted defaults**
+
+Modify `testing/ci/common.sh`:
+
+1. Add project root calculation after `SCRIPT_DIR`:
+
+```bash
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+```
+
+2. Add:
+
+```bash
+floe_contract_emit() {
+    PYTHONPATH="${PROJECT_ROOT}/packages/floe-core/src:${PYTHONPATH:-}" \
+        python3 -m floe_core.contracts.emit "$@"
+}
+
+eval "$(floe_contract_emit shell-defaults)"
+```
+
+3. Replace:
+
+```bash
+: "${FLOE_RELEASE_NAME:=floe-platform}"
+: "${FLOE_NAMESPACE:=floe-test}"
+```
+
+with:
+
+```bash
+: "${FLOE_RELEASE_NAME:=${FLOE_DEFAULT_RELEASE_NAME}}"
+: "${FLOE_NAMESPACE:=${FLOE_DEFAULT_NAMESPACE}}"
+```
+
+4. Replace the `floe_service_name` body with:
+
+```bash
+floe_service_name() {
+    local component="$1"
+    if [[ -z "${component}" ]]; then
+        echo "floe_service_name: component argument required" >&2
+        return 2
+    fi
+    floe_contract_emit service-name --release-name "${FLOE_RELEASE_NAME}" "${component}"
+}
+```
+
+- [ ] **Step 6: Remove locally authored service-name precomputation from `test-e2e.sh`**
+
+Modify `testing/ci/test-e2e.sh`:
+
+1. Delete this block:
+
+```bash
+# Pre-compute platform service names from the chart release name.
+# No literal `floe-platform-*` strings may appear below this line.
+SVC_DAGSTER_WEB="$(floe_service_name dagster-webserver)"
+SVC_POLARIS="$(floe_service_name polaris)"
+SVC_MINIO="$(floe_service_name minio)"
+SVC_OTEL="$(floe_service_name otel)"
+SVC_MARQUEZ="$(floe_service_name marquez)"
+SVC_JAEGER_QUERY="$(floe_service_name jaeger-query)"
+SVC_POSTGRES="$(floe_service_name postgresql)"
+```
+
+2. Replace later usages of those variables with command substitutions:
+
+```bash
+"$(floe_service_name dagster-webserver)"
+"$(floe_service_name polaris)"
+"$(floe_service_name minio)"
+"$(floe_service_name otel-collector-grpc)"
+"$(floe_service_name marquez)"
+"$(floe_service_name jaeger-query)"
+"$(floe_service_name postgresql)"
+```
+
+- [ ] **Step 7: Update shell wiring tests**
+
+Modify `testing/ci/tests/test_e2e_sh_manifest_wiring.py` and add:
+
+```python
+def test_common_sh_uses_contract_emitter_for_service_names(repo_root: Path) -> None:
+    """Shell service names must come from floe_core.contracts.emit."""
+    common = (repo_root / "testing" / "ci" / "common.sh").read_text()
+
+    assert "python3 -m floe_core.contracts.emit" in common
+    assert 'printf \'%s-%s\\n\' "${FLOE_RELEASE_NAME}" "${component}"' not in common
+```
+
+- [ ] **Step 8: Run shell adapter tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/contracts/test_emit_contracts.py \
+  testing/ci/tests/test_e2e_sh_manifest_wiring.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit shell adapter migration**
+
+Run:
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/contracts/emit.py \
+  packages/floe-core/tests/unit/contracts/test_emit_contracts.py \
+  testing/ci/common.sh \
+  testing/ci/test-e2e.sh \
+  testing/ci/tests/test_e2e_sh_manifest_wiring.py
+git commit -m "refactor: generate shell service bindings from contracts"
+```
+
+### Task 6: Helm Test Runner Contract Adapter
+
+**Files:**
+
+- Create: `charts/floe-platform/templates/tests/_contract-env.generated.tpl`
+- Modify: `charts/floe-platform/templates/tests/_test-job.tpl`
+- Modify: `tests/unit/test_e2e_runner_chart_contract.py`
+- Test: `tests/unit/test_e2e_runner_chart_contract.py`
+
+- [ ] **Step 1: Write chart contract tests for generated env usage**
+
+Modify `tests/unit/test_e2e_runner_chart_contract.py` and add:
+
+```python
+def test_test_runner_uses_generated_contract_env_helper() -> None:
+    """The test Job env table must come from the generated contract helper."""
+    template = _TEMPLATE_PATH.read_text()
+
+    assert 'include "floe-platform.testRunner.contractEnv" $context' in template
+    assert "name: INTEGRATION_TEST_HOST" not in template
+    assert "name: POLARIS_HOST" not in template
+
+
+def test_generated_contract_env_helper_matches_emitter() -> None:
+    """Committed Helm helper must match the contract emitter output."""
+    from floe_core.contracts.emit import render_helm_test_env_template
+
+    generated = (
+        _REPO_ROOT
+        / "charts"
+        / "floe-platform"
+        / "templates"
+        / "tests"
+        / "_contract-env.generated.tpl"
+    )
+
+    assert generated.read_text() == render_helm_test_env_template()
+```
+
+- [ ] **Step 2: Run chart contract tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_e2e_runner_chart_contract.py -v
+```
+
+Expected: FAIL because `_test-job.tpl` still owns the env table and the generated helper file does not exist.
+
+- [ ] **Step 3: Generate the Helm env helper**
+
+Run:
+
+```bash
+PYTHONPATH=packages/floe-core/src python3 -m floe_core.contracts.emit helm-test-env \
+  > charts/floe-platform/templates/tests/_contract-env.generated.tpl
+```
+
+Expected: file is created and contains `FLOE_EXECUTION_CONTEXT`, `POLARIS_HOST`, and `POLARIS_PORT`.
+
+- [ ] **Step 4: Replace the env table in `_test-job.tpl`**
+
+Modify `charts/floe-platform/templates/tests/_test-job.tpl`:
+
+1. Delete the local variables that only feed the env table:
+
+```gotemplate
+{{- $polaris := include "floe-platform.polaris.fullname" $context }}
+{{- $minio := include "floe-platform.minio.fullname" $context }}
+{{- $postgres := include "floe-platform.postgresql.host" $context }}
+{{- $dagsterWeb := include "floe-platform.dagster.webserverName" $context }}
+{{- $marquez := include "floe-platform.marquez.fullname" $context }}
+{{- $otel := include "floe-platform.otel.fullname" $context }}
+{{- $jaegerQuery := include "floe-platform.jaeger.queryName" $context }}
+```
+
+2. Replace the entire current `env:` list with:
+
+```gotemplate
+          env:
+            {{- include "floe-platform.testRunner.contractEnv" $context | nindent 12 }}
+            - name: POSTGRES_USER
+              value: floe
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.postgresql.secretName" $context }}
+                  key: postgresql-password
+            - name: MINIO_ENDPOINT
+              value: "http://{{ include "floe-platform.minio.fullname" $context }}:9000"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.minio.secretName" $context }}
+                  key: root-user
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.minio.secretName" $context }}
+                  key: root-password
+            - name: AWS_REGION
+              value: us-east-1
+            - name: POLARIS_URI
+              value: "http://{{ include "floe-platform.polaris.fullname" $context }}:{{ $context.Values.polaris.service.port | default 8181 }}/api/catalog"
+            - name: POLARIS_CREDENTIAL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "floe-platform.polaris.credentialSecretName" $context }}
+                  key: POLARIS_CREDENTIAL
+            - name: POLARIS_WAREHOUSE
+              value: {{ include "floe-platform.polaris.warehouse" $context | quote }}
+            - name: POLARIS_SCOPE
+              value: "PRINCIPAL_ROLE:ALL"
+            - name: JAEGER_URL
+              value: "http://{{ include "floe-platform.jaeger.queryName" $context }}:16686"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://{{ include "floe-platform.otel.fullname" $context }}:4317"
+            - name: OTEL_SERVICE_NAME
+              value: "floe-test-runner-{{ $suite }}"
+            - name: PYTHONPATH
+              value: "/app:/app/testing"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+```
+
+- [ ] **Step 5: Render the standard E2E Job**
+
+Run:
+
+```bash
+source testing/ci/common.sh && floe_render_test_job tests/job-e2e.yaml >/tmp/floe-e2e-job.yaml
+```
+
+Expected: exit code 0.
+
+Run:
+
+```bash
+rg -n "FLOE_EXECUTION_CONTEXT|POLARIS_HOST|POLARIS_PORT|INTEGRATION_TEST_HOST" /tmp/floe-e2e-job.yaml
+```
+
+Expected: output includes `FLOE_EXECUTION_CONTEXT`, `POLARIS_HOST`, and `POLARIS_PORT`; output does not include `INTEGRATION_TEST_HOST`.
+
+- [ ] **Step 6: Run chart contract tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_e2e_runner_chart_contract.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Helm adapter migration**
+
+Run:
+
+```bash
+git add \
+  charts/floe-platform/templates/tests/_contract-env.generated.tpl \
+  charts/floe-platform/templates/tests/_test-job.tpl \
+  tests/unit/test_e2e_runner_chart_contract.py
+git commit -m "refactor: generate test runner env bindings"
+```
+
+### Task 7: Validation Boundary Split
+
+**Files:**
+
+- Modify: `pyproject.toml`
+- Modify: `Makefile`
+- Create: `tests/bootstrap/conftest.py`
+- Move: `tests/e2e/test_platform_bootstrap.py` to `tests/bootstrap/test_platform_bootstrap.py`
+- Modify: `tests/e2e/conftest.py`
+- Test: `tests/unit/test_validation_boundary_markers.py`
+
+- [ ] **Step 1: Write validation-boundary marker tests**
+
+Create `tests/unit/test_validation_boundary_markers.py`:
+
+```python
+"""Tests for validation-boundary configuration."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_pytest_markers_include_validation_boundaries() -> None:
+    """The validation stack has explicit boundary markers."""
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    markers = pyproject["tool"]["pytest"]["ini_options"]["markers"]
+    marker_names = {entry.split(":", 1)[0] for entry in markers}
+
+    assert {"contract", "bootstrap", "platform_blackbox", "developer_workflow"} <= marker_names
+
+
+def test_make_test_runs_contract_before_integration() -> None:
+    """Top-level test target runs contract tests before integration tests."""
+    makefile = Path("Makefile").read_text()
+
+    assert "test: test-unit test-contract test-integration" in makefile
+    assert ".PHONY: test-contract" in makefile
+```
+
+- [ ] **Step 2: Run marker tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py -v
+```
+
+Expected: FAIL because `platform_blackbox`, `developer_workflow`, and Makefile contract wiring are missing.
+
+- [ ] **Step 3: Add pytest validation-boundary markers**
+
+Modify the `markers` list in `pyproject.toml`:
+
+```toml
+    "bootstrap: Marks environment bring-up and platform readiness checks",
+    "platform_blackbox: Marks deployed-system behavior checks with no repo-local assumptions",
+    "developer_workflow: Marks repo-aware local/developer workflow checks",
+```
+
+- [ ] **Step 4: Wire contract tests into the standard test target**
+
+Modify `Makefile`:
+
+1. Change:
+
+```make
+test: test-unit test-integration ## Run all tests (unit + integration)
+```
+
+to:
+
+```make
+test: test-unit test-contract test-integration ## Run all tests (unit + contract + integration)
+```
+
+2. Add after `test-unit`:
+
+```make
+.PHONY: test-contract
+test-contract: ## Run cross-package contract tests
+	@echo "Running contract tests..."
+	@./testing/ci/test-contract.sh
+```
+
+- [ ] **Step 5: Move bootstrap test to the bootstrap boundary**
+
+Run:
+
+```bash
+mkdir -p tests/bootstrap
+git mv tests/e2e/test_platform_bootstrap.py tests/bootstrap/test_platform_bootstrap.py
+```
+
+Create `tests/bootstrap/conftest.py`:
+
+```python
+"""Bootstrap validation fixtures.
+
+Bootstrap tests validate environment bring-up before product E2E tests run.
+They may use Kubernetes and Helm readiness checks, but they should not assert
+data-platform product behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Mark all bootstrap tests with the bootstrap boundary marker."""
+    for item in items:
+        item.add_marker(pytest.mark.bootstrap)
+```
+
+- [ ] **Step 6: Mark E2E tests as platform black-box by default**
+
+Modify `tests/e2e/conftest.py` inside `pytest_collection_modifyitems` before the destructive reordering logic returns:
+
+```python
+    for item in items:
+        item.add_marker(pytest.mark.platform_blackbox)
+```
+
+Keep the existing destructive reordering and TQR checks in place.
+
+- [ ] **Step 7: Run validation-boundary tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py tests/bootstrap/test_platform_bootstrap.py --collect-only -q
+```
+
+Expected: PASS collection.
+
+- [ ] **Step 8: Commit validation boundary split**
+
+Run:
+
+```bash
+git add \
+  Makefile \
+  pyproject.toml \
+  tests/bootstrap/conftest.py \
+  tests/bootstrap/test_platform_bootstrap.py \
+  tests/e2e/conftest.py \
+  tests/unit/test_validation_boundary_markers.py
+git commit -m "test: split validation boundaries"
+```
+
+### Task 8: Contract Drift Guard And Final Verification
+
+**Files:**
+
+- Modify: `scripts/check-architecture-drift`
+- Create: `tests/contract/test_platform_contract_generated_bindings.py`
+- Test: `tests/contract/test_platform_contract_generated_bindings.py`
+
+- [ ] **Step 1: Write contract-generated binding tests**
+
+Create `tests/contract/test_platform_contract_generated_bindings.py`:
+
+```python
+"""Cross-consumer contract tests for generated platform bindings."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_shell_and_python_render_same_polaris_service_name() -> None:
+    """Shell bindings and Python contracts render the same service name."""
+    from floe_core.contracts.topology import ComponentId, render_service_name
+
+    expected = render_service_name(ComponentId.POLARIS, release_name="floe-platform").strip()
+    result = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            "source testing/ci/common.sh && floe_service_name polaris",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == expected
+
+
+def test_chart_generated_env_helper_is_emitter_output() -> None:
+    """The committed Helm helper is generated from the contract emitter."""
+    from floe_core.contracts.emit import render_helm_test_env_template
+
+    path = Path("charts/floe-platform/templates/tests/_contract-env.generated.tpl")
+
+    assert path.read_text() == render_helm_test_env_template()
+
+
+def test_service_fixture_uses_contract_owned_port_table() -> None:
+    """Python service fixture defaults are generated from topology contracts."""
+    from floe_core.contracts.topology import service_contracts
+    from testing.fixtures.services import SERVICE_DEFAULT_PORTS
+
+    assert SERVICE_DEFAULT_PORTS == {
+        service.short_name: service.default_port for service in service_contracts()
+    }
+```
+
+- [ ] **Step 2: Run contract binding tests**
+
+Run:
+
+```bash
+uv run pytest tests/contract/test_platform_contract_generated_bindings.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Add duplicate service-literal guard**
+
+Modify `scripts/check-architecture-drift`:
+
+1. Add this function before `check_file`:
+
+```bash
+check_platform_contract_literals() {
+    local file="$1"
+
+    case "$file" in
+        *"packages/floe-core/src/floe_core/contracts/"*|*"charts/floe-platform/templates/tests/_contract-env.generated.tpl")
+            return 0
+            ;;
+    esac
+
+    if grep -qE '"(dagster|polaris|polaris-management|minio|minio-console|postgres|postgresql|jaeger-query|otel-collector-grpc|otel-collector-http|marquez|oci-registry|oci-registry-auth)"[[:space:]]*:' "$file" 2>/dev/null; then
+        log_error "$file: duplicated platform service map detected - use floe_core.contracts.topology"
+        ((violations++))
+    fi
+}
+```
+
+2. Call it from `check_file` after `check_test_organization "$file"`:
+
+```bash
+    check_platform_contract_literals "$file"
+```
+
+- [ ] **Step 4: Run architecture drift check against migrated files**
+
+Run:
+
+```bash
+./scripts/check-architecture-drift testing/fixtures/services.py
+```
+
+Expected: exit code 0.
+
+Run:
+
+```bash
+./scripts/check-architecture-drift packages/floe-core/src/floe_core/contracts/topology.py
+```
+
+Expected: exit code 0 because contract-domain files are allowed to author canonical service literals.
+
+- [ ] **Step 5: Run focused contract, unit, shell, and chart verification**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/contracts \
+  tests/unit/test_e2e_fixture_wiring.py \
+  tests/unit/test_e2e_runner_chart_contract.py \
+  tests/unit/test_validation_boundary_markers.py \
+  tests/contract/test_platform_contract_generated_bindings.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run type and lint checks for touched areas**
+
+Run:
+
+```bash
+uv run ruff check packages/floe-core/src/floe_core/contracts testing/fixtures/services.py tests/unit tests/contract
+uv run ruff format --check packages/floe-core/src/floe_core/contracts testing/fixtures/services.py tests/unit tests/contract
+uv run mypy --strict packages/floe-core/src/floe_core/contracts testing/fixtures
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run top-level tests that do not require a live cluster**
+
+Run:
+
+```bash
+make test-unit
+make test-contract
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run cluster validation on DevPod + Hetzner**
+
+Run:
+
+```bash
+DEVPOD_WORKSPACE=floe scripts/devpod-ensure-ready.sh
+DEVPOD_WORKSPACE=floe scripts/devpod-sync-kubeconfig.sh
+make test-e2e
+make test-e2e-full
+```
+
+Expected: standard and destructive E2E suites pass. If bootstrap fails, record it as a bootstrap failure and do not debug product E2E behavior until bootstrap is green.
+
+- [ ] **Step 9: Commit drift guard and verification contract tests**
+
+Run:
+
+```bash
+git add scripts/check-architecture-drift tests/contract/test_platform_contract_generated_bindings.py
+git commit -m "test: guard generated platform contracts"
+```
+
+## Acceptance Mapping
+
+- `floe_core.contracts` exists with runtime, schemas, topology, and execution domains: Tasks 1, 2, and 3.
+- Shared runtime enums are sourced from the contract layer: Task 1.
+- Machine-readable output keys are contract-owned: Task 2.
+- Python fixtures consume generated bindings rather than local service maps: Task 4.
+- Shell scripts consume contract emitters rather than authoring service-name formulas: Task 5.
+- Helm test-runner env bindings are generated from the contract emitter: Task 6.
+- Validation stack is split into contract, bootstrap, platform-blackbox, and developer-workflow categories: Task 7.
+- Legacy duplicate authoring paths for migrated domains are removed or guarded against: Task 8.
+
+## Final Verification
+
+Run the full local non-cluster validation:
+
+```bash
+make lint
+make typecheck
+make test-unit
+make test-contract
+```
+
+Run the DevPod + Hetzner cluster validation:
+
+```bash
+DEVPOD_WORKSPACE=floe scripts/devpod-ensure-ready.sh
+DEVPOD_WORKSPACE=floe scripts/devpod-sync-kubeconfig.sh
+make test-e2e
+make test-e2e-full
+```
+
+The implementation is complete when all focused tests, unit tests, contract tests, and DevPod + Hetzner E2E suites pass.

--- a/docs/superpowers/plans/2026-04-23-validation-architecture-reset.md
+++ b/docs/superpowers/plans/2026-04-23-validation-architecture-reset.md
@@ -1,0 +1,935 @@
+# Validation Architecture Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split floe validation into explicit execution lanes so standard in-cluster E2E only validates deployed product behavior, while admin/bootstrap and repo-aware checks run in the correct context.
+
+**Architecture:** Use pytest lane markers plus runner split. `tests/e2e` items default to `platform_blackbox` unless explicitly marked `bootstrap`, `developer_workflow`, or `destructive`, and the shell orchestration runs host-side bootstrap and developer lanes separately from the in-cluster product lane. Strengthen Polaris/Iceberg reset logic so dbt-based product tests fail on real product issues, not stale catalog state.
+
+**Tech Stack:** Python 3.10+, pytest, Bash, Helm templates, Kubernetes Jobs, DevPod/Hetzner, Polaris, Iceberg, dbt, PyIceberg, boto3.
+
+---
+
+## Scope Check
+
+This plan covers one connected subsystem: the validation harness and its supporting dbt reset discipline. It does not attempt the broader contract-layer migration, and it intentionally leaves the OpenLineage `parentRun` defect as a separate product bug after the harness split lands.
+
+## File Structure
+
+Modify lane selection and defaults:
+
+- `pyproject.toml`: register `bootstrap`, `platform_blackbox`, and `developer_workflow` pytest markers.
+- `tests/e2e/conftest.py`: register lane markers at runtime, auto-default unclassified E2E items to `platform_blackbox`, and keep destructive tests ordered last.
+- `tests/unit/test_validation_boundary_markers.py`: structural tests for marker registration and critical file-level lane assignments.
+
+Modify critical outlier tests:
+
+- `tests/e2e/test_helm_workflow.py`: explicit `bootstrap` lane.
+- `tests/e2e/test_platform_bootstrap.py`: explicit `bootstrap` lane.
+- `tests/e2e/test_platform_deployment_e2e.py`: explicit `bootstrap` lane.
+- `tests/e2e/test_profile_isolation.py`: explicit `developer_workflow` lane.
+- `tests/e2e/test_governance.py`: mark `test_pip_audit_clean` as `developer_workflow`.
+- `tests/e2e/test_runtime_loader_e2e.py`: replace `127.0.0.1` with service-contract resolution and split function-level lanes.
+
+Split orchestration:
+
+- `charts/floe-platform/templates/tests/job-e2e.yaml`: standard in-cluster runner selects `platform_blackbox and not destructive`.
+- `testing/ci/test-e2e-cluster.sh`: keep in-cluster execution for product and destructive lanes, update suite semantics and output.
+- `testing/ci/test-e2e-full.sh`: orchestrate `bootstrap`, `platform_blackbox`, `developer_workflow`, then gated `destructive`.
+- `testing/ci/test-bootstrap-validation.sh`: host-side bootstrap/admin runner.
+- `testing/ci/test-developer-workflow.sh`: host-side repo-aware runner.
+- `tests/unit/test_validation_runner_wiring.py`: structural tests for runner commands and chart marker wiring.
+
+Harden reset/idempotency:
+
+- `tests/e2e/dbt_utils.py`: fresh Polaris catalog reset helpers, verified namespace purge, and clearer reset failures.
+- `tests/e2e/conftest.py`: shared dbt fixture uses verified namespace reset before and after module-scoped runs.
+- `tests/unit/test_dbt_namespace_reset.py`: unit tests for reset semantics and `run_dbt()` preconditions.
+
+Update docs:
+
+- `TESTING.md`: describe the four validation lanes and their execution environments.
+
+## Tasks
+
+### Task 1: Add Validation Lane Markers And Defaulting
+
+**Files:**
+
+- Modify: `pyproject.toml`
+- Modify: `tests/e2e/conftest.py`
+- Create: `tests/unit/test_validation_boundary_markers.py`
+
+- [ ] **Step 1: Write the failing structural tests**
+
+Create `tests/unit/test_validation_boundary_markers.py`:
+
+```python
+"""Structural tests for validation lane markers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pyproject_registers_validation_lane_markers() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert '"bootstrap: Marks admin/bootstrap validation"' in pyproject
+    assert '"platform_blackbox: Marks in-cluster product validation"' in pyproject
+    assert '"developer_workflow: Marks repo-aware host validation"' in pyproject
+
+
+def test_e2e_conftest_registers_lane_markers() -> None:
+    conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
+
+    assert 'bootstrap: mark test as bootstrap/admin validation' in conftest
+    assert 'platform_blackbox: mark test as deployed in-cluster product validation' in conftest
+    assert 'developer_workflow: mark test as repo-aware host validation' in conftest
+
+
+def test_e2e_conftest_defaults_unclassified_items_to_platform_blackbox() -> None:
+    conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
+
+    assert "platform_blackbox" in conftest
+    assert "item.add_marker(pytest.mark.platform_blackbox)" in conftest
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py -v
+```
+
+Expected: FAIL because `pyproject.toml` does not yet declare the new markers and `tests/e2e/conftest.py` does not yet default unclassified E2E items to `platform_blackbox`.
+
+- [ ] **Step 3: Register the new markers in `pyproject.toml`**
+
+Modify the `markers = [` block in `pyproject.toml` to include:
+
+```toml
+    "bootstrap: Marks admin/bootstrap validation",
+    "platform_blackbox: Marks in-cluster product validation",
+    "developer_workflow: Marks repo-aware host validation",
+```
+
+Keep the existing `e2e`, `contract`, `integration`, and `benchmark` markers.
+
+- [ ] **Step 4: Default unclassified E2E items to `platform_blackbox`**
+
+Modify `tests/e2e/conftest.py`.
+
+1. Add the new marker registrations inside `pytest_configure()`:
+
+```python
+    config.addinivalue_line(
+        "markers",
+        "bootstrap: mark test as bootstrap/admin validation",
+    )
+    config.addinivalue_line(
+        "markers",
+        "platform_blackbox: mark test as deployed in-cluster product validation",
+    )
+    config.addinivalue_line(
+        "markers",
+        "developer_workflow: mark test as repo-aware host validation",
+    )
+```
+
+2. At the top of `pytest_collection_modifyitems()`, add a lane-marker helper:
+
+```python
+    lane_markers = {
+        "bootstrap",
+        "platform_blackbox",
+        "developer_workflow",
+        "destructive",
+    }
+```
+
+3. Before the destructive reordering logic, add defaulting for unclassified E2E tests:
+
+```python
+    for item in items:
+        item_markers = {mark.name for mark in item.iter_markers()}
+        if "e2e" not in item_markers:
+            continue
+        if item_markers.isdisjoint(lane_markers):
+            item.add_marker(pytest.mark.platform_blackbox)
+```
+
+4. Keep the destructive test reordering logic intact so `destructive` tests still run last when collected.
+
+- [ ] **Step 5: Run the structural tests again**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml tests/e2e/conftest.py tests/unit/test_validation_boundary_markers.py
+git commit -m "test: add validation lane markers"
+```
+
+### Task 2: Explicitly Reclassify The Current Outlier Tests
+
+**Files:**
+
+- Modify: `tests/e2e/test_helm_workflow.py`
+- Modify: `tests/e2e/test_platform_bootstrap.py`
+- Modify: `tests/e2e/test_platform_deployment_e2e.py`
+- Modify: `tests/e2e/test_profile_isolation.py`
+- Modify: `tests/e2e/test_governance.py`
+- Modify: `tests/e2e/test_runtime_loader_e2e.py`
+- Modify: `tests/unit/test_validation_boundary_markers.py`
+
+- [ ] **Step 1: Extend the structural tests to cover critical lane assignments**
+
+Append these tests to `tests/unit/test_validation_boundary_markers.py`:
+
+```python
+def test_bootstrap_modules_are_explicitly_marked() -> None:
+    helm_workflow = (REPO_ROOT / "tests" / "e2e" / "test_helm_workflow.py").read_text()
+    platform_bootstrap = (REPO_ROOT / "tests" / "e2e" / "test_platform_bootstrap.py").read_text()
+    platform_deployment = (
+        REPO_ROOT / "tests" / "e2e" / "test_platform_deployment_e2e.py"
+    ).read_text()
+
+    assert "pytest.mark.bootstrap" in helm_workflow
+    assert "pytest.mark.bootstrap" in platform_bootstrap
+    assert "pytest.mark.bootstrap" in platform_deployment
+
+
+def test_developer_workflow_outliers_are_explicitly_marked() -> None:
+    profile_isolation = (REPO_ROOT / "tests" / "e2e" / "test_profile_isolation.py").read_text()
+    governance = (REPO_ROOT / "tests" / "e2e" / "test_governance.py").read_text()
+    runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
+
+    assert "pytest.mark.developer_workflow" in profile_isolation
+    assert "def test_pip_audit_clean" in governance
+    assert "@pytest.mark.developer_workflow" in governance
+    assert "pytest.mark.developer_workflow" in runtime_loader
+
+
+def test_runtime_loader_uses_service_contract_not_localhost_literal() -> None:
+    runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
+
+    assert 'ServiceEndpoint("dagster-webserver")' in runtime_loader
+    assert 'DAGSTER_HOST = "127.0.0.1"' not in runtime_loader
+```
+
+- [ ] **Step 2: Run the structural tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py -v
+```
+
+Expected: FAIL because the outlier files are not yet explicitly classified and `test_runtime_loader_e2e.py` still hardcodes `127.0.0.1`.
+
+- [ ] **Step 3: Mark the bootstrap/admin files explicitly**
+
+Add module-level `pytestmark` blocks near the imports of these files:
+
+`tests/e2e/test_helm_workflow.py`
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+```
+
+`tests/e2e/test_platform_bootstrap.py`
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+```
+
+`tests/e2e/test_platform_deployment_e2e.py`
+
+```python
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+```
+
+Keep existing `@pytest.mark.requirement(...)` decorators in place.
+
+- [ ] **Step 4: Mark the repo-aware developer workflow tests explicitly**
+
+1. Add a module-level marker in `tests/e2e/test_profile_isolation.py`:
+
+```python
+pytestmark = [pytest.mark.developer_workflow]
+```
+
+2. Add `@pytest.mark.developer_workflow` directly above `test_pip_audit_clean()` in `tests/e2e/test_governance.py`:
+
+```python
+    @pytest.mark.developer_workflow
+    @pytest.mark.e2e
+    @pytest.mark.requirement("FR-064")
+    def test_pip_audit_clean(self) -> None:
+```
+
+3. In `tests/e2e/test_runtime_loader_e2e.py`, mark the functions individually:
+
+```python
+@pytest.mark.e2e
+@pytest.mark.platform_blackbox
+@pytest.mark.requirement("AC-1")
+@pytest.mark.requirement("AC-6")
+def test_dagster_discovers_code_location(dagster_url: str) -> None:
+    ...
+
+
+@pytest.mark.e2e
+@pytest.mark.platform_blackbox
+@pytest.mark.requirement("AC-1")
+@pytest.mark.requirement("AC-6")
+def test_dagster_discovers_assets(dagster_url: str) -> None:
+    ...
+
+
+@pytest.mark.developer_workflow
+@pytest.mark.requirement("AC-6")
+def test_thin_definitions_are_deployed() -> None:
+    ...
+```
+
+- [ ] **Step 5: Replace the runtime loader localhost contract with service resolution**
+
+Modify `tests/e2e/test_runtime_loader_e2e.py`.
+
+1. Remove:
+
+```python
+DAGSTER_HOST = "127.0.0.1"
+DAGSTER_PORT = 3000
+```
+
+2. Add these imports and helper logic:
+
+```python
+import os
+
+from testing.fixtures.services import ServiceEndpoint
+```
+
+```python
+    url = os.environ.get("DAGSTER_URL", ServiceEndpoint("dagster-webserver").url)
+```
+
+3. Keep the health check against `f"{url}/server_info"` exactly as the fixture entrypoint.
+
+- [ ] **Step 6: Run the structural tests again**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_boundary_markers.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the directly affected tests in their proper lanes**
+
+Run:
+
+```bash
+uv run pytest tests/e2e/test_runtime_loader_e2e.py -m "platform_blackbox or developer_workflow" -v
+uv run pytest tests/e2e/test_profile_isolation.py tests/e2e/test_governance.py -m developer_workflow -v
+uv run pytest tests/e2e/test_helm_workflow.py tests/e2e/test_platform_bootstrap.py tests/e2e/test_platform_deployment_e2e.py -m bootstrap -v
+```
+
+Expected: collection succeeds with the new lane markers. Runtime pass/fail depends on environment state, but there should be no marker warnings and no `127.0.0.1` contract left in `test_runtime_loader_e2e.py`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  tests/e2e/test_helm_workflow.py \
+  tests/e2e/test_platform_bootstrap.py \
+  tests/e2e/test_platform_deployment_e2e.py \
+  tests/e2e/test_profile_isolation.py \
+  tests/e2e/test_governance.py \
+  tests/e2e/test_runtime_loader_e2e.py \
+  tests/unit/test_validation_boundary_markers.py
+git commit -m "test: classify validation outliers by execution lane"
+```
+
+### Task 3: Split The Runner Orchestration By Lane
+
+**Files:**
+
+- Modify: `charts/floe-platform/templates/tests/job-e2e.yaml`
+- Modify: `testing/ci/test-e2e-cluster.sh`
+- Modify: `testing/ci/test-e2e-full.sh`
+- Create: `testing/ci/test-bootstrap-validation.sh`
+- Create: `testing/ci/test-developer-workflow.sh`
+- Create: `tests/unit/test_validation_runner_wiring.py`
+
+- [ ] **Step 1: Write failing runner-wiring tests**
+
+Create `tests/unit/test_validation_runner_wiring.py`:
+
+```python
+"""Structural tests for validation lane runner wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_chart_standard_runner_selects_platform_blackbox() -> None:
+    job_e2e = (
+        REPO_ROOT / "charts" / "floe-platform" / "templates" / "tests" / "job-e2e.yaml"
+    ).read_text()
+
+    assert '"pytestMarker" "platform_blackbox and not destructive"' in job_e2e
+
+
+def test_bootstrap_runner_uses_bootstrap_marker() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-bootstrap-validation.sh").read_text()
+
+    assert "uv run pytest tests/e2e" in script
+    assert '-m "bootstrap"' in script
+
+
+def test_developer_workflow_runner_uses_developer_marker() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-developer-workflow.sh").read_text()
+
+    assert "uv run pytest tests/e2e" in script
+    assert '-m "developer_workflow"' in script
+
+
+def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
+
+    assert 'test-bootstrap-validation.sh' in script
+    assert 'test-e2e-cluster.sh' in script
+    assert 'test-developer-workflow.sh' in script
+    assert 'TEST_SUITE=e2e-destructive' in script
+```
+
+- [ ] **Step 2: Run the runner-wiring tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_runner_wiring.py -v
+```
+
+Expected: FAIL because the host-side lane scripts do not exist and the standard chart runner still uses `not destructive`.
+
+- [ ] **Step 3: Narrow the in-cluster standard Job to the product lane**
+
+Modify `charts/floe-platform/templates/tests/job-e2e.yaml`:
+
+```yaml
+{{- include "floe-platform.testJob" (dict
+    "context" .
+    "suite" "e2e"
+    "pytestMarker" "platform_blackbox and not destructive"
+    "serviceAccount" (include "floe-platform.testRunner.saName" .)
+    "artifactPrefix" "e2e"
+    ) }}
+```
+
+This keeps the Job name stable while changing the semantic contract of the standard lane.
+
+- [ ] **Step 4: Add the host-side bootstrap runner**
+
+Create `testing/ci/test-bootstrap-validation.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+mkdir -p test-artifacts
+
+uv run pytest tests/e2e \
+  -m "bootstrap" \
+  --tb=short \
+  -v \
+  --junitxml=test-artifacts/bootstrap-results.xml
+```
+
+Make it executable:
+
+```bash
+chmod +x testing/ci/test-bootstrap-validation.sh
+```
+
+- [ ] **Step 5: Add the host-side developer-workflow runner**
+
+Create `testing/ci/test-developer-workflow.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+mkdir -p test-artifacts
+
+uv run pytest tests/e2e \
+  -m "developer_workflow" \
+  --tb=short \
+  -v \
+  --junitxml=test-artifacts/developer-workflow-results.xml
+```
+
+Make it executable:
+
+```bash
+chmod +x testing/ci/test-developer-workflow.sh
+```
+
+- [ ] **Step 6: Update the full orchestrator**
+
+Modify `testing/ci/test-e2e-full.sh`.
+
+1. Replace the current two-exit-code model with separate lane exits:
+
+```bash
+BOOTSTRAP_EXIT=0
+PLATFORM_EXIT=0
+DEVELOPER_EXIT=0
+DESTRUCTIVE_EXIT=0
+```
+
+2. Run bootstrap first:
+
+```bash
+if "${SCRIPT_DIR}/test-bootstrap-validation.sh"; then
+    info "Bootstrap validation PASSED"
+else
+    BOOTSTRAP_EXIT=$?
+    error "Bootstrap validation FAILED (exit code: ${BOOTSTRAP_EXIT})"
+fi
+```
+
+3. Gate the in-cluster platform lane on bootstrap:
+
+```bash
+if [[ "${BOOTSTRAP_EXIT}" -eq 0 ]]; then
+    if "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+        info "Platform blackbox validation PASSED"
+    else
+        PLATFORM_EXIT=$?
+        error "Platform blackbox validation FAILED (exit code: ${PLATFORM_EXIT})"
+    fi
+else
+    info "Skipping platform blackbox validation because bootstrap failed."
+fi
+```
+
+4. Always run the repo-aware developer lane:
+
+```bash
+if "${SCRIPT_DIR}/test-developer-workflow.sh"; then
+    info "Developer workflow validation PASSED"
+else
+    DEVELOPER_EXIT=$?
+    error "Developer workflow validation FAILED (exit code: ${DEVELOPER_EXIT})"
+fi
+```
+
+5. Only run destructive if bootstrap and platform both passed, unless `FORCE_DESTRUCTIVE=true`.
+
+6. Update the summary block to print all four lanes explicitly.
+
+- [ ] **Step 7: Update `testing/ci/test-e2e-cluster.sh` comments and suite messaging**
+
+Modify comments and status output so the standard suite is described as:
+
+```bash
+# platform-blackbox E2E test runner — runs deployed product validation in-cluster
+```
+
+Keep the existing `TEST_SUITE=e2e|e2e-destructive` external interface for now so callers do not break in the same change.
+
+- [ ] **Step 8: Run the structural runner tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_runner_wiring.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Smoke-test the new runners**
+
+Run:
+
+```bash
+./testing/ci/test-bootstrap-validation.sh
+./testing/ci/test-developer-workflow.sh
+./testing/ci/test-e2e-full.sh
+```
+
+Expected:
+
+- bootstrap lane runs only `-m bootstrap`
+- standard in-cluster lane runs only `platform_blackbox and not destructive`
+- developer lane runs only `-m developer_workflow`
+- destructive lane stays gated behind bootstrap + platform success unless overridden
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add \
+  charts/floe-platform/templates/tests/job-e2e.yaml \
+  testing/ci/test-e2e-cluster.sh \
+  testing/ci/test-e2e-full.sh \
+  testing/ci/test-bootstrap-validation.sh \
+  testing/ci/test-developer-workflow.sh \
+  tests/unit/test_validation_runner_wiring.py
+git commit -m "test: split validation runners by execution lane"
+```
+
+### Task 4: Harden Polaris And Iceberg Reset Semantics
+
+**Files:**
+
+- Modify: `tests/e2e/dbt_utils.py`
+- Modify: `tests/e2e/conftest.py`
+- Create: `tests/unit/test_dbt_namespace_reset.py`
+
+- [ ] **Step 1: Write failing reset-contract tests**
+
+Create `tests/unit/test_dbt_namespace_reset.py`:
+
+```python
+"""Unit tests for Polaris/Iceberg namespace reset semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import dbt_utils
+
+
+def test_clear_catalog_cache_drops_cached_catalog() -> None:
+    dbt_utils._catalog_cache["catalog"] = object()
+
+    dbt_utils._clear_catalog_cache()
+
+    assert dbt_utils._catalog_cache == {}
+
+
+def test_purge_namespace_raises_when_namespace_still_contains_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_catalog = Mock()
+    fake_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", lambda fresh=False: fake_catalog)
+    monkeypatch.setattr(dbt_utils, "_delete_s3_prefix", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: Mock())
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="Namespace reset incomplete"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
+def test_run_dbt_resets_raw_namespace_before_seed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    project_dir = tmp_path / "customer-360"
+    project_dir.mkdir()
+
+    purge_calls: list[tuple[str, bool]] = []
+
+    def _record(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+        purge_calls.append((namespace, verify_empty))
+
+    monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _record)
+    monkeypatch.setattr(
+        dbt_utils.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    dbt_utils.run_dbt(["seed"], project_dir)
+
+    assert purge_calls == [("customer_360_raw", True)]
+```
+
+- [ ] **Step 2: Run the reset-contract tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_dbt_namespace_reset.py -v
+```
+
+Expected: FAIL because `_clear_catalog_cache()` and `NamespaceResetError` do not exist, and `run_dbt()` does not yet request verified reset behavior.
+
+- [ ] **Step 3: Add explicit reset helpers and error type**
+
+Modify `tests/e2e/dbt_utils.py`.
+
+1. Add the reset error and cache clearer near the top of the file:
+
+```python
+class NamespaceResetError(RuntimeError):
+    """Raised when an Iceberg namespace cannot be reset to an empty state."""
+
+
+def _clear_catalog_cache() -> None:
+    """Drop cached Polaris catalog state so each reset can re-auth cleanly."""
+    _catalog_cache.clear()
+```
+
+2. Change `_get_polaris_catalog()` to accept a freshness flag:
+
+```python
+def _get_polaris_catalog(*, fresh: bool = False) -> Any:
+    if fresh:
+        _clear_catalog_cache()
+    if "catalog" in _catalog_cache:
+        return _catalog_cache["catalog"]
+    ...
+```
+
+- [ ] **Step 4: Make namespace purge verified instead of best-effort**
+
+Modify `_purge_iceberg_namespace()` in `tests/e2e/dbt_utils.py`:
+
+```python
+def _purge_iceberg_namespace(
+    namespace: str,
+    verify_empty: bool = False,
+    retries: int = 3,
+) -> None:
+```
+
+Use a fresh Polaris catalog client for the purge path when verified reset is required, and make the verification loop fail closed:
+
+```python
+    catalog = _get_polaris_catalog(fresh=verify_empty)
+    verification_failure: str | None = None
+
+    if not verify_empty:
+        return
+
+    for attempt in range(retries):
+        verification_catalog = _get_polaris_catalog(fresh=True)
+        if verification_catalog is None:
+            verification_failure = "catalog unavailable"
+            break
+
+        try:
+            remaining = verification_catalog.list_tables(namespace)
+        except NoSuchNamespaceError:
+            return
+        except Exception as exc:
+            verification_failure = f"verification failed: {type(exc).__name__}"
+            break
+
+        if not remaining:
+            return
+
+    if verification_failure is not None:
+        raise NamespaceResetError(
+            f"Namespace reset verification failed for {namespace}: {verification_failure}"
+        )
+
+    raise NamespaceResetError(
+        f"Namespace reset incomplete for {namespace}: remaining tables={remaining}"
+    )
+```
+
+Keep the S3 prefix deletion and namespace drop logic, but make inability to verify a reset failure instead of silently continuing.
+
+When `verify_empty=True`, treat explicit object-store cleanup failures during the purge path as reset failures too. A namespace-only verification is not sufficient if:
+
+- the object-store sweep for a known table prefix failed
+- `delete_objects` returned per-object errors
+- a table existed but its storage location could not be loaded, preventing the explicit prefix sweep
+- the purge-phase catalog lookup itself failed before table locations could be enumerated
+
+- [ ] **Step 5: Require verified reset before dbt seed and run**
+
+Modify `run_dbt()` in `tests/e2e/dbt_utils.py`:
+
+```python
+    if args and args[0] == "seed":
+        product_name = project_dir.name.replace("-", "_")
+        _purge_iceberg_namespace(f"{product_name}_raw", verify_empty=True)
+    elif args and args[0] == "run":
+        product_name = project_dir.name.replace("-", "_")
+        _purge_iceberg_namespace(product_name, verify_empty=True)
+```
+
+Modify the module-scoped `dbt_pipeline_result` fixture in `tests/e2e/conftest.py` so setup and teardown use verified reset too:
+
+```python
+        _purge_iceberg_namespace(namespace_raw, verify_empty=True)
+        _purge_iceberg_namespace(namespace_models, verify_empty=True)
+```
+
+If teardown verified-reset fails after an earlier dbt or test failure, preserve the original failure as the primary signal and only log or otherwise surface the teardown reset problem without masking it.
+
+On the no-prior-error path, teardown should still attempt verified reset for both namespaces before raising the first collected reset error.
+
+and in `finally`:
+
+```python
+        _purge_iceberg_namespace(namespace_raw, verify_empty=True)
+        _purge_iceberg_namespace(namespace_models, verify_empty=True)
+```
+
+- [ ] **Step 6: Run the reset tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_dbt_namespace_reset.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the dbt-heavy platform tests against the cleaned reset path**
+
+Run:
+
+```bash
+uv run pytest tests/e2e/test_dbt_lifecycle_e2e.py tests/e2e/test_data_pipeline.py tests/e2e/test_compile_deploy_materialize_e2e.py -m platform_blackbox -v
+```
+
+Expected: stale-state failures should either disappear or collapse into a smaller, real product defect set. If failures remain, they should now fail with a reset-specific message instead of ambiguous stale-metadata noise.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/e2e/dbt_utils.py tests/e2e/conftest.py tests/unit/test_dbt_namespace_reset.py
+git commit -m "test: verify Polaris namespace reset before dbt execution"
+```
+
+### Task 5: Update Testing Documentation And Final Validation
+
+**Files:**
+
+- Modify: `TESTING.md`
+
+- [ ] **Step 1: Add a failing documentation check**
+
+Append this test to `tests/unit/test_validation_runner_wiring.py`:
+
+```python
+def test_testing_guide_describes_validation_lanes() -> None:
+    guide = (REPO_ROOT / "TESTING.md").read_text()
+
+    assert "bootstrap" in guide
+    assert "platform_blackbox" in guide
+    assert "developer_workflow" in guide
+    assert "destructive" in guide
+```
+
+- [ ] **Step 2: Run the documentation test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_validation_runner_wiring.py -v
+```
+
+Expected: FAIL because `TESTING.md` still describes E2E as a single K8s lane.
+
+- [ ] **Step 3: Update `TESTING.md` to describe the new validation architecture**
+
+Add a new subsection under `## Running Tests` describing:
+
+```md
+### Validation Lanes
+
+- `contract`: host-side structural and cross-package validation
+- `bootstrap`: host-side admin/deployment validation with real `helm` and `kubectl`
+- `platform_blackbox`: standard in-cluster product validation under least-privilege RBAC
+- `developer_workflow`: host-side repo-aware checks (`.git`, `.gitignore`, `.vuln-ignore`)
+- `destructive`: gated in-cluster disruptive validation after standard product pass
+```
+
+Update the E2E section so it no longer claims every E2E-shaped test must execute only in-cluster.
+
+- [ ] **Step 4: Run the structural test suite**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/unit/test_validation_boundary_markers.py \
+  tests/unit/test_validation_runner_wiring.py \
+  tests/unit/test_dbt_namespace_reset.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full validation flow**
+
+Run:
+
+```bash
+./testing/ci/test-bootstrap-validation.sh
+./testing/ci/test-developer-workflow.sh
+./testing/ci/test-e2e-full.sh
+```
+
+Expected:
+
+- bootstrap/admin failures report separately
+- developer-workflow failures report separately
+- standard in-cluster lane contains only `platform_blackbox` product tests
+- destructive remains gated
+- any remaining red tests are much more likely to be real product defects, with OpenLineage `parentRun` still expected as a separate follow-up
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TESTING.md tests/unit/test_validation_runner_wiring.py
+git commit -m "docs: describe validation lanes"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - lane split: covered by Tasks 1-3
+  - current failing outliers: covered by Task 2
+  - reset/idempotency: covered by Task 4
+  - documentation and execution handoff: covered by Task 5
+- Placeholder scan:
+  - no `TBD`, `TODO`, or deferred-code placeholders remain inside task steps
+- Type consistency:
+  - marker names are consistently `bootstrap`, `platform_blackbox`, `developer_workflow`, `destructive`
+  - reset error is consistently `NamespaceResetError`
+  - standard in-cluster runner keeps `TEST_SUITE=e2e` externally but semantically means the `platform_blackbox` lane

--- a/docs/superpowers/specs/2026-04-23-contract-layer-hard-reset-design.md
+++ b/docs/superpowers/specs/2026-04-23-contract-layer-hard-reset-design.md
@@ -1,0 +1,389 @@
+# Contract Layer Hard Reset Design
+
+Status: Proposed and approved in brainstorming
+Date: 2026-04-23
+Author: Codex
+
+## Summary
+
+floe is accumulating debugging cost because cross-consumer operational facts are authored in multiple places at once. Service identity, ports, env bindings, runtime enums, CLI/result payloads, and execution assumptions are currently spread across Helm templates, Python fixtures, shell scripts, runtime code, and tests. The system therefore does not have one source of truth; it has several partially-overlapping truths that drift independently.
+
+This design introduces a generation-first contract layer inside `floe-core` and treats it as the only authoritative source for shared operational facts. Consumers such as charts, fixtures, scripts, runtime helpers, and tests become adapters over generated bindings rather than authors of their own facts.
+
+This is a hard reset. floe has not shipped a tagged release, so the design explicitly favors deletion of legacy compatibility paths over preservation.
+
+## Problem Statement
+
+Recent failures show the same structural issue repeating at different boundaries:
+
+- Runtime contract drift:
+  - `AuthType.NONE` is referenced in integration tests while the runtime schema defines `AuthType.ANONYMOUS`.
+- Behavioral schema drift:
+  - CLI/test expectations diverge on keys like `findings` and `diffs`.
+- Service identity drift:
+  - Service names and network assumptions differ across charts, fixtures, and tests.
+- Execution-context drift:
+  - Some in-cluster tests behave like black-box deployed checks, while others expect git metadata, local files, `localhost`, or privileged Helm/secret access.
+- Bootstrap coupling:
+  - DevPod, Flux, direct Helm, vendored chart dependencies, and local/runtime test assumptions are too entangled, so failures are difficult to classify correctly.
+
+The result is ambiguous red builds. A failing test may indicate:
+
+- a real product regression
+- contract drift between consumers
+- bootstrap/environment failure
+- execution-context mismatch
+- fixture or test harness drift
+
+This ambiguity is the core reason debugging is expensive.
+
+## Goals
+
+- Establish one authoritative contract system for cross-consumer operational facts.
+- Remove hand-authored duplication for service identity, env bindings, runtime enums, and behavioral/result schemas.
+- Make drift structurally hard by generating consumer bindings from canonical models.
+- Split validation into execution classes that answer one question each.
+- Favor deletion of obsolete authoring paths over compatibility shims.
+- Make a red test easier to classify as contract, bootstrap, platform-behavior, or developer-workflow failure.
+
+## Non-Goals
+
+- Preserve backward compatibility for pre-release interfaces.
+- Build a language-neutral platform for hypothetical future ecosystems.
+- Keep old fixtures, scripts, or aliases alive "just in case."
+- Solve every architecture concern in the repo unrelated to shared-contract drift.
+
+## Approaches Considered
+
+### 1. Monolithic canonical contract package
+
+Create a single package that owns topology, env injection, runtime enums, and behavioral/result schemas in one place.
+
+Pros:
+
+- Strong conceptual source of truth.
+- Fastest to explain.
+
+Cons:
+
+- High risk of becoming a god-model.
+- Unnecessary coupling between unrelated domains.
+- Harder to evolve safely.
+
+### 2. Domain-bounded contract layer with generation-first adapters
+
+Create one contract system with bounded domains, and generate consumer-specific bindings and adapters from those domains.
+
+Pros:
+
+- Removes duplicate authoring while keeping domains understandable.
+- Matches the actual drift patterns seen in floe.
+- Supports a hard reset without forcing a monolith.
+
+Cons:
+
+- Requires clearer boundary definition up front.
+- Slightly more architecture work before implementation.
+
+### 3. External declarative spec registry with multi-language generation
+
+Define shared contracts in a neutral registry format and generate Python, Helm, shell, and schema outputs from it.
+
+Pros:
+
+- Strong long-term extensibility.
+- Good fit for a future multi-language ecosystem.
+
+Cons:
+
+- Too much machinery for the current stage.
+- Slower path to reducing current debugging cost.
+
+## Decision
+
+Adopt approach 2.
+
+The target architecture is a domain-bounded, generation-first contract layer inside `floe-core`. This contract layer becomes the only permitted source for shared operational facts. Consumer code may transform or validate those facts, but it may not author competing versions.
+
+## Target Architecture
+
+Canonical models live under `floe_core.contracts` and are split into four domains.
+
+### 1. `topology`
+
+Owns shared service and deployment identity:
+
+- canonical component IDs
+- service names
+- namespaces and namespace rules
+- ports
+- readiness/health endpoints
+- connection descriptors
+
+### 2. `execution`
+
+Owns execution-context bindings:
+
+- in-cluster runtime bindings
+- host-based runtime bindings
+- DevPod bindings
+- demo runtime bindings
+- env var mappings and exposure rules
+- context-specific access rules
+
+### 3. `schemas`
+
+Owns machine-readable behavioral contracts:
+
+- CLI JSON payloads
+- status/result payloads
+- artifact/result schemas
+- adapter-visible machine outputs
+
+### 4. `runtime`
+
+Owns cross-package runtime constants and enums:
+
+- auth modes
+- shared runtime identifiers
+- shared plugin/runtime contract values
+
+## Generation Model
+
+The contract layer is generation-first.
+
+Canonical models produce consumer-facing artifacts such as:
+
+- Python bindings for fixtures, test helpers, and runtime adapters
+- Helm-facing values/helpers or generated binding fragments for charts
+- shell/env export artifacts for scripts that still require env injection
+- JSON schema artifacts or typed adapter surfaces for CLI/result contracts
+
+The direction of truth is one-way:
+
+1. canonical contract model
+2. generated consumer binding
+3. thin consumer adapter
+
+Consumers do not define new facts if those facts are shared across more than one boundary.
+
+## Architectural Rules
+
+These rules are mandatory.
+
+### Rule 1: No duplicated cross-consumer literals
+
+If a service name, port, auth mode, schema key, readiness path, or env binding matters across multiple consumers, it must exist in the contract layer and nowhere else as an authored literal.
+
+### Rule 2: Consumers are adapters, not authorities
+
+Charts, scripts, fixtures, and tests may consume generated bindings, but they may not independently define the same facts.
+
+### Rule 3: Wrong execution context must fail explicitly
+
+Helpers may not silently fall back from in-cluster to localhost, from black-box to git-local, or from runtime to developer context. Context mismatch must produce an explicit failure.
+
+### Rule 4: Bootstrap failures must fail before product validation
+
+Environment availability belongs to bootstrap validation, not to downstream product tests.
+
+## Data Flow
+
+Facts flow downward in a single direction:
+
+1. contract domain models are defined in `floe_core.contracts`
+2. generators emit bindings for consumers
+3. consumers adapt those bindings into their local runtime
+4. tests validate behavior against generated contracts
+
+This eliminates the current pattern where:
+
+- fixtures have their own service tables
+- chart templates define env binding semantics independently
+- scripts invent their own env conventions
+- tests encode alternate assumptions
+
+## Validation Boundary Split
+
+The test stack must be split into distinct execution classes.
+
+### `contract`
+
+Purpose:
+
+- validate canonical models
+- validate generated artifacts
+- validate adapter conformance
+
+Properties:
+
+- fast
+- deterministic
+- no unnecessary cluster dependency
+
+### `bootstrap`
+
+Purpose:
+
+- validate environment bring-up
+- validate DevPod/Hetzner, Helm, Flux, registry, chart dependency, and platform readiness prerequisites
+
+Properties:
+
+- answers "is the environment usable?"
+- should fail before product E2E begins
+
+### `platform-blackbox`
+
+Purpose:
+
+- validate deployed system behavior from an in-cluster consumer perspective
+
+Properties:
+
+- no git-local assumptions
+- no localhost fallback assumptions
+- no developer-checkout requirements unless explicitly modeled in the runtime contract
+
+### `developer-workflow`
+
+Purpose:
+
+- validate repo-aware local/developer behavior
+
+Properties:
+
+- may rely on git metadata
+- may rely on local files or developer tooling
+- should stop pretending to be runtime black-box validation
+
+## Error Handling And Failure Semantics
+
+The new structure must classify failures explicitly.
+
+### Generation-time failure
+
+If required topology, execution, runtime, or schema facts are contradictory or incomplete, generation fails immediately. Shared cross-consumer facts must not rely on silent defaults.
+
+### Adapter validation failure
+
+If a consumer misuses generated bindings, it should fail with a contract-specific error naming the violated contract object, not a generic runtime exception.
+
+### Execution-context mismatch failure
+
+If code intended for `platform-blackbox` attempts to rely on developer-only context, it should fail as an execution-context violation.
+
+### Bootstrap prerequisite failure
+
+If the environment is unavailable, that failure should appear in `bootstrap`, not cascade as dozens of downstream product failures.
+
+## Migration Strategy
+
+This is a hard-reset migration executed in strict phases.
+
+### Phase 1: Establish contract domains and generators
+
+- create `floe_core.contracts`
+- add `topology`, `execution`, `schemas`, and `runtime` domains
+- add generation targets for Python bindings, Helm-facing bindings, and shell/env outputs
+- add contract tests for internal consistency
+
+### Phase 2: Migrate highest-value runtime and schema contracts
+
+Start with the highest-pain drift areas:
+
+- runtime enums and shared constants such as OCI auth modes
+- behavioral/result schemas such as CLI JSON outputs and machine-readable payloads
+
+Rationale:
+
+- improves failure signal quickly
+- reduces ambiguity in integration failures
+
+### Phase 3: Migrate topology and execution consumers
+
+Move:
+
+- chart job/test bindings
+- test fixtures
+- bootstrap scripts
+- E2E runner env injection
+
+Each consumer becomes an adapter over generated bindings.
+
+### Phase 4: Delete legacy authoring paths and rebuild validation boundaries
+
+- remove duplicate service/port/env tables
+- remove stale aliases and compatibility paths
+- move tests into `contract`, `bootstrap`, `platform-blackbox`, and `developer-workflow`
+- remove tests whose assertions only exist to preserve duplicated literals
+
+## Deletion Policy
+
+The hard reset only works if legacy authoring paths are removed.
+
+Delete immediately after migration of the affected domain:
+
+- duplicate service maps in fixtures
+- alternate env-binding logic in scripts
+- stale enum names and compatibility aliases
+- tests that rely on duplicated facts instead of generated contracts
+
+Do not keep shadow compatibility layers unless required for the same branch migration.
+
+## Success Criteria
+
+The redesign is successful when all of the following are true:
+
+- A shared fact such as a service name, port, auth mode, or output key is authored once.
+- Charts, fixtures, scripts, and tests consume generated bindings or fail validation.
+- Contract failures are distinguishable from bootstrap failures.
+- Platform-blackbox failures reflect deployed behavior, not developer-local assumptions.
+- Developer-workflow tests are explicitly scoped and no longer contaminate runtime validation.
+- The number of hand-authored cross-consumer literals is materially reduced.
+
+## Risks And Mitigations
+
+### Risk: contract layer becomes a monolith
+
+Mitigation:
+
+- keep domains bounded
+- avoid mixing unrelated facts
+- enforce ownership by domain
+
+### Risk: generators create opaque complexity
+
+Mitigation:
+
+- keep generated artifacts reviewable
+- use thin adapters
+- test generation outputs directly
+
+### Risk: migration stalls halfway and leaves two systems alive
+
+Mitigation:
+
+- migrate one domain at a time
+- delete legacy authoring paths immediately after each migration
+- reject new duplicated facts during migration
+
+### Risk: test split becomes naming-only and not behavioral
+
+Mitigation:
+
+- define hard execution rules per suite
+- make context mismatch explicit failures
+- stop allowing silent fallback behavior
+
+## Acceptance Criteria
+
+- `floe_core.contracts` exists with the four bounded domains defined in this spec.
+- Shared runtime enums and machine-readable output schemas are sourced from that layer.
+- Test-runner and bootstrap bindings are generated from the same contract system used by fixtures.
+- The validation stack is split into contract, bootstrap, platform-blackbox, and developer-workflow categories.
+- Legacy duplicate authoring paths for migrated domains are removed.
+
+## Final Recommendation
+
+Build a broad, generation-first contract layer now, and use a hard reset to move all cross-consumer operational facts into it. Start implementation with runtime/result schemas, then topology and execution bindings, then finish by deleting legacy authoring paths and restructuring the validation stack around the new boundaries.

--- a/docs/superpowers/specs/2026-04-23-validation-architecture-reset-design.md
+++ b/docs/superpowers/specs/2026-04-23-validation-architecture-reset-design.md
@@ -1,0 +1,251 @@
+# Validation Architecture Reset Design
+
+Status: Proposed
+Date: 2026-04-23
+Author: Codex
+
+## Summary
+
+floe's current validation harness conflates distinct execution contexts into one "standard E2E" lane. The in-cluster least-privilege runner is currently expected to validate deployed product behavior, perform Helm-admin deployment workflows, inspect repo-local metadata such as `.gitignore` and `.vuln-ignore`, and tolerate localhost assumptions that only make sense on a developer machine.
+
+That is why the latest failures look unrelated while sharing one root cause. RBAC-denied Helm tests, missing `.git` metadata, `127.0.0.1` service assumptions, and stale Polaris/Iceberg state all appear as "standard E2E" failures even though they belong to different validation classes.
+
+This design resets validation architecture around explicit execution lanes. Each lane gets one purpose, one execution context, and one allowed assumption set.
+
+## Problem Statement
+
+The latest validated failures cluster into five categories:
+
+- Execution-context mismatch:
+  - `tests/e2e/test_runtime_loader_e2e.py` assumes `http://127.0.0.1:3000` from inside the cluster.
+- Repo-checkout assumptions inside the test-runner image:
+  - `tests/e2e/test_governance.py::test_pip_audit_clean` expects `.vuln-ignore`.
+  - `tests/e2e/test_profile_isolation.py` expects `.gitignore` and a real git checkout.
+- Admin/Helm workflow assumptions inside a least-privilege runner:
+  - `tests/e2e/test_helm_workflow.py` needs Helm release-secret access in its own namespace and currently fails under the standard in-cluster RBAC profile.
+- Product-state/idempotency weakness:
+  - `tests/e2e/test_dbt_lifecycle_e2e.py`
+  - `tests/e2e/test_data_pipeline.py`
+  - `tests/e2e/test_compile_deploy_materialize_e2e.py`
+  still fail on reruns because Polaris/Iceberg state is not reset deterministically enough.
+- Actual product gap:
+  - `tests/e2e/test_observability.py::TestObservability::test_openlineage_four_emission_points`
+    still indicates missing valid `parentRun` lineage semantics.
+
+The first four are validation-architecture failures. The last one is a real product defect and should remain visible after the harness is fixed.
+
+## Goals
+
+- Separate validation by execution context so failures classify cleanly.
+- Keep least-privilege in-cluster validation focused on deployed product behavior.
+- Move repo-aware and admin/deployment workflows out of the standard product lane.
+- Make Polaris/Iceberg reset behavior explicit and deterministic before dbt seed/run flows.
+- Preserve visibility for real product defects instead of burying them under harness noise.
+
+## Non-Goals
+
+- Rewrite every E2E file into a new directory structure in one pass.
+- Replace all existing shell orchestration at once.
+- Hide true product bugs behind retries or broad skips.
+- Revisit the broader contract-layer hard-reset design in this plan.
+
+## Decision
+
+Adopt four validation lanes:
+
+1. `contract`
+2. `bootstrap`
+3. `platform_blackbox`
+4. `developer_workflow`
+
+`destructive` remains a gated follow-on lane rather than part of the standard pass.
+
+The immediate implementation uses pytest markers plus runner split. It does not require a full filesystem re-home of all tests on day one.
+
+## Lane Definitions
+
+### 1. `contract`
+
+Purpose:
+
+- Validate schemas, wiring, marker discipline, chart/test-runner contracts, and structural invariants.
+
+Execution context:
+
+- Host pytest.
+
+Allowed assumptions:
+
+- Source checkout is present.
+- Files can be read directly.
+
+Disallowed assumptions:
+
+- Live cluster state.
+- Deployed services.
+
+### 2. `bootstrap`
+
+Purpose:
+
+- Validate admin/deployment workflows and environment readiness.
+- Answer "can an operator bring this platform up correctly?"
+
+Execution context:
+
+- Host-side pytest with real `kubectl` and `helm`.
+- Full kubeconfig available.
+
+Allowed assumptions:
+
+- Helm CLI access.
+- Namespace creation/deletion.
+- Helm release inspection.
+- Repo checkout is present.
+
+Disallowed assumptions:
+
+- Least-privilege in-cluster RBAC.
+- `localhost` inside a K8s pod.
+
+Representative tests:
+
+- `tests/e2e/test_helm_workflow.py`
+- `tests/e2e/test_platform_bootstrap.py`
+- `tests/e2e/test_platform_deployment_e2e.py`
+
+### 3. `platform_blackbox`
+
+Purpose:
+
+- Validate deployed platform behavior from an in-cluster consumer perspective.
+- This is the actual standard product lane.
+
+Execution context:
+
+- In-cluster pytest Job using the standard least-privilege ServiceAccount.
+
+Allowed assumptions:
+
+- K8s DNS and service environment variables.
+- Real platform services already deployed.
+- No direct repo metadata required.
+
+Disallowed assumptions:
+
+- `.git`, `.gitignore`, `.vuln-ignore`
+- Helm admin workflows
+- `127.0.0.1`/port-forward access patterns
+
+Representative tests:
+
+- `tests/e2e/test_compile_deploy_materialize_e2e.py`
+- `tests/e2e/test_data_pipeline.py`
+- `tests/e2e/test_dbt_lifecycle_e2e.py`
+- `tests/e2e/test_observability.py`
+- `tests/e2e/test_runtime_loader_e2e.py` after service-contract correction
+
+### 4. `developer_workflow`
+
+Purpose:
+
+- Validate repo-aware developer behavior.
+- Answer "does this checkout behave correctly for local tooling and source-controlled workflow contracts?"
+
+Execution context:
+
+- Host-side pytest on a normal checkout.
+
+Allowed assumptions:
+
+- `.git`
+- `.gitignore`
+- `.vuln-ignore`
+- local source tree inspection
+
+Disallowed assumptions:
+
+- In-cluster service DNS as the only execution mode.
+- Least-privilege runtime SA context.
+
+Representative tests:
+
+- `tests/e2e/test_profile_isolation.py`
+- `tests/e2e/test_governance.py::test_pip_audit_clean`
+- `tests/e2e/test_runtime_loader_e2e.py::test_thin_definitions_are_deployed`
+
+### 5. `destructive`
+
+Purpose:
+
+- Validate upgrades, pod kills, and other intentionally disruptive workflows.
+
+Execution context:
+
+- Separate in-cluster privileged Job after non-destructive product validation passes.
+
+Allowed assumptions:
+
+- Elevated RBAC compared with the standard runner.
+
+Disallowed assumptions:
+
+- Being mixed into the same status signal as the standard product lane.
+
+## Classification Rules
+
+The immediate classification strategy is marker-first:
+
+- Explicit markers for outlier files and functions.
+- Any `tests/e2e` item with no explicit lane marker defaults to `platform_blackbox`.
+- Existing `destructive` marker keeps precedence over all other lane defaults.
+
+This avoids a large file move while still making the execution boundary explicit.
+
+## Reset And Idempotency Contract
+
+The product failures around dbt seed/run are not solved by lane split alone. The platform lane also needs a stronger reset contract:
+
+- Before `dbt seed`:
+  - purge the raw namespace with a fresh Polaris catalog client
+  - verify the namespace is actually empty or absent before continuing
+- Before `dbt run`:
+  - purge the model namespace with the same verification
+- After shared module-scoped fixtures:
+  - purge both namespaces again
+- On reset failure:
+  - fail early with a reset-specific error instead of letting dbt fail with stale metadata symptoms
+
+Current silent best-effort cleanup is too weak. Reset must become an asserted precondition, not a courtesy.
+
+## Runner Architecture
+
+The full validation orchestration becomes:
+
+1. Host `bootstrap`
+2. In-cluster `platform_blackbox`
+3. Host `developer_workflow`
+4. In-cluster `destructive` only if `bootstrap` and `platform_blackbox` pass
+
+This preserves one decisive product signal while still surfacing repo/admin failures separately.
+
+## Why This Is Sufficient
+
+More brainstorming is not required before acting because the current failure set already maps cleanly onto these boundaries:
+
+- RBAC failures are from running admin workflows in a least-privilege product lane.
+- repo-metadata failures are from running checkout-aware tests inside an image that is not a checkout.
+- localhost failures are from mixed execution assumptions.
+- dbt/Polaris rerun failures are from weak reset semantics.
+
+Those are specific design faults, not canaries of an unknown larger collapse.
+
+## Deferred Work
+
+The following stays intentionally separate from the validation-architecture reset:
+
+- OpenLineage `parentRun`/`runId` correctness
+- broader contract-layer generation work
+- full filesystem re-home of all tests into new directories
+
+Those can follow once the validation lanes produce clean, trustworthy signals.

--- a/packages/floe-core/pyproject.toml
+++ b/packages/floe-core/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.23",  # Async test support for contract monitoring (3D-T002)
     "mypy>=1.8",
@@ -98,6 +98,13 @@ select = [
 [tool.uv]
 # sigstore requires betterproto which only has pre-release versions (8B-T001)
 prerelease = "allow"
+constraint-dependencies = [
+    "cryptography>=46.0.7",
+    "python-dotenv>=1.2.2",
+    "python-multipart>=0.0.26",
+    "pytest>=9.0.3",
+    "rfc3161-client>=1.0.6",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/packages/floe-core/uv.lock
+++ b/packages/floe-core/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 [options]
 prerelease-mode = "allow"
 
+[manifest]
+constraints = [
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "rfc3161-client", specifier = ">=1.0.6" },
+]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -452,62 +461,62 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064 }
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289 },
-    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637 },
-    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742 },
-    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528 },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993 },
-    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855 },
-    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635 },
-    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038 },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181 },
-    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482 },
-    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497 },
-    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819 },
-    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230 },
-    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909 },
-    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287 },
-    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728 },
-    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287 },
-    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291 },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539 },
-    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199 },
-    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131 },
-    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072 },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170 },
-    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741 },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728 },
-    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001 },
-    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637 },
-    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487 },
-    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514 },
-    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349 },
-    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667 },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980 },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143 },
-    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674 },
-    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801 },
-    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755 },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539 },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794 },
-    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160 },
-    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123 },
-    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220 },
-    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050 },
-    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964 },
-    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321 },
-    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786 },
-    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990 },
-    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252 },
-    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605 },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869 },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492 },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670 },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275 },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402 },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985 },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652 },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805 },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883 },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756 },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244 },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868 },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504 },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363 },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671 },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551 },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887 },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354 },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845 },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641 },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749 },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942 },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079 },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999 },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191 },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782 },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227 },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332 },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618 },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628 },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405 },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715 },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400 },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634 },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233 },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955 },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888 },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961 },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696 },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256 },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001 },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985 },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879 },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700 },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982 },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115 },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479 },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829 },
 ]
 
 [[package]]
@@ -654,7 +663,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0,<2.0" },
     { name = "oras", specifier = ">=0.2.38,<1.0" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
@@ -1570,7 +1579,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1581,9 +1590,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
 ]
 
 [[package]]
@@ -1628,20 +1637,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230 },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101 },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579 },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847 },
 ]
 
 [[package]]
@@ -1761,25 +1770,29 @@ wheels = [
 
 [[package]]
 name = "rfc3161-client"
-version = "1.0.5"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/19/c04a07f9926943b6a6945ae6972dc2c3c79b7f02e2be6346e3010a48d5f5/rfc3161_client-1.0.5.tar.gz", hash = "sha256:f1a2e32e2a053455cee1ff9b325b88dbc7c66c8882dde60962add92f572df5c5", size = 60966 }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a7/be3b086133a87d595e7b11564931d5e5283edeeabba05dfee636a34b4dab/rfc3161_client-1.0.6.tar.gz", hash = "sha256:9969262fe6c08ecce39f9fe3996cf412187793834a022a643803090db5aae6b4", size = 106710 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/11/96bc76086113b8d24291f7f72826739d4fc8d8e83683e27125b8966d0cea/rfc3161_client-1.0.5-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8a54fdb2f9e64481272b89137a7b71403cf1d30f5505c2e0c15a47a1cc100264", size = 473872 },
-    { url = "https://files.pythonhosted.org/packages/80/45/19224e046d76f214d056c40a2086d9147afb0bcadc0c823c2c8bd54d62aa/rfc3161_client-1.0.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9ed8e597d0ee7387da1945e1583c4516b26f133770b3956e079606e2d90b69c", size = 458218 },
-    { url = "https://files.pythonhosted.org/packages/27/d7/0511f1423f1658b708cfa27043a21b06699ba7c2aef37ba465379b81c24d/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61c04b4953453e5c26a1949c20adac415b65cd062dab0960574d6c36240222d2", size = 2396335 },
-    { url = "https://files.pythonhosted.org/packages/bc/d3/f93d1af5d9a1fed348ef543d39418aff02b0badf019b772f128c3483321c/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31b6ee79f15b93d90952efd0395bb3f5ebf07941469c5c6eb32f9b64312cda6e", size = 1805162 },
-    { url = "https://files.pythonhosted.org/packages/69/51/0b30e3542fdf7adeb9f6afac1f095c543328a1a28c9d220f4e2207c6b845/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c53a6711bab0c3f77dc9cf1e2fd750da475ff7abbc40ffe0333d8c518a8a9c8", size = 2115530 },
-    { url = "https://files.pythonhosted.org/packages/2e/b9/4da9f80da4ac30b9645c9a3455e71c4f6652ed886f20e11bfb9a01bcacd0/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09c47582ecea2ca4a3debf8a1eda775cc3d5ae1379da40272cc065d32e639a7a", size = 2124925 },
-    { url = "https://files.pythonhosted.org/packages/46/ed/f173556ddbd667e9f4642f8f7eb0f920e3e3be4b7459ec98c73a5029200d/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d31d30e354d2349ae8483ce811ef61498a3780daf8622c0b79d8cd44d271b46b", size = 2695972 },
-    { url = "https://files.pythonhosted.org/packages/84/97/2ca7bdbb2d84b75fad7f572264a45c0b54446a7a65735172275c09293bd6/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:ae440461a310ae097417afe536d9d22fd71c95fbc9d21db3561b2707bed0aff0", size = 2096478 },
-    { url = "https://files.pythonhosted.org/packages/da/94/9e16134e04a45347eaad5680f8f52b0388664b45be09a0877daa196e1157/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:8fb34470e867a29cc15dc4987ea14f19d3bd25c863e132b6f75dca583e2cc67e", size = 2243602 },
-    { url = "https://files.pythonhosted.org/packages/c2/13/85b6a5b5247f79dfa75d80a2e8f8d415472ff7fd72b31d152e00f71198b9/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3106f3361a5a36789f43d2700e5678c847a9d3460a23f455f4c20cd39314c557", size = 2296304 },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/f7991ff6158a00ed79d6e151ede63ae50bef650cf49436cea7226a0457dc/rfc3161_client-1.0.5-cp39-abi3-win32.whl", hash = "sha256:078e4bbf0770ddc472e2ca96cf1e23efd0c313e6682b4c2c9765e1fdf09f55a3", size = 1917793 },
-    { url = "https://files.pythonhosted.org/packages/47/28/140516906a2117e15c37505d54968e9cc9a8275d042b195728f5ffc2ad02/rfc3161_client-1.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:e904430e27e75a5a379fc4aac09bd60ba5f4b48054f0481b2fb417297e404047", size = 2313057 },
+    { url = "https://files.pythonhosted.org/packages/57/b1/262af0901e1507a4e21d268091f1f7b738b44bca424b9bd481981828a7e8/rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a98e9c7ff632d9571fcea25fb70bde0e8339b86368aef67a65f6a301f125733", size = 474975 },
+    { url = "https://files.pythonhosted.org/packages/8a/b6/da7caa10c2a3e01f244ad116ffe2cc87056fa71a7dd76453faab2fc2c6ad/rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0b3920334f7334ec3bb9c319d53a5d08cd43b6883f75e2669cfd869cd264d53a", size = 467442 },
+    { url = "https://files.pythonhosted.org/packages/64/dd/5c92004ca167ae182f543aedc7a7a8bebeb0668ade7263b82212e4b4c59d/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1671b1be16480ea54c0d36239efd0fb62c13dd572a9865a5e91fea39f1b95303", size = 2435049 },
+    { url = "https://files.pythonhosted.org/packages/c4/19/c44702336aed367c6513493c4df9e880db8c4df37d5cd8d525aac9aad827/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63355099d932851eac507806bb9d0937dab546a66d5857d888168799ec635f6d", size = 1850399 },
+    { url = "https://files.pythonhosted.org/packages/64/fa/5af9bbfd4dcd9926463a95c4de6ea137176252d7a1d0b96533f6c85f2742/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bc9835467f6166edd6f876470484e5b294ee141add6eff6a59f5047937aaa75", size = 2174593 },
+    { url = "https://files.pythonhosted.org/packages/53/3c/32a0c7de4d63a69eb97e2564e5f1d51879ec93232b0c5ac1ec444843acba/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3caffaebf43242b000c4a6659d60eaf19c3b161ccbe05b15634a856c9ea7e61", size = 2177997 },
+    { url = "https://files.pythonhosted.org/packages/e5/8d/4253affe1d1e221369ad3043f5d697fc3f5d7fcb439d21add84c65cafc53/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b7ad54288a49379b01b1d0d9d15167d2b7c6c7f940332ab85eeb4a6e844da8c7", size = 2745033 },
+    { url = "https://files.pythonhosted.org/packages/1c/f0/eed22d6ed52d36b1eab3dfe56b9f507e22a328e3d018b84d48877ad7abe7/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:85a1d71d1eb2c9bced2b3eb75e96f9fe49732ec2567b5dafa1dd889fff42b7fe", size = 2145631 },
+    { url = "https://files.pythonhosted.org/packages/a2/bb/feeacd1859e364080729b9cded1129b740eeea54c6d61ff12daceed4b7dd/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1be4e1133f0f7fe875629f2c358285503c1cfc79cebfbc3fb4e28b8a57d6f1a4", size = 2328742 },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/2df8e402f069a6af2db1f21d1c88d5a929398923265189a0141709a6f25c/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bc379167238df32cbcc1dc9c324088559c1734331030f5293d75f4fd37b5f4f6", size = 2386899 },
+    { url = "https://files.pythonhosted.org/packages/a5/1b/f78c75c6c92a0f5de46a86b7f39cf9bb8fb5980fbd684a56f46f031dbce6/rfc3161_client-1.0.6-cp39-abi3-win32.whl", hash = "sha256:8631f7db7c1327bf87ee6a9a8681b4cd6bc2a90aae651388f29d045cd9ff1ac9", size = 1966796 },
+    { url = "https://files.pythonhosted.org/packages/26/10/6e54860ae82e4ed5665fd3f1d798a8f68f7bac321431f444640da6f93600/rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl", hash = "sha256:4ef4b096abe7d55b020526e39932c2721939a6c55e9a5cd3b3e77897a0942937", size = 2386738 },
+    { url = "https://files.pythonhosted.org/packages/f1/59/34be30cd647de25af4ef7ca5980c124205893248db40d93831afad53dbcf/rfc3161_client-1.0.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102165201c5224cf6e6634bfd68c6a39e8f800601188216f8210face4861215", size = 2432818 },
+    { url = "https://files.pythonhosted.org/packages/44/f6/99d15883d564235b14c8d429fda4c8a9145af2bd5157cce506d2dcb30cc0/rfc3161_client-1.0.6-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e16ed34f6f33fd62aa3b1f83615ecf2f96e1b1f57df4e1a36570b3f895333972", size = 1848117 },
+    { url = "https://files.pythonhosted.org/packages/06/c8/b486981966e9d4e754c6720bdaeeef2b59bc176cbeef5f3b30aa718c89a0/rfc3161_client-1.0.6-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78cdc6bde331492cb94f69328831d5c56b271012b00c6f1784c2e4b33837d585", size = 2168684 },
+    { url = "https://files.pythonhosted.org/packages/e1/c2/08be1373dd4ca4382472a4e97be300a9db3f974f35093b33e54abbced4e1/rfc3161_client-1.0.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940e1fc95ec0ca734927a82bcb5363fa988ef1a085d238ff0c861f29c0cfb746", size = 2174296 },
 ]
 
 [[package]]

--- a/plugins/floe-orchestrator-dagster/pyproject.toml
+++ b/plugins/floe-orchestrator-dagster/pyproject.toml
@@ -58,6 +58,15 @@ Repository = "https://github.com/Obsidian-Owl/floe"
 [tool.hatch.build.targets.wheel]
 packages = ["src/floe_orchestrator_dagster"]
 
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
+
+[tool.hatch.build]
+include = [
+    "src/floe_orchestrator_dagster/**/*.py",
+    "src/floe_orchestrator_dagster/py.typed",
+]
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/export/iceberg.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/export/iceberg.py
@@ -61,6 +61,8 @@ def export_dbt_to_iceberg(
 
     registry = _plugin_registry_module.get_registry()
     catalog_type = artifacts.plugins.catalog.type
+    # configure() validates config and applies it to the cached plugin instance.
+    # get() then returns that configured instance for the runtime connection.
     validated_config = registry.configure(PluginType.CATALOG, catalog_type, catalog_config)
     if validated_config is None:
         context.log.warning(

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/export/iceberg.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/export/iceberg.py
@@ -61,7 +61,6 @@ def export_dbt_to_iceberg(
 
     registry = _plugin_registry_module.get_registry()
     catalog_type = artifacts.plugins.catalog.type
-    catalog_plugin = registry.get(PluginType.CATALOG, catalog_type)
     validated_config = registry.configure(PluginType.CATALOG, catalog_type, catalog_config)
     if validated_config is None:
         context.log.warning(
@@ -69,7 +68,7 @@ def export_dbt_to_iceberg(
             catalog_type,
         )
         return
-    catalog_plugin = catalog_plugin(config=validated_config)
+    catalog_plugin = registry.get(PluginType.CATALOG, catalog_type)
     s3_config = {f"s3.{k}": v for k, v in storage_config.items()}
     catalog = catalog_plugin.connect(config=s3_config)
 

--- a/plugins/floe-orchestrator-dagster/tests/unit/test_export_iceberg.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/test_export_iceberg.py
@@ -251,12 +251,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        # Make type(mock_plugin)(...) return the configured instance
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -300,11 +297,9 @@ class TestExportDbtToIceberg:
         registry = MagicMock()
         mock_plugin = MagicMock()
         mock_catalog = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -404,11 +399,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -425,6 +418,7 @@ class TestExportDbtToIceberg:
                 artifacts=artifacts_with_catalog,
             )
 
+        mock_plugin.assert_not_called()
         mock_catalog.create_namespace.assert_called_once_with(SAFE_NAME)
 
     @pytest.mark.requirement("AC-4")
@@ -459,11 +453,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -516,11 +508,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -572,11 +562,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -626,11 +614,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = mock_catalog
+        mock_plugin.connect.return_value = mock_catalog
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -677,11 +663,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = MagicMock()
+        mock_plugin.connect.return_value = MagicMock()
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -723,11 +707,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = MagicMock()
+        mock_plugin.connect.return_value = MagicMock()
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -759,11 +741,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = MagicMock()
+        mock_plugin.connect.return_value = MagicMock()
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn),
@@ -796,11 +776,9 @@ class TestExportDbtToIceberg:
 
         registry = MagicMock()
         mock_plugin = MagicMock()
-        mock_plugin_instance = MagicMock()
-        mock_plugin_instance.connect.return_value = MagicMock()
+        mock_plugin.connect.return_value = MagicMock()
         registry.get.return_value = mock_plugin
         registry.configure.return_value = {}
-        type(mock_plugin).__call__ = MagicMock(return_value=mock_plugin_instance)
 
         with (
             patch("duckdb.connect", return_value=mock_conn) as mock_duckdb_connect,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10"
 
 # Development dependencies for the entire workspace
 dependencies = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-cov>=4.0",
     "pytest-timeout>=2.0",  # Test timeout enforcement for E2E tests
     "pytest-asyncio>=0.23",  # Async test support for alert channel plugins
@@ -94,9 +94,13 @@ prerelease = "allow"
 # constraint-dependencies sets floors without forcing resolution — if a package
 # appears in the tree, it must be at least this version.
 constraint-dependencies = [
+    "cryptography>=46.0.7",
     "diskcache>=5.6.4",
     "pillow>=12.1.1",
     "protobuf>=6.33.5",
+    "python-dotenv>=1.2.2",
+    "python-multipart>=0.0.26",
+    "rfc3161-client>=1.0.6",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,9 @@ markers = [
     "integration: Marks tests requiring K8s services",
     "contract: Marks cross-package contract tests",
     "e2e: Marks end-to-end pipeline tests",
+    "bootstrap: Marks admin/bootstrap validation",
+    "platform_blackbox: Marks in-cluster product validation",
+    "developer_workflow: Marks repo-aware host validation",
     "requires_sts: Marks tests requiring STS-enabled storage backend (MinIO with STS)",
     "benchmark: Marks performance benchmark tests (CodSpeed)",
 ]

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -24,13 +24,13 @@ LOCAL_HOOKS_PATH="$(git config --local --get core.hooksPath || true)"
 # Create hooks directory if it doesn't exist
 mkdir -p "$HOOKS_DIR"
 
-if [ -n "$GLOBAL_HOOKS_PATH" ] && [ "$GLOBAL_HOOKS_PATH" != "$HOOKS_DIR" ]; then
+if [[ -n "$GLOBAL_HOOKS_PATH" && "$GLOBAL_HOOKS_PATH" != "$HOOKS_DIR" ]]; then
     echo "Overriding global core.hooksPath for this repository:"
     echo "  global: $GLOBAL_HOOKS_PATH"
     echo "  local:  $HOOKS_DIR"
 fi
 
-if [ "$LOCAL_HOOKS_PATH" != "$HOOKS_DIR" ]; then
+if [[ "$LOCAL_HOOKS_PATH" != "$HOOKS_DIR" ]]; then
     git config --local core.hooksPath "$HOOKS_DIR"
 fi
 
@@ -40,7 +40,7 @@ HOOKS_TO_INSTALL="pre-commit post-commit pre-push post-merge"
 NEEDS_BACKUP=false
 
 for hook in $HOOKS_TO_INSTALL; do
-    if [ -f "$HOOKS_DIR/$hook" ]; then
+    if [[ -f "$HOOKS_DIR/$hook" ]]; then
         # Check if it's our hook (contains our marker)
         if ! grep -q "Installed by: scripts/setup-hooks.sh" "$HOOKS_DIR/$hook" 2>/dev/null; then
             NEEDS_BACKUP=true
@@ -49,10 +49,10 @@ for hook in $HOOKS_TO_INSTALL; do
     fi
 done
 
-if [ "$NEEDS_BACKUP" = true ]; then
+if [[ "$NEEDS_BACKUP" = true ]]; then
     mkdir -p "$BACKUP_DIR"
     for hook in $HOOKS_TO_INSTALL; do
-        if [ -f "$HOOKS_DIR/$hook" ]; then
+        if [[ -f "$HOOKS_DIR/$hook" ]]; then
             if ! grep -q "Installed by: scripts/setup-hooks.sh" "$HOOKS_DIR/$hook" 2>/dev/null; then
                 cp "$HOOKS_DIR/$hook" "$BACKUP_DIR/$hook"
                 echo "Backed up existing $hook to $BACKUP_DIR/"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -13,12 +13,26 @@
 
 set -euo pipefail
 
-# Get the git hooks directory (works with worktrees)
+# Get the git hooks directory (works with worktrees) and force Git to use it
+# for this repository, even when the developer has a global core.hooksPath.
 GIT_DIR="$(git rev-parse --git-common-dir 2>/dev/null || git rev-parse --git-dir)"
+GIT_DIR="$(cd "$GIT_DIR" && pwd)"
 HOOKS_DIR="$GIT_DIR/hooks"
+GLOBAL_HOOKS_PATH="$(git config --global --get core.hooksPath || true)"
+LOCAL_HOOKS_PATH="$(git config --local --get core.hooksPath || true)"
 
 # Create hooks directory if it doesn't exist
 mkdir -p "$HOOKS_DIR"
+
+if [ -n "$GLOBAL_HOOKS_PATH" ] && [ "$GLOBAL_HOOKS_PATH" != "$HOOKS_DIR" ]; then
+    echo "Overriding global core.hooksPath for this repository:"
+    echo "  global: $GLOBAL_HOOKS_PATH"
+    echo "  local:  $HOOKS_DIR"
+fi
+
+if [ "$LOCAL_HOOKS_PATH" != "$HOOKS_DIR" ]; then
+    git config --local core.hooksPath "$HOOKS_DIR"
+fi
 
 # Backup existing hooks if they exist and weren't created by this script
 BACKUP_DIR="$HOOKS_DIR/backup.$(date +%Y%m%d-%H%M%S)"
@@ -134,12 +148,13 @@ echo ""
 echo "Hooks installed successfully:"
 echo "  - pre-commit:   ruff, bandit, secrets, sleep-detection, etc."
 echo "  - post-commit:  Cognee async sync (non-blocking)"
-echo "  - pre-push:     mypy, import-linter, unit tests, contract tests, traceability"
+echo "  - pre-push:     CI-aligned lint, type, security, test, and traceability checks"
 echo "  - post-merge:   Cognee full rebuild (non-blocking)"
 echo ""
 echo "Quality bar alignment:"
 echo "  - Pre-commit: Fast checks (<5s) matching CI lint stage"
 echo "  - Pre-push:   Thorough checks matching CI test stages"
+echo "  - hooksPath:  repo-local core.hooksPath -> $HOOKS_DIR"
 echo ""
 echo "Note: Run 'make setup-hooks' again after 'pre-commit install'"
 echo "      to restore hooks."

--- a/testing/ci/common.sh
+++ b/testing/ci/common.sh
@@ -32,13 +32,75 @@
 # Remote repo root inside the DevPod workspace. Defaults to the devcontainer
 # workspaceFolder, but stays overrideable for non-standard layouts.
 : "${DEVPOD_REMOTE_WORKDIR:=/workspace}"
+_FLOE_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_FLOE_REPO_ROOT="$(cd "${_FLOE_COMMON_DIR}/../.." && pwd)"
+: "${FLOE_MANIFEST_PATH:=${_FLOE_REPO_ROOT}/demo/manifest.yaml}"
 
 # Flux CD version — pinned for reproducible CI installs.
 : "${FLUX_VERSION:=2.5.1}"
 
+if [[ -z "${FLOE_DEMO_IMAGE_REPOSITORY:-}" || -z "${FLOE_DEMO_IMAGE_TAG:-}" || -z "${FLOE_DEMO_IMAGE:-}" ]]; then
+    if command -v python3 >/dev/null 2>&1; then
+        # shellcheck disable=SC1091
+        eval "$(python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py")"
+    fi
+fi
+: "${FLOE_DEMO_IMAGE_REPOSITORY:=floe-dagster-demo}"
+: "${FLOE_DEMO_IMAGE_TAG:=local}"
+: "${FLOE_DEMO_IMAGE:=${FLOE_DEMO_IMAGE_REPOSITORY}:${FLOE_DEMO_IMAGE_TAG}}"
+
 export FLOE_RELEASE_NAME FLOE_NAMESPACE FLOE_KIND_CLUSTER FLOE_CHART_DIR FLOE_VALUES_FILE
 export FLOE_FLUX_FIXTURE_DIR FLOE_FLUX_GIT_URL FLOE_FLUX_GIT_BRANCH DEVPOD_REMOTE_WORKDIR
+export FLOE_MANIFEST_PATH FLOE_DEMO_IMAGE_REPOSITORY FLOE_DEMO_IMAGE_TAG FLOE_DEMO_IMAGE
 export FLUX_VERSION
+
+# floe_normalize_image_ref <image>
+# Normalizes a Docker image reference to the form containerd stores in Kind.
+floe_normalize_image_ref() {
+    local image="$1"
+    if [[ -z "${image}" ]]; then
+        echo "floe_normalize_image_ref: image argument required" >&2
+        return 2
+    fi
+    if [[ "${image}" == */* ]]; then
+        printf '%s\n' "${image}"
+        return 0
+    fi
+    printf 'docker.io/library/%s\n' "${image}"
+}
+
+# floe_kind_control_plane_name [cluster]
+# Returns the Docker container name for a Kind control-plane node.
+floe_kind_control_plane_name() {
+    local cluster="${1:-${FLOE_KIND_CLUSTER}}"
+    printf '%s-control-plane\n' "${cluster}"
+}
+
+# floe_kind_evict_image <image> [cluster]
+# Removes an image ref from the Kind node's containerd store so a subsequent
+# `kind load docker-image` cannot silently reuse a stale mutable tag.
+floe_kind_evict_image() {
+    local image="$1"
+    local cluster="${2:-${FLOE_KIND_CLUSTER}}"
+    local control_plane=""
+    local image_ref=""
+
+    if [[ -z "${image}" ]]; then
+        echo "floe_kind_evict_image: image argument required" >&2
+        return 2
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        return 0
+    fi
+
+    control_plane="$(floe_kind_control_plane_name "${cluster}")"
+    if ! docker inspect "${control_plane}" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    image_ref="$(floe_normalize_image_ref "${image}")"
+    docker exec "${control_plane}" ctr -n k8s.io images rm "${image_ref}" >/dev/null 2>&1 || true
+}
 
 # floe_service_name <component>
 # Returns the K8s service/resource name for a platform component, derived
@@ -147,6 +209,38 @@ floe_ensure_test_artifacts_pvc() {
         || { rm -f "${rendered_pvc}"; return 1; }
 
     rm -f "${rendered_pvc}"
+}
+
+# floe_export_minio_credentials_from_cluster [namespace] [secret-name]
+# Exports MINIO_USER and MINIO_PASS from the live cluster secret when the
+# caller already knows how to reach the cluster but has not pre-exported the
+# credentials.
+floe_export_minio_credentials_from_cluster() {
+    local namespace="${1:-${FLOE_NAMESPACE}}"
+    local secret_name="${2:-$(floe_service_name minio)}"
+    local user=""
+    local password=""
+
+    if [[ -n "${MINIO_USER:-}" && -n "${MINIO_PASS:-}" ]]; then
+        return 0
+    fi
+    if ! command -v kubectl >/dev/null 2>&1; then
+        return 1
+    fi
+
+    user=$(kubectl get secret -n "${namespace}" "${secret_name}" \
+        -o go-template='{{index .data "root-user" | base64decode}}' 2>/dev/null || true)
+    password=$(kubectl get secret -n "${namespace}" "${secret_name}" \
+        -o go-template='{{index .data "root-password" | base64decode}}' 2>/dev/null || true)
+
+    if [[ -n "${user}" && -z "${MINIO_USER:-}" ]]; then
+        export MINIO_USER="${user}"
+    fi
+    if [[ -n "${password}" && -z "${MINIO_PASS:-}" ]]; then
+        export MINIO_PASS="${password}"
+    fi
+
+    [[ -n "${MINIO_USER:-}" && -n "${MINIO_PASS:-}" ]]
 }
 
 # floe_require_cluster

--- a/testing/ci/common.sh
+++ b/testing/ci/common.sh
@@ -41,8 +41,21 @@ _FLOE_REPO_ROOT="$(cd "${_FLOE_COMMON_DIR}/../.." && pwd)"
 
 if [[ -z "${FLOE_DEMO_IMAGE_REPOSITORY:-}" || -z "${FLOE_DEMO_IMAGE_TAG:-}" || -z "${FLOE_DEMO_IMAGE:-}" ]]; then
     if command -v python3 >/dev/null 2>&1; then
-        # shellcheck disable=SC1091
-        eval "$(python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py")"
+        if [[ -z "${FLOE_DEMO_IMAGE_REPOSITORY:-}" ]]; then
+            FLOE_DEMO_IMAGE_REPOSITORY="$(
+                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field repository
+            )"
+        fi
+        if [[ -z "${FLOE_DEMO_IMAGE_TAG:-}" ]]; then
+            FLOE_DEMO_IMAGE_TAG="$(
+                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field tag
+            )"
+        fi
+        if [[ -z "${FLOE_DEMO_IMAGE:-}" ]]; then
+            FLOE_DEMO_IMAGE="$(
+                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field ref
+            )"
+        fi
     fi
 fi
 : "${FLOE_DEMO_IMAGE_REPOSITORY:=floe-dagster-demo}"

--- a/testing/ci/common.sh
+++ b/testing/ci/common.sh
@@ -41,21 +41,7 @@ _FLOE_REPO_ROOT="$(cd "${_FLOE_COMMON_DIR}/../.." && pwd)"
 
 if [[ -z "${FLOE_DEMO_IMAGE_REPOSITORY:-}" || -z "${FLOE_DEMO_IMAGE_TAG:-}" || -z "${FLOE_DEMO_IMAGE:-}" ]]; then
     if command -v python3 >/dev/null 2>&1; then
-        if [[ -z "${FLOE_DEMO_IMAGE_REPOSITORY:-}" ]]; then
-            FLOE_DEMO_IMAGE_REPOSITORY="$(
-                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field repository
-            )"
-        fi
-        if [[ -z "${FLOE_DEMO_IMAGE_TAG:-}" ]]; then
-            FLOE_DEMO_IMAGE_TAG="$(
-                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field tag
-            )"
-        fi
-        if [[ -z "${FLOE_DEMO_IMAGE:-}" ]]; then
-            FLOE_DEMO_IMAGE="$(
-                python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field ref
-            )"
-        fi
+        eval "$(python3 "${_FLOE_COMMON_DIR}/resolve-demo-image-ref.py" --field exports)"
     fi
 fi
 : "${FLOE_DEMO_IMAGE_REPOSITORY:=floe-dagster-demo}"

--- a/testing/ci/polaris-auth.sh
+++ b/testing/ci/polaris-auth.sh
@@ -10,7 +10,84 @@
 #
 # Environment:
 #   POLARIS_CLIENT_ID     Client ID (default: from MANIFEST_OAUTH_CLIENT_ID)
-#   POLARIS_CLIENT_SECRET Client secret (required — no hardcoded default)
+#   POLARIS_CLIENT_SECRET Client secret (default: from FLOE_MANIFEST_PATH)
+#   POLARIS_SCOPE         OAuth scope (default: from MANIFEST_OAUTH_SCOPE or manifest)
+#   FLOE_MANIFEST_PATH    Canonical manifest path override
+#   POLARIS_MANIFEST_PATH Back-compat manifest path override
+
+_polaris_manifest_path() {
+    if [[ -n "${FLOE_MANIFEST_PATH:-}" ]]; then
+        printf '%s\n' "${FLOE_MANIFEST_PATH}"
+        return 0
+    fi
+
+    if [[ -n "${POLARIS_MANIFEST_PATH:-}" ]]; then
+        printf '%s\n' "${POLARIS_MANIFEST_PATH}"
+        return 0
+    fi
+
+    local script_dir repo_root
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    repo_root="$(cd "${script_dir}/../.." && pwd)"
+    printf '%s\n' "${repo_root}/demo/manifest.yaml"
+}
+
+_manifest_polaris_field() {
+    local field="${1:?Usage: _manifest_polaris_field <field>}"
+    local manifest_path
+    manifest_path="$(_polaris_manifest_path)"
+
+    if [[ ! -f "${manifest_path}" ]]; then
+        return 0
+    fi
+
+    python3 - "${manifest_path}" "${field}" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+manifest_path = Path(sys.argv[1])
+field = sys.argv[2]
+
+try:
+    raw = yaml.safe_load(manifest_path.read_text()) or {}
+except Exception:
+    print("", end="")
+    raise SystemExit(0)
+
+catalog = raw.get("plugins", {}).get("catalog", {}).get("config", {})
+oauth2 = catalog.get("oauth2", {})
+
+value = ""
+if field == "client_secret":
+    value = oauth2.get("client_secret", "")
+elif field == "scope":
+    value = catalog.get("scope", oauth2.get("scope", ""))
+elif field == "warehouse":
+    value = catalog.get("warehouse", "")
+
+print("" if value is None else str(value), end="")
+PY
+}
+
+get_polaris_scope() {
+    local scope="${POLARIS_SCOPE:-${MANIFEST_OAUTH_SCOPE:-$(_manifest_polaris_field scope)}}"
+    if [[ -z "${scope}" ]]; then
+        echo "ERROR: POLARIS_SCOPE not set and manifest does not provide oauth2.scope" >&2
+        return 1
+    fi
+    echo "${scope}"
+}
+
+get_polaris_catalog_name() {
+    local catalog_name="${POLARIS_CATALOG_NAME:-${POLARIS_CATALOG:-${MANIFEST_WAREHOUSE:-$(_manifest_polaris_field warehouse)}}}"
+    if [[ -z "${catalog_name}" ]]; then
+        echo "ERROR: Polaris catalog name not set and manifest does not provide catalog.config.warehouse" >&2
+        return 1
+    fi
+    echo "${catalog_name}"
+}
 
 # Acquire an OAuth2 bearer token from the Polaris catalog API.
 #
@@ -26,7 +103,9 @@
 get_polaris_token() {
     local polaris_url="${1:?Usage: get_polaris_token <polaris_url>}"
     local client_id="${POLARIS_CLIENT_ID:-${MANIFEST_OAUTH_CLIENT_ID:-}}"
-    local client_secret="${POLARIS_CLIENT_SECRET:-}"
+    local client_secret="${POLARIS_CLIENT_SECRET:-$(_manifest_polaris_field client_secret)}"
+    local scope
+    scope="$(get_polaris_scope)" || return 1
 
     if [[ -z "$client_id" ]]; then
         echo "ERROR: POLARIS_CLIENT_ID not set (source extract-manifest-config.py first)" >&2
@@ -40,8 +119,8 @@ get_polaris_token() {
     local token
     # Pipe credentials via stdin (-d @-) to avoid exposing them in
     # process arguments (visible in ps aux / /proc/*/cmdline).
-    token=$(printf 'grant_type=client_credentials&client_id=%s&client_secret=%s&scope=PRINCIPAL_ROLE:ALL' \
-        "$client_id" "$client_secret" | \
+    token=$(printf 'grant_type=client_credentials&client_id=%s&client_secret=%s&scope=%s' \
+        "$client_id" "$client_secret" "$scope" | \
         curl -sf -X POST \
         "$polaris_url/api/catalog/v1/oauth/tokens" \
         -d @- \
@@ -59,7 +138,7 @@ get_polaris_token() {
 #
 # Args:
 #   $1 - Polaris base URL (e.g., http://localhost:8181)
-#   $2 - Catalog name (e.g., floe-e2e)
+#   $2 - Catalog name (e.g., floe-demo)
 #   $3 - Bearer token
 #
 # Returns:

--- a/testing/ci/resolve-demo-image-ref.py
+++ b/testing/ci/resolve-demo-image-ref.py
@@ -29,25 +29,35 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _git_output(repo_root: Path, *args: str, text: bool = True) -> str | bytes:
+def _git_text_output(repo_root: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],
         cwd=repo_root,
         check=True,
         capture_output=True,
-        text=text,
+        text=True,
+    )
+    return result.stdout
+
+
+def _git_binary_output(repo_root: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=False,
     )
     return result.stdout
 
 
 def _iter_untracked_files(repo_root: Path) -> list[Path]:
-    output = _git_output(
+    output = _git_binary_output(
         repo_root,
         "ls-files",
         "--others",
         "--exclude-standard",
         "-z",
-        text=False,
     )
     files: list[Path] = []
     for raw_path in output.split(b"\0"):
@@ -63,13 +73,13 @@ def _iter_untracked_files(repo_root: Path) -> list[Path]:
 
 
 def _compute_default_tag(repo_root: Path) -> str:
-    head = str(_git_output(repo_root, "rev-parse", "--short=12", "HEAD")).strip()
-    status = str(_git_output(repo_root, "status", "--porcelain=v1", "--untracked-files=all"))
+    head = _git_text_output(repo_root, "rev-parse", "--short=12", "HEAD").strip()
+    status = _git_text_output(repo_root, "status", "--porcelain=v1", "--untracked-files=all")
     if not status.strip():
         return head
 
     hasher = hashlib.sha256()
-    tracked_diff = _git_output(repo_root, "diff", "--no-ext-diff", "--binary", "HEAD", text=False)
+    tracked_diff = _git_binary_output(repo_root, "diff", "--no-ext-diff", "--binary", "HEAD")
     hasher.update(tracked_diff)
 
     for path in _iter_untracked_files(repo_root):

--- a/testing/ci/resolve-demo-image-ref.py
+++ b/testing/ci/resolve-demo-image-ref.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -104,10 +105,7 @@ def resolve_demo_image_ref(repo_root: Path | None = None) -> dict[str, str]:
 
 
 def _shell_quote(value: str) -> str:
-    if "'" not in value:
-        return f"'{value}'"
-    escaped = value.replace("\\", "\\\\").replace("'", "\\x27")
-    return f"$'{escaped}'"
+    return shlex.quote(value)
 
 
 def _parse_args() -> argparse.Namespace:

--- a/testing/ci/resolve-demo-image-ref.py
+++ b/testing/ci/resolve-demo-image-ref.py
@@ -1,0 +1,140 @@
+"""Resolve the demo Dagster image reference for local validation flows.
+
+This helper centralizes image-ref selection so Make, shell runners, and tests
+do not each invent their own mutable-tag behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_REPOSITORY = "floe-dagster-demo"
+IGNORED_UNTRACKED_PREFIXES = (
+    ".git/",
+    ".venv/",
+    ".mypy_cache/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    "test-artifacts/",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _git_output(repo_root: Path, *args: str, text: bool = True) -> str | bytes:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=text,
+    )
+    return result.stdout
+
+
+def _iter_untracked_files(repo_root: Path) -> list[Path]:
+    output = _git_output(
+        repo_root,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        text=False,
+    )
+    files: list[Path] = []
+    for raw_path in output.split(b"\0"):
+        if not raw_path:
+            continue
+        rel_path = raw_path.decode("utf-8", errors="surrogateescape")
+        if rel_path.startswith(IGNORED_UNTRACKED_PREFIXES):
+            continue
+        path = repo_root / rel_path
+        if path.is_file():
+            files.append(path)
+    return sorted(files)
+
+
+def _compute_default_tag(repo_root: Path) -> str:
+    head = str(_git_output(repo_root, "rev-parse", "--short=12", "HEAD")).strip()
+    status = str(_git_output(repo_root, "status", "--porcelain=v1", "--untracked-files=all"))
+    if not status.strip():
+        return head
+
+    hasher = hashlib.sha256()
+    tracked_diff = _git_output(repo_root, "diff", "--no-ext-diff", "--binary", "HEAD", text=False)
+    hasher.update(tracked_diff)
+
+    for path in _iter_untracked_files(repo_root):
+        rel_path = path.relative_to(repo_root).as_posix()
+        hasher.update(rel_path.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(path.read_bytes())
+        hasher.update(b"\0")
+
+    return f"{head}-dirty-{hasher.hexdigest()[:12]}"
+
+
+def resolve_demo_image_ref(repo_root: Path | None = None) -> dict[str, str]:
+    """Return repository, tag, and full image ref for the demo Dagster image."""
+    repo_root = repo_root or _repo_root()
+    repository = os.environ.get("FLOE_DEMO_IMAGE_REPOSITORY", DEFAULT_REPOSITORY).strip()
+    if not repository:
+        raise SystemExit("FLOE_DEMO_IMAGE_REPOSITORY cannot be empty")
+
+    tag = os.environ.get("FLOE_DEMO_IMAGE_TAG", "").strip()
+    if not tag:
+        try:
+            tag = _compute_default_tag(repo_root)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            tag = "local"
+
+    ref = f"{repository}:{tag}"
+    return {
+        "FLOE_DEMO_IMAGE_REPOSITORY": repository,
+        "FLOE_DEMO_IMAGE_TAG": tag,
+        "FLOE_DEMO_IMAGE": ref,
+    }
+
+
+def _shell_quote(value: str) -> str:
+    if "'" not in value:
+        return f"'{value}'"
+    escaped = value.replace("\\", "\\\\").replace("'", "\\x27")
+    return f"$'{escaped}'"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--field",
+        choices=("repository", "tag", "ref", "exports"),
+        default="exports",
+        help="Single field to print, or shell exports (default).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    resolved = resolve_demo_image_ref()
+    field_map = {
+        "repository": resolved["FLOE_DEMO_IMAGE_REPOSITORY"],
+        "tag": resolved["FLOE_DEMO_IMAGE_TAG"],
+        "ref": resolved["FLOE_DEMO_IMAGE"],
+    }
+    if args.field == "exports":
+        for key, value in resolved.items():
+            print(f"export {key}={_shell_quote(value)}")
+        return
+    sys.stdout.write(field_map[args.field])
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/ci/resolve-demo-image-ref.py
+++ b/testing/ci/resolve-demo-image-ref.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 DEFAULT_REPOSITORY = "floe-dagster-demo"
+MAX_HASH_FILE_SIZE = 50 * 1024 * 1024
 IGNORED_UNTRACKED_PREFIXES = (
     ".git/",
     ".venv/",
@@ -86,6 +87,11 @@ def _compute_default_tag(repo_root: Path) -> str:
         rel_path = path.relative_to(repo_root).as_posix()
         hasher.update(rel_path.encode("utf-8"))
         hasher.update(b"\0")
+        file_size = path.stat().st_size
+        if file_size > MAX_HASH_FILE_SIZE:
+            hasher.update(f"size:{file_size}".encode())
+            hasher.update(b"\0")
+            continue
         hasher.update(path.read_bytes())
         hasher.update(b"\0")
 

--- a/testing/ci/test-bootstrap-validation.sh
+++ b/testing/ci/test-bootstrap-validation.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=./common.sh
+source "${SCRIPT_DIR}/common.sh"
 
 cd "${PROJECT_ROOT}"
 mkdir -p test-artifacts

--- a/testing/ci/test-bootstrap-validation.sh
+++ b/testing/ci/test-bootstrap-validation.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+mkdir -p test-artifacts
+
+uv run pytest tests/e2e \
+  -m "bootstrap" \
+  --tb=short \
+  -v \
+  --junitxml=test-artifacts/bootstrap-results.xml

--- a/testing/ci/test-developer-workflow.sh
+++ b/testing/ci/test-developer-workflow.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=./common.sh
+source "${SCRIPT_DIR}/common.sh"
 
 cd "${PROJECT_ROOT}"
 mkdir -p test-artifacts

--- a/testing/ci/test-developer-workflow.sh
+++ b/testing/ci/test-developer-workflow.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+mkdir -p test-artifacts
+
+uv run pytest tests/e2e \
+  -m "developer_workflow" \
+  --tb=short \
+  -v \
+  --junitxml=test-artifacts/developer-workflow-results.xml

--- a/testing/ci/test-e2e-cluster.sh
+++ b/testing/ci/test-e2e-cluster.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# In-cluster E2E test runner — runs tests as a K8s Job inside the Kind cluster
+# In-cluster validation runner — runs deployed-product lanes as a K8s Job inside
+# the Kind cluster.
 #
 # This eliminates host-to-cluster connectivity issues (port-forwards, SSH tunnels)
 # by running tests where the services are.
@@ -13,7 +14,8 @@
 #   SKIP_BUILD          Skip image build if set to "true" (default: false)
 #   IMAGE_LOAD_METHOD   How to load image: auto|kind|devpod|skip (default: auto)
 #   STARTUP_ONLY        Exit after proving pod startup boundary (default: false)
-#   TEST_SUITE          Test suite to run: e2e|e2e-destructive (default: e2e)
+#   TEST_SUITE          Validation suite to run: e2e (platform blackbox) |
+#                       e2e-destructive (default: e2e)
 #   LOG_TAIL_LINES      Lines to capture per pod on failure (default: 100)
 #   DEVPOD_REMOTE_WORKDIR Remote repo root inside the DevPod workspace
 #
@@ -185,7 +187,8 @@ assert_startup_boundary() {
     return 1
 }
 
-# Select Job name and chart-rendered template based on TEST_SUITE
+# Select Job name and chart-rendered template based on TEST_SUITE. The standard
+# lane is the deployed-product/platform-blackbox validation that runs in-cluster.
 case "${TEST_SUITE}" in
     e2e)
         JOB_NAME="floe-test-e2e"

--- a/testing/ci/test-e2e-cluster.sh
+++ b/testing/ci/test-e2e-cluster.sh
@@ -48,7 +48,21 @@ info() { echo "[INFO] $*"; }
 error() { echo "[ERROR] $*" >&2; }
 
 devpod_workspace() {
-    printf '%s\n' "${DEVPOD_WORKSPACE:-floe}"
+    if [[ -n "${DEVPOD_WORKSPACE:-}" ]]; then
+        printf '%s\n' "${DEVPOD_WORKSPACE}"
+        return
+    fi
+
+    local first_kubeconfig=""
+    local kubeconfig_name=""
+    first_kubeconfig="${KUBECONFIG%%:*}"
+    kubeconfig_name="${first_kubeconfig##*/}"
+    if [[ "${kubeconfig_name}" =~ ^devpod-(.+)\.config$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return
+    fi
+
+    printf '%s\n' "floe"
 }
 
 devpod_kubeconfig_path() {
@@ -59,6 +73,18 @@ devpod_kubeconfig_path() {
 
 devpod_remote_workdir() {
     printf '%s\n' "${DEVPOD_REMOTE_WORKDIR}"
+}
+
+devpod_context_configured() {
+    if [[ -n "${DEVPOD_WORKSPACE:-}" ]]; then
+        return 0
+    fi
+
+    local first_kubeconfig=""
+    local kubeconfig_name=""
+    first_kubeconfig="${KUBECONFIG%%:*}"
+    kubeconfig_name="${first_kubeconfig##*/}"
+    [[ "${kubeconfig_name}" =~ ^devpod-.+\.config$ ]]
 }
 
 ensure_devpod_ready() {
@@ -226,6 +252,7 @@ load_image() {
             ;;
         kind)
             info "Loading image into Kind cluster '${kind_cluster}' (IMAGE_LOAD_METHOD=kind)..."
+            floe_kind_evict_image "${image}" "${kind_cluster}"
             kind load docker-image "${image}" --name "${kind_cluster}"
             return 0
             ;;
@@ -234,6 +261,8 @@ load_image() {
             workspace=$(devpod_workspace)
             info "Loading image into DevPod workspace '${workspace}' and Kind cluster '${kind_cluster}'..."
             docker save "${image}" | devpod_remote_command "docker load"
+            devpod_remote_command \
+                "source '${DEVPOD_REMOTE_WORKDIR}/testing/ci/common.sh' && floe_kind_evict_image '${image}' '${kind_cluster}'"
             devpod_remote_command "kind load docker-image '${image}' --name '${kind_cluster}'"
             return 0
             ;;
@@ -241,15 +270,18 @@ load_image() {
             # auto: detect environment
             if command -v kind &>/dev/null && kind get clusters 2>/dev/null | grep -q "^${kind_cluster}$"; then
                 info "Loading image into Kind cluster '${kind_cluster}'..."
+                floe_kind_evict_image "${image}" "${kind_cluster}"
                 kind load docker-image "${image}" --name "${kind_cluster}"
                 return 0
             fi
 
-            if [[ -n "${DEVPOD_WORKSPACE:-}" ]]; then
+            if devpod_context_configured; then
                 local workspace
                 workspace=$(devpod_workspace)
                 info "Loading image into DevPod workspace '${workspace}' and Kind cluster '${kind_cluster}'..."
                 docker save "${image}" | devpod_remote_command "docker load"
+                devpod_remote_command \
+                    "source '${DEVPOD_REMOTE_WORKDIR}/testing/ci/common.sh' && floe_kind_evict_image '${image}' '${kind_cluster}'"
                 devpod_remote_command "kind load docker-image '${image}' --name '${kind_cluster}'"
                 return 0
             fi
@@ -272,7 +304,7 @@ fi
 
 if [[ "${IMAGE_LOAD_METHOD}" == "devpod" ]]; then
     ensure_devpod_ready
-elif [[ "${IMAGE_LOAD_METHOD}" == "auto" && -n "${DEVPOD_WORKSPACE:-}" ]]; then
+elif [[ "${IMAGE_LOAD_METHOD}" == "auto" ]] && devpod_context_configured; then
     if ! kubectl cluster-info >/dev/null 2>&1; then
         ensure_devpod_ready
     fi

--- a/testing/ci/test-e2e-full.sh
+++ b/testing/ci/test-e2e-full.sh
@@ -87,7 +87,12 @@ info "Cleaning up platform validation pods before destructive suite..."
 kubectl delete pods -l test-type=e2e -n "${TEST_NAMESPACE}" --ignore-not-found 2>/dev/null || true
 
 for i in $(seq 1 30); do
-    pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' '); then
+        error "Failed to query platform validation pods during cleanup"
+        CLEANUP_FAILED=true
+        DESTRUCTIVE_EXIT=1
+        break
+    fi
     if [[ "${pod_count}" == "0" ]]; then
         break
     fi

--- a/testing/ci/test-e2e-full.sh
+++ b/testing/ci/test-e2e-full.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
-# Full E2E test orchestrator — runs standard then destructive E2E suites sequentially.
+# Full validation orchestrator — runs bootstrap, platform blackbox,
+# developer workflow, then destructive validation lanes.
 #
-# Standard E2E tests run first. If they fail, destructive tests are skipped
-# (unless FORCE_DESTRUCTIVE=true). Artifacts from both suites are preserved.
+# Bootstrap runs first and gates in-cluster platform validation. Developer
+# workflow validation always runs. Destructive validation requires bootstrap and
+# platform success unless FORCE_DESTRUCTIVE=true. Artifacts from all lanes are
+# preserved.
 #
 # Usage: ./testing/ci/test-e2e-full.sh
 #
 # Environment:
-#   FORCE_DESTRUCTIVE   Run destructive tests even if standard tests fail (default: false)
+#   FORCE_DESTRUCTIVE   Run destructive tests even if bootstrap/platform fail (default: false)
 #   SKIP_BUILD          Skip image build (passed through to test-e2e-cluster.sh)
 #   IMAGE_LOAD_METHOD   Image loading method (passed through to test-e2e-cluster.sh)
 #   TEST_NAMESPACE      K8s namespace (passed through, default: floe-test)
@@ -25,57 +28,85 @@ info() { echo "[INFO] $*"; }
 error() { echo "[ERROR] $*" >&2; }
 
 # Track exit codes
-STANDARD_EXIT=0
+BOOTSTRAP_EXIT=0
+PLATFORM_EXIT=0
+DEVELOPER_EXIT=0
 DESTRUCTIVE_EXIT=0
 
 # =============================================================================
-# Phase 1: Standard E2E tests (non-destructive)
+# Phase 1: Bootstrap validation
 # =============================================================================
 
-info "=== Phase 1: Standard E2E Tests ==="
+info "=== Phase 1: Bootstrap Validation ==="
 
-if "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
-    info "Standard E2E tests PASSED"
-    STANDARD_EXIT=0
+if "${SCRIPT_DIR}/test-bootstrap-validation.sh"; then
+    info "Bootstrap validation PASSED"
 else
-    STANDARD_EXIT=$?
-    error "Standard E2E tests FAILED (exit code: ${STANDARD_EXIT})"
+    BOOTSTRAP_EXIT=$?
+    error "Bootstrap validation FAILED (exit code: ${BOOTSTRAP_EXIT})"
 fi
 
 # =============================================================================
-# Pod cleanup between suites
+# Phase 2: Platform blackbox validation
 # =============================================================================
 
-info "Cleaning up standard test pods before destructive suite..."
+if [[ "${BOOTSTRAP_EXIT}" -eq 0 ]]; then
+    info "=== Phase 2: Platform Blackbox Validation ==="
+
+    if "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+        info "Platform blackbox validation PASSED"
+    else
+        PLATFORM_EXIT=$?
+        error "Platform blackbox validation FAILED (exit code: ${PLATFORM_EXIT})"
+    fi
+else
+    info "Skipping platform blackbox validation because bootstrap failed."
+fi
+
+# =============================================================================
+# Phase 3: Developer workflow validation
+# =============================================================================
+
+info "=== Phase 3: Developer Workflow Validation ==="
+
+if "${SCRIPT_DIR}/test-developer-workflow.sh"; then
+    info "Developer workflow validation PASSED"
+else
+    DEVELOPER_EXIT=$?
+    error "Developer workflow validation FAILED (exit code: ${DEVELOPER_EXIT})"
+fi
+
+# =============================================================================
+# Pod cleanup before destructive suite
+# =============================================================================
+
+info "Cleaning up platform validation pods before destructive suite..."
 kubectl delete pods -l test-type=e2e -n "${TEST_NAMESPACE}" --ignore-not-found 2>/dev/null || true
 
-# Wait for pods to terminate
 for i in $(seq 1 30); do
     pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
     if [[ "${pod_count}" == "0" ]]; then
         break
     fi
     if [[ $i -eq 30 ]]; then
-        error "Standard test pods did not terminate within 30s"
+        error "Platform validation pods did not terminate within 30s"
         exit 1
     fi
     sleep 1
 done
 
 # =============================================================================
-# Phase 2: Destructive E2E tests
+# Phase 4: Destructive E2E tests
 # =============================================================================
 
-if [[ "${STANDARD_EXIT}" -ne 0 ]] && [[ "${FORCE_DESTRUCTIVE}" != "true" ]]; then
-    info "Skipping destructive tests (standard tests failed). Set FORCE_DESTRUCTIVE=true to override."
-    DESTRUCTIVE_EXIT=0
+if [[ ("${BOOTSTRAP_EXIT}" -ne 0 || "${PLATFORM_EXIT}" -ne 0) && "${FORCE_DESTRUCTIVE}" != "true" ]]; then
+    info "Skipping destructive tests (bootstrap and platform must pass). Set FORCE_DESTRUCTIVE=true to override."
 else
-    info "=== Phase 2: Destructive E2E Tests ==="
+    info "=== Phase 4: Destructive E2E Tests ==="
 
     # Use SKIP_BUILD=true since the image was already built in Phase 1
     if SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
         info "Destructive E2E tests PASSED"
-        DESTRUCTIVE_EXIT=0
     else
         DESTRUCTIVE_EXIT=$?
         error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
@@ -88,13 +119,27 @@ fi
 
 info ""
 info "=== E2E Test Summary ==="
-if [[ "${STANDARD_EXIT}" -eq 0 ]]; then
-    info "  Standard:    PASSED"
+if [[ "${BOOTSTRAP_EXIT}" -eq 0 ]]; then
+    info "  Bootstrap:   PASSED"
 else
-    error "  Standard:    FAILED (exit ${STANDARD_EXIT})"
+    error "  Bootstrap:   FAILED (exit ${BOOTSTRAP_EXIT})"
 fi
 
-if [[ "${STANDARD_EXIT}" -ne 0 ]] && [[ "${FORCE_DESTRUCTIVE}" != "true" ]]; then
+if [[ "${BOOTSTRAP_EXIT}" -ne 0 ]]; then
+    info "  Platform:    SKIPPED"
+elif [[ "${PLATFORM_EXIT}" -eq 0 ]]; then
+    info "  Platform:    PASSED"
+else
+    error "  Platform:    FAILED (exit ${PLATFORM_EXIT})"
+fi
+
+if [[ "${DEVELOPER_EXIT}" -eq 0 ]]; then
+    info "  Developer:   PASSED"
+else
+    error "  Developer:   FAILED (exit ${DEVELOPER_EXIT})"
+fi
+
+if [[ ("${BOOTSTRAP_EXIT}" -ne 0 || "${PLATFORM_EXIT}" -ne 0) && "${FORCE_DESTRUCTIVE}" != "true" ]]; then
     info "  Destructive: SKIPPED"
 elif [[ "${DESTRUCTIVE_EXIT}" -eq 0 ]]; then
     info "  Destructive: PASSED"
@@ -103,8 +148,12 @@ else
 fi
 
 # Exit with first non-zero exit code
-if [[ "${STANDARD_EXIT}" -ne 0 ]]; then
-    exit "${STANDARD_EXIT}"
+if [[ "${BOOTSTRAP_EXIT}" -ne 0 ]]; then
+    exit "${BOOTSTRAP_EXIT}"
+elif [[ "${PLATFORM_EXIT}" -ne 0 ]]; then
+    exit "${PLATFORM_EXIT}"
+elif [[ "${DEVELOPER_EXIT}" -ne 0 ]]; then
+    exit "${DEVELOPER_EXIT}"
 elif [[ "${DESTRUCTIVE_EXIT}" -ne 0 ]]; then
     exit "${DESTRUCTIVE_EXIT}"
 fi

--- a/testing/ci/test-e2e-full.sh
+++ b/testing/ci/test-e2e-full.sh
@@ -32,6 +32,8 @@ BOOTSTRAP_EXIT=0
 PLATFORM_EXIT=0
 DEVELOPER_EXIT=0
 DESTRUCTIVE_EXIT=0
+CAN_REUSE_PLATFORM_IMAGE=false
+CLEANUP_FAILED=false
 
 # =============================================================================
 # Phase 1: Bootstrap validation
@@ -55,6 +57,7 @@ if [[ "${BOOTSTRAP_EXIT}" -eq 0 ]]; then
 
     if "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
         info "Platform blackbox validation PASSED"
+        CAN_REUSE_PLATFORM_IMAGE=true
     else
         PLATFORM_EXIT=$?
         error "Platform blackbox validation FAILED (exit code: ${PLATFORM_EXIT})"
@@ -90,7 +93,9 @@ for i in $(seq 1 30); do
     fi
     if [[ $i -eq 30 ]]; then
         error "Platform validation pods did not terminate within 30s"
-        exit 1
+        CLEANUP_FAILED=true
+        DESTRUCTIVE_EXIT=1
+        break
     fi
     sleep 1
 done
@@ -101,11 +106,20 @@ done
 
 if [[ ("${BOOTSTRAP_EXIT}" -ne 0 || "${PLATFORM_EXIT}" -ne 0) && "${FORCE_DESTRUCTIVE}" != "true" ]]; then
     info "Skipping destructive tests (bootstrap and platform must pass). Set FORCE_DESTRUCTIVE=true to override."
+elif [[ "${CLEANUP_FAILED}" == "true" ]]; then
+    info "Skipping destructive tests because platform cleanup failed."
 else
     info "=== Phase 4: Destructive E2E Tests ==="
 
-    # Use SKIP_BUILD=true since the image was already built in Phase 1
-    if SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+    if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then
+        # Platform validation already built and loaded the runner image.
+        if SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+            info "Destructive E2E tests PASSED"
+        else
+            DESTRUCTIVE_EXIT=$?
+            error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
+        fi
+    elif TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
         info "Destructive E2E tests PASSED"
     else
         DESTRUCTIVE_EXIT=$?
@@ -141,6 +155,8 @@ fi
 
 if [[ ("${BOOTSTRAP_EXIT}" -ne 0 || "${PLATFORM_EXIT}" -ne 0) && "${FORCE_DESTRUCTIVE}" != "true" ]]; then
     info "  Destructive: SKIPPED"
+elif [[ "${CLEANUP_FAILED}" == "true" ]]; then
+    error "  Destructive: SKIPPED (cleanup failed)"
 elif [[ "${DESTRUCTIVE_EXIT}" -eq 0 ]]; then
     info "  Destructive: PASSED"
 else

--- a/testing/ci/test-e2e-full.sh
+++ b/testing/ci/test-e2e-full.sh
@@ -106,6 +106,7 @@ else
                 DESTRUCTIVE_EXIT=1
                 break
             fi
+            # Intentional shell polling between kubectl probes while cleanup finishes.
             sleep 1
         done
     fi

--- a/testing/ci/test-e2e-full.sh
+++ b/testing/ci/test-e2e-full.sh
@@ -83,52 +83,54 @@ fi
 # Pod cleanup before destructive suite
 # =============================================================================
 
-info "Cleaning up platform validation pods before destructive suite..."
-kubectl delete pods -l test-type=e2e -n "${TEST_NAMESPACE}" --ignore-not-found 2>/dev/null || true
-
-for i in $(seq 1 30); do
-    if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' '); then
-        error "Failed to query platform validation pods during cleanup"
-        CLEANUP_FAILED=true
-        DESTRUCTIVE_EXIT=1
-        break
-    fi
-    if [[ "${pod_count}" == "0" ]]; then
-        break
-    fi
-    if [[ $i -eq 30 ]]; then
-        error "Platform validation pods did not terminate within 30s"
-        CLEANUP_FAILED=true
-        DESTRUCTIVE_EXIT=1
-        break
-    fi
-    sleep 1
-done
-
-# =============================================================================
-# Phase 4: Destructive E2E tests
-# =============================================================================
-
 if [[ ("${BOOTSTRAP_EXIT}" -ne 0 || "${PLATFORM_EXIT}" -ne 0) && "${FORCE_DESTRUCTIVE}" != "true" ]]; then
     info "Skipping destructive tests (bootstrap and platform must pass). Set FORCE_DESTRUCTIVE=true to override."
-elif [[ "${CLEANUP_FAILED}" == "true" ]]; then
-    info "Skipping destructive tests because platform cleanup failed."
 else
-    info "=== Phase 4: Destructive E2E Tests ==="
-
     if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then
-        # Platform validation already built and loaded the runner image.
-        if SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
-            info "Destructive E2E tests PASSED"
-        else
-            DESTRUCTIVE_EXIT=$?
-            error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
-        fi
-    elif TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
-        info "Destructive E2E tests PASSED"
+        info "Cleaning up platform validation pods before destructive suite..."
+        kubectl delete pods -l test-type=e2e -n "${TEST_NAMESPACE}" --ignore-not-found 2>/dev/null || true
+
+        for i in $(seq 1 30); do
+            if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d ' '); then
+                error "Failed to query platform validation pods during cleanup"
+                CLEANUP_FAILED=true
+                DESTRUCTIVE_EXIT=1
+                break
+            fi
+            if [[ "${pod_count}" == "0" ]]; then
+                break
+            fi
+            if [[ $i -eq 30 ]]; then
+                error "Platform validation pods did not terminate within 30s"
+                CLEANUP_FAILED=true
+                DESTRUCTIVE_EXIT=1
+                break
+            fi
+            sleep 1
+        done
+    fi
+
+    if [[ "${CLEANUP_FAILED}" == "true" ]]; then
+        info "Skipping destructive tests because platform cleanup failed."
     else
-        DESTRUCTIVE_EXIT=$?
-        error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
+        info "=== Phase 4: Destructive E2E Tests ==="
+
+        if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then
+            # Platform validation already built and loaded the runner image.
+            if SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+                info "Destructive E2E tests PASSED"
+            else
+                DESTRUCTIVE_EXIT=$?
+                error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
+            fi
+        else
+            if TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then
+                info "Destructive E2E tests PASSED"
+            else
+                DESTRUCTIVE_EXIT=$?
+                error "Destructive E2E tests FAILED (exit code: ${DESTRUCTIVE_EXIT})"
+            fi
+        fi
     fi
 fi
 

--- a/testing/ci/test-e2e.sh
+++ b/testing/ci/test-e2e.sh
@@ -19,6 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=./common.sh
 source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=./polaris-auth.sh
+source "${SCRIPT_DIR}/polaris-auth.sh"
 
 # Configuration
 KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
@@ -29,6 +31,7 @@ COLLECT_LOGS="${COLLECT_LOGS:-true}"
 # can read them without exposing via process arguments.
 export MINIO_USER="${MINIO_USER:-${AWS_ACCESS_KEY_ID:-}}"
 export MINIO_PASS="${MINIO_PASS:-${AWS_SECRET_ACCESS_KEY:-}}"
+floe_export_minio_credentials_from_cluster "${TEST_NAMESPACE}" || true
 
 # Pre-compute platform service names from the chart release name.
 # No literal `floe-platform-*` strings may appear below this line.
@@ -54,8 +57,11 @@ fi
 
 cd "${PROJECT_ROOT}"
 
-# Extract config from manifest.yaml — sets MANIFEST_BUCKET, MANIFEST_REGION, etc.
-eval "$(python3 "${SCRIPT_DIR}/extract-manifest-config.py" "${PROJECT_ROOT}/demo/manifest.yaml")"
+# Extract config from the selected manifest — sets MANIFEST_BUCKET,
+# MANIFEST_REGION, etc. The demo lane passes its manifest explicitly.
+export FLOE_MANIFEST_PATH="${FLOE_MANIFEST_PATH:-${PROJECT_ROOT}/demo/manifest.yaml}"
+eval "$(python3 "${SCRIPT_DIR}/extract-manifest-config.py" "${FLOE_MANIFEST_PATH}")"
+POLARIS_MANIFEST_PATH="${POLARIS_MANIFEST_PATH:-${FLOE_MANIFEST_PATH}}"
 
 # Validate namespace format (K8s DNS label: lowercase alphanumeric + hyphens)
 if [[ ! "${TEST_NAMESPACE}" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$ ]]; then
@@ -441,9 +447,11 @@ while true; do
 done
 
 # Verify Polaris catalog exists (defense-in-depth for bootstrap job failures)
-POLARIS_CATALOG="${POLARIS_CATALOG:-${MANIFEST_WAREHOUSE}}"
+POLARIS_CATALOG="${POLARIS_CATALOG:-$(get_polaris_catalog_name)}"
 POLARIS_CLIENT_ID="${POLARIS_CLIENT_ID:-${MANIFEST_OAUTH_CLIENT_ID}}"
-POLARIS_CLIENT_SECRET="${POLARIS_CLIENT_SECRET:-}"
+POLARIS_SCOPE="${POLARIS_SCOPE:-$(get_polaris_scope)}"
+export POLARIS_WAREHOUSE="${POLARIS_WAREHOUSE:-${POLARIS_CATALOG}}"
+export POLARIS_SCOPE
 
 # Validate catalog name to prevent URL injection
 if [[ ! "${POLARIS_CATALOG}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
@@ -453,14 +461,7 @@ fi
 
 echo "Verifying Polaris catalog '${POLARIS_CATALOG}'..."
 
-# Acquire OAuth token — pipe credentials via stdin (-d @-) to avoid
-# exposing them in process arguments (visible in ps aux).
-POLARIS_TOKEN=$(printf 'grant_type=client_credentials&client_id=%s&client_secret=%s&scope=PRINCIPAL_ROLE:ALL' \
-    "${POLARIS_CLIENT_ID}" "${POLARIS_CLIENT_SECRET}" | \
-    curl -s -X POST \
-    "http://localhost:8181/api/catalog/v1/oauth/tokens" \
-    -d @- \
-    2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))") || true
+POLARIS_TOKEN=$(get_polaris_token "http://localhost:8181") || true
 
 if [[ -z "${POLARIS_TOKEN}" ]]; then
     echo "ERROR: Failed to acquire Polaris OAuth token" >&2

--- a/testing/ci/test-unit-c-boundary.sh
+++ b/testing/ci/test-unit-c-boundary.sh
@@ -65,10 +65,12 @@ sync_devpod_checkout() {
 }
 
 ensure_remote_demo_image_loaded() {
-    local demo_image="floe-dagster-demo:latest"
+    local demo_image="${FLOE_DEMO_IMAGE}"
 
     if remote_image_present "${demo_image}"; then
         info "Remote demo image '${demo_image}' is present. Reloading it into Kind..."
+        devpod_remote_command \
+            "source '${DEVPOD_REMOTE_WORKDIR}/testing/ci/common.sh' && floe_kind_evict_image '${demo_image}' '${FLOE_KIND_CLUSTER}'"
         devpod_remote_command \
             "kind load docker-image '${demo_image}' --name '${FLOE_KIND_CLUSTER}'"
         return 0
@@ -77,7 +79,7 @@ ensure_remote_demo_image_loaded() {
     sync_devpod_checkout
     info "Remote demo image '${demo_image}' is missing. Rebuilding it in the DevPod workspace..."
     devpod_remote_command \
-        "KIND_CLUSTER_NAME='${FLOE_KIND_CLUSTER}' make build-demo-image"
+        "FLOE_DEMO_IMAGE_REPOSITORY='${FLOE_DEMO_IMAGE_REPOSITORY}' FLOE_DEMO_IMAGE_TAG='${FLOE_DEMO_IMAGE_TAG}' KIND_CLUSTER_NAME='${FLOE_KIND_CLUSTER}' make build-demo-image"
 }
 
 ensure_remote_test_runner_image_loaded() {

--- a/testing/ci/tests/test_e2e_sh_manifest_wiring.py
+++ b/testing/ci/tests/test_e2e_sh_manifest_wiring.py
@@ -98,6 +98,27 @@ class TestEvalManifestExtractorPresent:
         )
 
 
+@pytest.mark.requirement("ARC-002")
+class TestManifestPathSelection:
+    """Verify test-e2e.sh uses the shared manifest path contract."""
+
+    def test_sets_floe_manifest_path_before_extraction(self) -> None:
+        pattern = r"FLOE_MANIFEST_PATH=.*\$\{PROJECT_ROOT\}/demo/manifest\.yaml"
+        match = _find_line_index(pattern)
+        assert match is not None, (
+            "test-e2e.sh must export FLOE_MANIFEST_PATH before extracting "
+            "manifest-derived config."
+        )
+
+    def test_extractor_uses_floe_manifest_path(self) -> None:
+        pattern = r'extract-manifest-config\.py"\s+"\$\{FLOE_MANIFEST_PATH\}"'
+        match = _find_line_index(pattern)
+        assert match is not None, (
+            "test-e2e.sh must pass ${FLOE_MANIFEST_PATH} to "
+            "extract-manifest-config.py."
+        )
+
+
 # ---------------------------------------------------------------------------
 # AC-2.2: MINIO_BUCKET defaults to ${MANIFEST_BUCKET}
 # ---------------------------------------------------------------------------
@@ -145,10 +166,13 @@ class TestPolarisCatalogDefault:
 
     def test_polaris_catalog_uses_manifest_warehouse(self) -> None:
         """POLARIS_CATALOG default must reference MANIFEST_WAREHOUSE variable."""
-        pattern = r"POLARIS_CATALOG=.*\$\{POLARIS_CATALOG:-\$\{?MANIFEST_WAREHOUSE\}?"
-        match = _find_line_index(pattern)
-        assert match is not None, (
-            "POLARIS_CATALOG must default to ${MANIFEST_WAREHOUSE}, not a hardcoded value"
+        direct_pattern = r"POLARIS_CATALOG=.*\$\{POLARIS_CATALOG:-\$\{?MANIFEST_WAREHOUSE\}?"
+        helper_pattern = r"POLARIS_CATALOG=.*\$\{POLARIS_CATALOG:-\$\(get_polaris_catalog_name\)\}"
+        direct_match = _find_line_index(direct_pattern)
+        helper_match = _find_line_index(helper_pattern)
+        assert direct_match is not None or helper_match is not None, (
+            "POLARIS_CATALOG must default via manifest-derived wiring "
+            "(${MANIFEST_WAREHOUSE} or get_polaris_catalog_name()), not a hardcoded value"
         )
 
     def test_polaris_catalog_not_hardcoded_floe_e2e(self) -> None:
@@ -187,6 +211,32 @@ class TestPolarisClientIdDefault:
             f"POLARIS_CLIENT_ID still uses hardcoded 'demo-admin' as default "
             f"(line {match + 1 if match is not None else '?'}). "
             "Must use ${MANIFEST_OAUTH_CLIENT_ID} instead."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2.4b: Polaris auth wiring must come from manifest-derived helper path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requirement("ARC-002")
+class TestPolarisAuthHelperWiring:
+    """Verify test-e2e.sh reuses the Polaris helper instead of hardcoding scope."""
+
+    def test_sources_polaris_auth_helper(self) -> None:
+        pattern = r"source\s+\"\$\{SCRIPT_DIR\}/polaris-auth\.sh\""
+        match = _find_line_index(pattern)
+        assert match is not None, "test-e2e.sh must source testing/ci/polaris-auth.sh"
+
+    def test_uses_get_polaris_token_helper(self) -> None:
+        pattern = r"POLARIS_TOKEN=.*get_polaris_token"
+        match = _find_line_index(pattern)
+        assert match is not None, "test-e2e.sh must acquire OAuth tokens via get_polaris_token()"
+
+    def test_no_inline_hardcoded_scope_in_token_request(self) -> None:
+        assert "scope=PRINCIPAL_ROLE:ALL" not in _script_content, (
+            "test-e2e.sh must not hardcode the Polaris OAuth scope; "
+            "it should flow from manifest-derived configuration."
         )
 
 

--- a/testing/ci/tests/test_e2e_sh_manifest_wiring.py
+++ b/testing/ci/tests/test_e2e_sh_manifest_wiring.py
@@ -106,16 +106,14 @@ class TestManifestPathSelection:
         pattern = r"FLOE_MANIFEST_PATH=.*\$\{PROJECT_ROOT\}/demo/manifest\.yaml"
         match = _find_line_index(pattern)
         assert match is not None, (
-            "test-e2e.sh must export FLOE_MANIFEST_PATH before extracting "
-            "manifest-derived config."
+            "test-e2e.sh must export FLOE_MANIFEST_PATH before extracting manifest-derived config."
         )
 
     def test_extractor_uses_floe_manifest_path(self) -> None:
         pattern = r'extract-manifest-config\.py"\s+"\$\{FLOE_MANIFEST_PATH\}"'
         match = _find_line_index(pattern)
         assert match is not None, (
-            "test-e2e.sh must pass ${FLOE_MANIFEST_PATH} to "
-            "extract-manifest-config.py."
+            "test-e2e.sh must pass ${FLOE_MANIFEST_PATH} to extract-manifest-config.py."
         )
 
 

--- a/testing/ci/uv-security-audit.sh
+++ b/testing/ci/uv-security-audit.sh
@@ -20,13 +20,13 @@ output="$(uv run --no-sync uv-secure --no-check-uv-tool --ignore-vulns "${IGNORE
     echo "${output}"
 
     # Exit code 2 = warnings (not blocking)
-    if [ "${exit_code}" -eq 2 ]; then
+    if [[ "${exit_code}" -eq 2 ]]; then
         echo "uv-secure returned warnings (exit code 2)" >&2
         exit 0
     fi
 
     # Exit code 3 = tool crash, check if actual vulnerabilities were reported
-    if [ "${exit_code}" -eq 3 ]; then
+    if [[ "${exit_code}" -eq 3 ]]; then
         if echo "${output}" | grep -q "Vulnerable:" && ! echo "${output}" | grep -q "Vulnerable: 0"; then
             echo "Vulnerabilities detected" >&2
             exit 1

--- a/testing/ci/uv-security-audit.sh
+++ b/testing/ci/uv-security-audit.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run uv-secure with the same ignores and exit handling used in CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Centralized vulnerability ignores:
+# - GHSA-5j53-63w8-8625: fastapi-users OAuth/CSRF (not used)
+# - GHSA-7gcm-g887-7qv7: protobuf DoS (transitive, no fix)
+IGNORE_VULNS="${UV_SECURE_IGNORE_VULNS:-GHSA-5j53-63w8-8625,GHSA-7gcm-g887-7qv7}"
+
+cd "${PROJECT_ROOT}"
+
+echo "Running uv-secure with ignores: ${IGNORE_VULNS}"
+
+output="$(uv run --no-sync uv-secure --no-check-uv-tool --ignore-vulns "${IGNORE_VULNS}" . 2>&1)" || {
+    exit_code=$?
+    echo "${output}"
+
+    # Exit code 2 = warnings (not blocking)
+    if [ "${exit_code}" -eq 2 ]; then
+        echo "uv-secure returned warnings (exit code 2)" >&2
+        exit 0
+    fi
+
+    # Exit code 3 = tool crash, check if actual vulnerabilities were reported
+    if [ "${exit_code}" -eq 3 ]; then
+        if echo "${output}" | grep -q "Vulnerable:" && ! echo "${output}" | grep -q "Vulnerable: 0"; then
+            echo "Vulnerabilities detected" >&2
+            exit 1
+        fi
+
+        echo "uv-secure crashed but no vulnerabilities were reported" >&2
+        exit 0
+    fi
+
+    exit "${exit_code}"
+}
+
+echo "${output}"

--- a/testing/ci/validate-dbt-version-requirements.sh
+++ b/testing/ci/validate-dbt-version-requirements.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Validate dbt plugin version requirements for CI and local pre-push hooks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${PROJECT_ROOT}"
+
+echo "Validating dbt plugin version requirements..."
+
+# Check floe-dbt-core requires dbt-core>=1.6,<2.0 (NFR-003)
+core_dep="$(grep -E '"dbt-core.*"' plugins/floe-dbt-core/pyproject.toml || true)"
+if [[ -z "${core_dep}" ]]; then
+    echo "ERROR: floe-dbt-core must depend on dbt-core" >&2
+    exit 1
+fi
+
+if ! echo "${core_dep}" | grep -qE '>=1\.6.*<2\.0'; then
+    echo "ERROR: floe-dbt-core must require dbt-core>=1.6,<2.0" >&2
+    echo "Current: ${core_dep}" >&2
+    echo "Required: dbt-core>=1.6,<2.0 (NFR-003)" >&2
+    exit 1
+fi
+
+echo "✓ floe-dbt-core: ${core_dep}"
+
+# Check floe-dbt-fusion requires dbt Fusion CLI >=1.0 (NFR-004)
+# Note: Fusion is a CLI binary, not a Python dependency
+fusion_check="$(grep -E 'MIN_FUSION_VERSION|>=.*1\.0' plugins/floe-dbt-fusion/src/floe_dbt_fusion/detection.py || true)"
+if [[ -z "${fusion_check}" ]]; then
+    echo "WARNING: Could not verify Fusion version check in detection.py" >&2
+else
+    echo "✓ floe-dbt-fusion: Fusion version check found"
+fi
+
+echo "dbt version requirements validated"

--- a/testing/ci/wait-for-services.sh
+++ b/testing/ci/wait-for-services.sh
@@ -9,11 +9,11 @@
 #   POD_TIMEOUT           Pod readiness timeout in seconds (default: 300)
 #   JOB_TIMEOUT           Job completion timeout in seconds (default: 180)
 #   POLARIS_URL           Polaris API URL (default: http://localhost:8181)
-#   POLARIS_CATALOG_NAME  Catalog name to verify (default: floe-e2e)
+#   POLARIS_CATALOG_NAME  Catalog name to verify (default: from FLOE_MANIFEST_PATH)
 #   MINIO_URL             MinIO API URL (default: http://localhost:9000)
-#   MINIO_BUCKET          Expected bucket name (default: floe-iceberg)
+#   MINIO_BUCKET          Expected bucket name (default: from FLOE_MANIFEST_PATH)
 #   POLARIS_CLIENT_ID     OAuth client ID (default: from MANIFEST_OAUTH_CLIENT_ID)
-#   POLARIS_CLIENT_SECRET OAuth client secret (required — no hardcoded default)
+#   POLARIS_CLIENT_SECRET OAuth client secret (default: from FLOE_MANIFEST_PATH)
 #   MINIO_USER            MinIO admin username (from env or AWS_ACCESS_KEY_ID)
 #   MINIO_PASS            MinIO admin password (from env or AWS_SECRET_ACCESS_KEY)
 
@@ -21,14 +21,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="${1:-${TEST_NAMESPACE:-floe-test}}"
+export FLOE_NAMESPACE="${NAMESPACE}"
+# shellcheck source=./common.sh
+source "${SCRIPT_DIR}/common.sh"
 POD_TIMEOUT="${POD_TIMEOUT:-300}"
 JOB_TIMEOUT="${JOB_TIMEOUT:-180}"
 POLARIS_URL="${POLARIS_URL:-http://localhost:8181}"
-POLARIS_CATALOG_NAME="${POLARIS_CATALOG_NAME:-floe-e2e}"
 # Export credentials as env vars so child processes (ensure-bucket.py)
 # can read them without exposing via process arguments.
 export MINIO_USER="${MINIO_USER:-${AWS_ACCESS_KEY_ID:-}}"
 export MINIO_PASS="${MINIO_PASS:-${AWS_SECRET_ACCESS_KEY:-}}"
+floe_export_minio_credentials_from_cluster "${NAMESPACE}" || true
 
 # Validate MinIO credentials are available
 if [[ -z "${MINIO_USER}" ]]; then
@@ -45,6 +48,9 @@ fi
 # Source Polaris auth helper
 # shellcheck source=testing/ci/polaris-auth.sh
 source "$SCRIPT_DIR/polaris-auth.sh"
+eval "$(python3 "${SCRIPT_DIR}/extract-manifest-config.py" "${FLOE_MANIFEST_PATH}")"
+POLARIS_MANIFEST_PATH="${POLARIS_MANIFEST_PATH:-${FLOE_MANIFEST_PATH}}"
+POLARIS_CATALOG_NAME="${POLARIS_CATALOG_NAME:-$(get_polaris_catalog_name)}"
 
 echo "Waiting for services in namespace: ${NAMESPACE}"
 
@@ -88,7 +94,7 @@ done
 # Uses boto3 HeadBucket with credentials — anonymous curl returns 403 for both
 # existing and non-existing buckets, making it useless for detection.
 MINIO_URL="${MINIO_URL:-http://localhost:9000}"
-MINIO_BUCKET="${MINIO_BUCKET:-floe-iceberg}"
+MINIO_BUCKET="${MINIO_BUCKET:-${MANIFEST_BUCKET}}"
 echo "Verifying MinIO bucket '${MINIO_BUCKET}' exists..."
 MINIO_ATTEMPT=0
 # 30 attempts (vs 10 in test-e2e.sh): this script runs at cluster startup

--- a/testing/fixtures/credentials.py
+++ b/testing/fixtures/credentials.py
@@ -1,8 +1,9 @@
 """Centralized test credentials module.
 
-Provides functions to retrieve credentials for MinIO and Polaris services.
-Each function reads from environment variables first, falling back to
-demo/manifest.yaml values, with sensible hardcoded defaults as a last resort.
+Provides functions to retrieve credentials and connection defaults for MinIO
+and Polaris services. Each function reads from environment variables first,
+then from a manifest path supplied explicitly or via ``FLOE_MANIFEST_PATH``,
+falling back to repo demo defaults only as a last resort.
 
 This is the SINGLE SOURCE of credential access for all Python tests and
 fixtures. No test file should hardcode ``minioadmin``, ``demo-admin``, or
@@ -19,6 +20,7 @@ from typing import Any
 import yaml
 
 logger = logging.getLogger(__name__)
+MANIFEST_PATH_ENV_VARS = ("FLOE_MANIFEST_PATH", "POLARIS_MANIFEST_PATH")
 
 # ---------------------------------------------------------------------------
 # Hardcoded defaults — used when both env vars and manifest are unavailable.
@@ -27,12 +29,27 @@ logger = logging.getLogger(__name__)
 _DEFAULT_POLARIS_CLIENT_ID = "demo-admin"
 _DEFAULT_POLARIS_CLIENT_SECRET = "demo-secret"  # pragma: allowlist secret  # noqa: S105
 _DEFAULT_POLARIS_ENDPOINT = "http://floe-platform-polaris:8181/api/catalog"
+_DEFAULT_POLARIS_SCOPE = "PRINCIPAL_ROLE:ALL"
+_DEFAULT_POLARIS_WAREHOUSE = "floe-demo"
 _DEFAULT_MINIO_ACCESS_KEY = "minioadmin"
 _DEFAULT_MINIO_SECRET_KEY = "minioadmin123"  # pragma: allowlist secret  # noqa: S105
 
 
+def resolve_manifest_path(manifest_path: Path | None = None) -> Path:
+    """Resolve the manifest path from an explicit argument, env, or repo default."""
+    if manifest_path is not None:
+        return manifest_path
+
+    for env_var in MANIFEST_PATH_ENV_VARS:
+        env_path = _env_or_none(env_var)
+        if env_path is not None:
+            return Path(env_path).expanduser()
+
+    return _default_manifest_path()
+
+
 def _default_manifest_path() -> Path:
-    """Return the default path to ``demo/manifest.yaml`` relative to the repo root."""
+    """Return the repo-owned fallback path to ``demo/manifest.yaml``."""
     return Path(__file__).resolve().parents[2] / "demo" / "manifest.yaml"
 
 
@@ -48,8 +65,7 @@ def _read_manifest(manifest_path: Path | None) -> dict[str, Any]:
     Returns:
         Parsed YAML as a dict, or empty dict on failure.
     """
-    if manifest_path is None:
-        manifest_path = _default_manifest_path()
+    manifest_path = resolve_manifest_path(manifest_path)
 
     if not manifest_path.is_file():
         return {}
@@ -77,6 +93,24 @@ def _env_or_none(name: str) -> str | None:
     if value is not None and value.strip() == "":
         return None
     return value
+
+
+def _catalog_config(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed catalog config block from a manifest dict."""
+    plugins = raw.get("plugins", {})
+    if not isinstance(plugins, dict):
+        return {}
+    catalog = plugins.get("catalog", {})
+    if not isinstance(catalog, dict):
+        return {}
+    config = catalog.get("config", {})
+    return config if isinstance(config, dict) else {}
+
+
+def _catalog_oauth2(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed Polaris oauth2 block from a manifest dict."""
+    oauth2 = _catalog_config(raw).get("oauth2", {})
+    return oauth2 if isinstance(oauth2, dict) else {}
 
 
 def get_minio_credentials(manifest_path: Path | None = None) -> tuple[str, str]:  # noqa: ARG001
@@ -124,13 +158,63 @@ def get_polaris_credentials(manifest_path: Path | None = None) -> tuple[str, str
 
     # Read manifest for any values not provided via env vars
     raw = _read_manifest(manifest_path)
-    oauth2: dict[str, Any] = (
-        raw.get("plugins", {}).get("catalog", {}).get("config", {}).get("oauth2", {})
-    )
+    oauth2 = _catalog_oauth2(raw)
 
     client_id = env_id or str(oauth2.get("client_id", _DEFAULT_POLARIS_CLIENT_ID))
     client_secret = env_secret or str(oauth2.get("client_secret", _DEFAULT_POLARIS_CLIENT_SECRET))
     return (client_id, client_secret)
+
+
+def get_polaris_scope(manifest_path: Path | None = None) -> str:
+    """Return the OAuth scope for Polaris.
+
+    Priority: env var ``POLARIS_SCOPE``, then ``manifest_path`` (or default
+    ``demo/manifest.yaml``), then the canonical demo default.
+
+    Args:
+        manifest_path: Optional path to manifest.yaml.
+
+    Returns:
+        Polaris OAuth scope string.
+    """
+    env_scope = _env_or_none("POLARIS_SCOPE")
+    if env_scope is not None:
+        return env_scope
+
+    raw = _read_manifest(manifest_path)
+    catalog_cfg = _catalog_config(raw)
+    oauth2 = _catalog_oauth2(raw)
+    scope = catalog_cfg.get("scope", oauth2.get("scope"))
+
+    if scope is not None and str(scope).strip():
+        return str(scope)
+
+    return _DEFAULT_POLARIS_SCOPE
+
+
+def get_polaris_warehouse(manifest_path: Path | None = None) -> str:
+    """Return the Polaris warehouse/catalog name.
+
+    Priority: env var ``POLARIS_WAREHOUSE``, then ``manifest_path`` (or default
+    ``demo/manifest.yaml``), then the canonical demo default.
+
+    Args:
+        manifest_path: Optional path to manifest.yaml.
+
+    Returns:
+        Polaris warehouse/catalog string.
+    """
+    env_warehouse = _env_or_none("POLARIS_WAREHOUSE")
+    if env_warehouse is not None:
+        return env_warehouse
+
+    raw = _read_manifest(manifest_path)
+    warehouse = _catalog_config(raw).get("warehouse")
+
+    if warehouse is not None and str(warehouse).strip():
+        return str(warehouse)
+
+    return _DEFAULT_POLARIS_WAREHOUSE
 
 
 def get_polaris_endpoint(manifest_path: Path | None = None) -> str:
@@ -150,7 +234,7 @@ def get_polaris_endpoint(manifest_path: Path | None = None) -> str:
         return env_endpoint
 
     raw = _read_manifest(manifest_path)
-    uri = raw.get("plugins", {}).get("catalog", {}).get("config", {}).get("uri")
+    uri = _catalog_config(raw).get("uri")
 
     if uri is not None:
         return str(uri)

--- a/testing/fixtures/polaris.py
+++ b/testing/fixtures/polaris.py
@@ -20,7 +20,12 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
-from testing.fixtures.credentials import get_minio_credentials, get_polaris_credentials
+from testing.fixtures.credentials import (
+    get_minio_credentials,
+    get_polaris_credentials,
+    get_polaris_scope,
+    get_polaris_warehouse,
+)
 from testing.fixtures.services import ServiceEndpoint
 
 if TYPE_CHECKING:
@@ -60,13 +65,9 @@ class PolarisConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     uri: str = Field(default_factory=_default_polaris_uri)
-    warehouse: str = Field(
-        default_factory=lambda: os.environ.get("POLARIS_WAREHOUSE", "test_warehouse")
-    )
+    warehouse: str = Field(default_factory=get_polaris_warehouse)
     credential: SecretStr = Field(default_factory=_default_polaris_credential)
-    scope: str = Field(
-        default_factory=lambda: os.environ.get("POLARIS_SCOPE", "PRINCIPAL_ROLE:ALL")
-    )
+    scope: str = Field(default_factory=get_polaris_scope)
     namespace: str = Field(default="floe-test")
 
     @property

--- a/testing/k8s/setup-cluster.sh
+++ b/testing/k8s/setup-cluster.sh
@@ -64,6 +64,41 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
+inject_demo_image_values() {
+    local manifest_path="$1"
+    python3 - "${manifest_path}" "${FLOE_DEMO_IMAGE_REPOSITORY}" "${FLOE_DEMO_IMAGE_TAG}" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+manifest_path = Path(sys.argv[1])
+repository = sys.argv[2]
+tag = sys.argv[3]
+
+raw = yaml.safe_load(manifest_path.read_text()) or {}
+spec = raw.setdefault("spec", {})
+values = spec.setdefault("values", {})
+dagster = values.setdefault("dagster", {})
+
+for component in ("dagsterWebserver", "dagsterDaemon"):
+    image = dagster.setdefault(component, {}).setdefault("image", {})
+    image["repository"] = repository
+    image["tag"] = tag
+
+run_image = (
+    dagster.setdefault("runLauncher", {})
+    .setdefault("config", {})
+    .setdefault("k8sRunLauncher", {})
+    .setdefault("image", {})
+)
+run_image["repository"] = repository
+run_image["tag"] = tag
+
+manifest_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+PY
+}
+
 # Check prerequisites
 check_prerequisites() {
     log_info "Checking prerequisites..."
@@ -271,7 +306,7 @@ deploy_monitoring_stack() {
 # Both Helm and Flux paths need this — Dagster pods use pullPolicy: Never.
 build_demo_image() {
     if [[ -f "${PROJECT_ROOT}/docker/dagster-demo/Dockerfile" ]]; then
-        log_info "Building Dagster demo image..."
+        log_info "Building Dagster demo image (${FLOE_DEMO_IMAGE})..."
         KIND_CLUSTER_NAME="${CLUSTER_NAME}" make -C "${PROJECT_ROOT}" build-demo-image 2>&1 || {
             log_warn "Dagster demo image build failed — Dagster pods will be in ErrImageNeverPull"
         }
@@ -302,6 +337,12 @@ deploy_services_helm() {
     helm upgrade --install floe-platform "${PROJECT_ROOT}/charts/floe-platform" \
         --namespace "${NAMESPACE}" --create-namespace \
         --values "${PROJECT_ROOT}/charts/floe-platform/values-test.yaml" \
+        --set "dagster.dagsterWebserver.image.repository=${FLOE_DEMO_IMAGE_REPOSITORY}" \
+        --set "dagster.dagsterWebserver.image.tag=${FLOE_DEMO_IMAGE_TAG}" \
+        --set "dagster.dagsterDaemon.image.repository=${FLOE_DEMO_IMAGE_REPOSITORY}" \
+        --set "dagster.dagsterDaemon.image.tag=${FLOE_DEMO_IMAGE_TAG}" \
+        --set "dagster.runLauncher.config.k8sRunLauncher.image.repository=${FLOE_DEMO_IMAGE_REPOSITORY}" \
+        --set "dagster.runLauncher.config.k8sRunLauncher.image.tag=${FLOE_DEMO_IMAGE_TAG}" \
         --wait \
         --timeout 10m
 
@@ -497,6 +538,8 @@ render_flux_manifests() {
         -e "s|branch: main|branch: ${flux_git_branch}|" \
         "${rendered_dir}/gitrepository.yaml"
     rm -f "${rendered_dir}/gitrepository.yaml.bak"
+
+    inject_demo_image_values "${rendered_dir}/helmrelease-platform.yaml"
 
     printf '%s\n' "${rendered_dir}"
 }

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -21,8 +21,21 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WEEKLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "weekly.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+UV_SECURITY_ACTION = REPO_ROOT / ".github" / "actions" / "uv-security-audit" / "action.yml"
+PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+SETUP_HOOKS = REPO_ROOT / "scripts" / "setup-hooks.sh"
 CUBE_STORE_DOCKERFILE = REPO_ROOT / "docker" / "cube-store" / "Dockerfile"
 VALUES_TEST = REPO_ROOT / "charts" / "floe-platform" / "values-test.yaml"
+
+
+def _local_pre_commit_hooks() -> dict[str, dict[str, object]]:
+    config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text())
+    hooks: dict[str, dict[str, object]] = {}
+    for repo in config["repos"]:
+        if repo["repo"] == "local":
+            hooks.update({hook["id"]: hook for hook in repo["hooks"]})
+    return hooks
 
 
 class TestWeeklyWorkflow:
@@ -257,6 +270,60 @@ class TestValuesTestJobs:
             "values-test.yaml must keep tests.enabled=false so chart test Jobs "
             "remain opt-in via testing/ci/common.sh rendering."
         )
+
+
+class TestLocalHookAlignment:
+    """Structural validation for local pre-push and CI alignment."""
+
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_pre_push_runs_ruff_format_check(self) -> None:
+        """Local pre-push must catch the same Ruff formatting failure as CI."""
+        hooks = _local_pre_commit_hooks()
+
+        assert hooks["ruff-format-check"]["entry"] == "uv run --no-sync ruff format --check ."
+        assert hooks["ruff-format-check"]["stages"] == ["pre-push"]
+
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_mutating_file_hygiene_hooks_are_pre_commit_only(self) -> None:
+        """Auto-fix hygiene hooks should not mutate files during pre-push."""
+        config = yaml.safe_load(PRE_COMMIT_CONFIG.read_text())
+        hygiene_repo = next(
+            repo
+            for repo in config["repos"]
+            if repo["repo"] == "https://github.com/pre-commit/pre-commit-hooks"
+        )
+
+        for hook in hygiene_repo["hooks"]:
+            assert hook["stages"] == ["pre-commit"], f"{hook['id']} should not run during pre-push"
+
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_pre_push_reuses_ci_scripts_for_shared_gates(self) -> None:
+        """Local pre-push should call the same reusable scripts as CI."""
+        hooks = _local_pre_commit_hooks()
+
+        assert hooks["dbt-version-contracts"]["entry"] == (
+            "./testing/ci/validate-dbt-version-requirements.sh"
+        )
+        assert hooks["uv-secure"]["entry"] == "./testing/ci/uv-security-audit.sh"
+        assert hooks["pytest-unit"]["entry"] == "./testing/ci/test-unit.sh"
+        assert hooks["pytest-contract"]["entry"] == "./testing/ci/test-contract.sh"
+
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_ci_reuses_local_hook_scripts_for_shared_gates(self) -> None:
+        """CI should invoke the same scripts used by local pre-push."""
+        ci_text = CI_WORKFLOW.read_text()
+        action_text = UV_SECURITY_ACTION.read_text()
+
+        assert "./testing/ci/validate-dbt-version-requirements.sh" in ci_text
+        assert "./testing/ci/uv-security-audit.sh" in action_text
+
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_setup_hooks_overrides_global_hooks_path_locally(self) -> None:
+        """Hook setup should make repo-local hooks win over global hook managers."""
+        setup_text = SETUP_HOOKS.read_text()
+
+        assert "git config --local core.hooksPath" in setup_text
+        assert "git config --global --get core.hooksPath" in setup_text
 
 
 class TestCubeStoreRollbackPath:

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1277,8 +1277,7 @@ class TestMakefileBuildDemoImage:
             "for docker build and kind load."
         )
         assert "resolve-demo-image-ref.py" in content, (
-            "Makefile must derive the demo image tag from testing/ci/"
-            "resolve-demo-image-ref.py."
+            "Makefile must derive the demo image tag from testing/ci/resolve-demo-image-ref.py."
         )
 
 

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1262,6 +1262,25 @@ class TestMakefileBuildDemoImage:
             f"build-demo-image must depend on compile-demo. Found prerequisites: {prereqs}"
         )
 
+    @pytest.mark.requirement("WU11-AC6")
+    def test_build_demo_image_uses_explicit_demo_image_ref_variable(self) -> None:
+        """Verify build-demo-image tags and loads the shared demo image ref.
+
+        The Makefile should not hardcode ``floe-dagster-demo:latest`` in the
+        recipe body anymore. It should use the shared image-ref variables so
+        build, Kind load, and deploy flows stay aligned.
+        """
+        content = _read_makefile_content()
+        body = _extract_target_body(content, "build-demo-image")
+        assert "$(DEMO_IMAGE_REF)" in body, (
+            "build-demo-image must use the shared $(DEMO_IMAGE_REF) variable "
+            "for docker build and kind load."
+        )
+        assert "resolve-demo-image-ref.py" in content, (
+            "Makefile must derive the demo image tag from testing/ci/"
+            "resolve-demo-image-ref.py."
+        )
+
 
 # ============================================================
 # T62: Makefile Demo Chain Tests (AC-11.6)
@@ -1354,6 +1373,28 @@ class TestMakefileDemoChain:
             f"demo target must still deploy via Helm (upgrade/install) or "
             f"'floe platform deploy'. Recipe body:\n{body}"
         )
+
+    @pytest.mark.requirement("WU11-AC6")
+    def test_repo_owned_deploy_targets_pass_demo_image_override(self) -> None:
+        """Repo-owned deploy targets must pass the shared demo image override.
+
+        This keeps local/test/demo deploys on the same explicit image ref that
+        ``build-demo-image`` produced, instead of falling back to a mutable tag
+        baked into values files.
+        """
+        content = _read_makefile_content()
+        for target in (
+            "helm-install-dev",
+            "helm-install-test",
+            "helm-upgrade-test",
+            "demo",
+            "demo-local",
+        ):
+            body = _extract_target_body(content, target)
+            assert "$(DEMO_IMAGE_HELM_SET_ARGS)" in body, (
+                f"{target} must pass $(DEMO_IMAGE_HELM_SET_ARGS) so the chart "
+                "deploys the explicit demo image ref."
+            )
 
 
 # ============================================================

--- a/testing/tests/unit/test_polaris_fixture.py
+++ b/testing/tests/unit/test_polaris_fixture.py
@@ -12,8 +12,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import SecretStr, ValidationError
 
-from testing.fixtures.credentials import get_minio_credentials
-from testing.fixtures.credentials import get_polaris_scope, get_polaris_warehouse
+from testing.fixtures.credentials import (
+    get_minio_credentials,
+    get_polaris_scope,
+    get_polaris_warehouse,
+)
 from testing.fixtures.polaris import (
     PolarisConfig,
     PolarisConnectionError,

--- a/testing/tests/unit/test_polaris_fixture.py
+++ b/testing/tests/unit/test_polaris_fixture.py
@@ -13,6 +13,7 @@ import pytest
 from pydantic import SecretStr, ValidationError
 
 from testing.fixtures.credentials import get_minio_credentials
+from testing.fixtures.credentials import get_polaris_scope, get_polaris_warehouse
 from testing.fixtures.polaris import (
     PolarisConfig,
     PolarisConnectionError,
@@ -31,8 +32,8 @@ class TestPolarisConfig:
         """Test default configuration values."""
         config = PolarisConfig()
         assert config.uri == f"{ServiceEndpoint('polaris').url}/api/catalog"
-        assert config.warehouse == "test_warehouse"
-        assert config.scope == "PRINCIPAL_ROLE:ALL"
+        assert config.warehouse == get_polaris_warehouse()
+        assert config.scope == get_polaris_scope()
         assert config.namespace == "floe-test"
 
     @pytest.mark.requirement("9c-FR-012")

--- a/testing/tests/unit/test_polaris_manifest_settings.py
+++ b/testing/tests/unit/test_polaris_manifest_settings.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from testing.fixtures.credentials import (
+    get_polaris_credentials,
     get_polaris_scope,
     get_polaris_warehouse,
     resolve_manifest_path,
@@ -22,15 +23,16 @@ def _write_manifest(path: Path, content: dict[str, object]) -> Path:
 
 
 def _make_manifest(tmp_path: Path, *, warehouse: str, scope: str | None) -> Path:
+    client_id, client_secret = get_polaris_credentials()
     oauth2: dict[str, str] = {
-        "client_id": "demo-admin",
-        "client_secret": "demo-secret",
+        "client_id": client_id,
+        "client_secret": client_secret,
         "token_url": "http://floe-platform-polaris:8181/api/catalog/v1/oauth/tokens",
     }
     if scope is not None:
         oauth2["scope"] = scope
 
-    manifest = {
+    manifest: dict[str, object] = {
         "plugins": {
             "catalog": {
                 "type": "polaris",

--- a/testing/tests/unit/test_polaris_manifest_settings.py
+++ b/testing/tests/unit/test_polaris_manifest_settings.py
@@ -13,6 +13,8 @@ from testing.fixtures.credentials import (
     resolve_manifest_path,
 )
 
+pytestmark = pytest.mark.requirement("VAL-MANIFEST-CONFIG")
+
 
 def _write_manifest(path: Path, content: dict[str, object]) -> Path:
     path.write_text(yaml.dump(content, default_flow_style=False))
@@ -47,12 +49,14 @@ class TestGetPolarisWarehouse:
     """Tests for get_polaris_warehouse()."""
 
     def test_reads_manifest_value(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Manifest warehouse values should feed the shared helper."""
         monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
         manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="CUSTOM_SCOPE")
 
         assert get_polaris_warehouse(manifest_path=manifest) == "custom-warehouse"
 
     def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Explicit environment configuration should override the manifest."""
         monkeypatch.setenv("POLARIS_WAREHOUSE", "env-warehouse")
         manifest = _make_manifest(tmp_path, warehouse="manifest-warehouse", scope="CUSTOM_SCOPE")
 
@@ -61,6 +65,7 @@ class TestGetPolarisWarehouse:
     def test_missing_manifest_uses_demo_default(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        """Missing manifests should fall back to the canonical demo warehouse."""
         monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
 
         assert get_polaris_warehouse(manifest_path=tmp_path / "missing.yaml") == "floe-demo"
@@ -68,7 +73,12 @@ class TestGetPolarisWarehouse:
     def test_manifest_path_resolves_from_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        manifest = _make_manifest(tmp_path, warehouse="env-manifest-warehouse", scope="CUSTOM_SCOPE")
+        """The shared manifest path env var should drive warehouse resolution."""
+        manifest = _make_manifest(
+            tmp_path,
+            warehouse="env-manifest-warehouse",
+            scope="CUSTOM_SCOPE",
+        )
         monkeypatch.setenv("FLOE_MANIFEST_PATH", str(manifest))
         monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
 
@@ -80,12 +90,14 @@ class TestGetPolarisScope:
     """Tests for get_polaris_scope()."""
 
     def test_reads_manifest_value(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Manifest scope values should feed the shared helper."""
         monkeypatch.delenv("POLARIS_SCOPE", raising=False)
         manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="CUSTOM_SCOPE")
 
         assert get_polaris_scope(manifest_path=manifest) == "CUSTOM_SCOPE"
 
     def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Explicit environment scope should override the manifest value."""
         monkeypatch.setenv("POLARIS_SCOPE", "ENV_SCOPE")
         manifest = _make_manifest(tmp_path, warehouse="manifest-warehouse", scope="MANIFEST_SCOPE")
 
@@ -94,6 +106,7 @@ class TestGetPolarisScope:
     def test_missing_scope_uses_demo_default(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        """Missing manifest scope should fall back to the canonical demo scope."""
         monkeypatch.delenv("POLARIS_SCOPE", raising=False)
         manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope=None)
 
@@ -102,7 +115,12 @@ class TestGetPolarisScope:
     def test_scope_reads_from_manifest_path_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="ENV_MANIFEST_SCOPE")
+        """The shared manifest path env var should drive scope resolution."""
+        manifest = _make_manifest(
+            tmp_path,
+            warehouse="custom-warehouse",
+            scope="ENV_MANIFEST_SCOPE",
+        )
         monkeypatch.setenv("FLOE_MANIFEST_PATH", str(manifest))
         monkeypatch.delenv("POLARIS_SCOPE", raising=False)
 

--- a/testing/tests/unit/test_polaris_manifest_settings.py
+++ b/testing/tests/unit/test_polaris_manifest_settings.py
@@ -1,0 +1,109 @@
+"""Unit tests for manifest-derived Polaris warehouse and scope helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from testing.fixtures.credentials import (
+    get_polaris_scope,
+    get_polaris_warehouse,
+    resolve_manifest_path,
+)
+
+
+def _write_manifest(path: Path, content: dict[str, object]) -> Path:
+    path.write_text(yaml.dump(content, default_flow_style=False))
+    return path
+
+
+def _make_manifest(tmp_path: Path, *, warehouse: str, scope: str | None) -> Path:
+    oauth2: dict[str, str] = {
+        "client_id": "demo-admin",
+        "client_secret": "demo-secret",
+        "token_url": "http://floe-platform-polaris:8181/api/catalog/v1/oauth/tokens",
+    }
+    if scope is not None:
+        oauth2["scope"] = scope
+
+    manifest = {
+        "plugins": {
+            "catalog": {
+                "type": "polaris",
+                "config": {
+                    "uri": "http://floe-platform-polaris:8181/api/catalog",
+                    "warehouse": warehouse,
+                    "oauth2": oauth2,
+                },
+            }
+        }
+    }
+    return _write_manifest(tmp_path / "manifest.yaml", manifest)
+
+
+class TestGetPolarisWarehouse:
+    """Tests for get_polaris_warehouse()."""
+
+    def test_reads_manifest_value(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
+        manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="CUSTOM_SCOPE")
+
+        assert get_polaris_warehouse(manifest_path=manifest) == "custom-warehouse"
+
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("POLARIS_WAREHOUSE", "env-warehouse")
+        manifest = _make_manifest(tmp_path, warehouse="manifest-warehouse", scope="CUSTOM_SCOPE")
+
+        assert get_polaris_warehouse(manifest_path=manifest) == "env-warehouse"
+
+    def test_missing_manifest_uses_demo_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
+
+        assert get_polaris_warehouse(manifest_path=tmp_path / "missing.yaml") == "floe-demo"
+
+    def test_manifest_path_resolves_from_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        manifest = _make_manifest(tmp_path, warehouse="env-manifest-warehouse", scope="CUSTOM_SCOPE")
+        monkeypatch.setenv("FLOE_MANIFEST_PATH", str(manifest))
+        monkeypatch.delenv("POLARIS_WAREHOUSE", raising=False)
+
+        assert resolve_manifest_path() == manifest
+        assert get_polaris_warehouse() == "env-manifest-warehouse"
+
+
+class TestGetPolarisScope:
+    """Tests for get_polaris_scope()."""
+
+    def test_reads_manifest_value(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.delenv("POLARIS_SCOPE", raising=False)
+        manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="CUSTOM_SCOPE")
+
+        assert get_polaris_scope(manifest_path=manifest) == "CUSTOM_SCOPE"
+
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setenv("POLARIS_SCOPE", "ENV_SCOPE")
+        manifest = _make_manifest(tmp_path, warehouse="manifest-warehouse", scope="MANIFEST_SCOPE")
+
+        assert get_polaris_scope(manifest_path=manifest) == "ENV_SCOPE"
+
+    def test_missing_scope_uses_demo_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("POLARIS_SCOPE", raising=False)
+        manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope=None)
+
+        assert get_polaris_scope(manifest_path=manifest) == "PRINCIPAL_ROLE:ALL"
+
+    def test_scope_reads_from_manifest_path_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        manifest = _make_manifest(tmp_path, warehouse="custom-warehouse", scope="ENV_MANIFEST_SCOPE")
+        monkeypatch.setenv("FLOE_MANIFEST_PATH", str(manifest))
+        monkeypatch.delenv("POLARIS_SCOPE", raising=False)
+
+        assert get_polaris_scope() == "ENV_MANIFEST_SCOPE"

--- a/tests/contract/test_demo_platform_catalog_contract.py
+++ b/tests/contract/test_demo_platform_catalog_contract.py
@@ -1,16 +1,22 @@
-"""Contract tests for demo manifest and test/demo chart catalog alignment."""
+"""Contract tests for demo manifest and chart catalog alignment."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEMO_MANIFEST = REPO_ROOT / "demo" / "manifest.yaml"
 VALUES_DEMO = REPO_ROOT / "charts" / "floe-platform" / "values-demo.yaml"
 VALUES_TEST = REPO_ROOT / "charts" / "floe-platform" / "values-test.yaml"
+
+pytestmark = [
+    pytest.mark.contract,
+    pytest.mark.requirement("VAL-MANIFEST-CONTRACT"),
+]
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -56,8 +62,10 @@ def _assert_bootstrap_alignment(values_path: Path) -> None:
 
 
 def test_values_demo_aligns_with_demo_manifest_catalog_contract() -> None:
+    """Demo chart values should stay aligned with the demo manifest contract."""
     _assert_bootstrap_alignment(VALUES_DEMO)
 
 
 def test_values_test_aligns_with_demo_manifest_catalog_contract() -> None:
+    """Test chart values should stay aligned with the demo manifest contract."""
     _assert_bootstrap_alignment(VALUES_TEST)

--- a/tests/contract/test_demo_platform_catalog_contract.py
+++ b/tests/contract/test_demo_platform_catalog_contract.py
@@ -26,11 +26,15 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
 
 def _manifest_catalog_config() -> dict[str, Any]:
-    return _load_yaml(DEMO_MANIFEST)["plugins"]["catalog"]["config"]
+    config = _load_yaml(DEMO_MANIFEST)["plugins"]["catalog"]["config"]
+    assert isinstance(config, dict)
+    return config
 
 
 def _manifest_storage_config() -> dict[str, Any]:
-    return _load_yaml(DEMO_MANIFEST)["plugins"]["storage"]["config"]
+    config = _load_yaml(DEMO_MANIFEST)["plugins"]["storage"]["config"]
+    assert isinstance(config, dict)
+    return config
 
 
 def _assert_bootstrap_alignment(values_path: Path) -> None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -109,6 +109,18 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "destructive: mark test as destructive (helm upgrade, pod kill — requires elevated RBAC)",
     )
+    config.addinivalue_line(
+        "markers",
+        "bootstrap: mark test as bootstrap/admin validation",
+    )
+    config.addinivalue_line(
+        "markers",
+        "platform_blackbox: mark test as deployed in-cluster product validation",
+    )
+    config.addinivalue_line(
+        "markers",
+        "developer_workflow: mark test as repo-aware host validation",
+    )
 
     # Configure pytest-rerunfailures for E2E infrastructure resilience.
     # Scoped to E2E conftest so unit/contract/integration tests are unaffected.
@@ -148,6 +160,20 @@ def pytest_collection_modifyitems(
     import inspect
     import re
     import warnings
+
+    lane_markers = {
+        "bootstrap",
+        "platform_blackbox",
+        "developer_workflow",
+        "destructive",
+    }
+
+    for item in items:
+        item_markers = {mark.name for mark in item.iter_markers()}
+        if "e2e" not in item_markers:
+            continue
+        if item_markers.isdisjoint(lane_markers):
+            item.add_marker(pytest.mark.platform_blackbox)
 
     # Reorder: move destructive (pod-killing) tests to the end
     destructive_module = "test_service_failure_resilience_e2e"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -39,6 +39,18 @@ from testing.fixtures.services import ServiceEndpoint, get_effective_port
 logger = logging.getLogger(__name__)
 
 
+def _read_manifest_config(manifest_path: Path | None = None) -> dict[str, str]:
+    """Read Polaris config defaults from the selected manifest path."""
+    resolved_manifest = resolve_manifest_path(manifest_path)
+    client_id, client_secret = get_polaris_credentials(resolved_manifest)
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,  # pragma: allowlist secret
+        "scope": get_polaris_scope(resolved_manifest),
+        "warehouse": get_polaris_warehouse(resolved_manifest),
+    }
+
+
 _MANIFEST_PATH = resolve_manifest_path()
 _manifest_scope: str = get_polaris_scope(_MANIFEST_PATH)
 _manifest_warehouse: str = get_polaris_warehouse(_MANIFEST_PATH)
@@ -54,7 +66,9 @@ def _resolve_polaris_credential(
     """
     credential = os.environ.get("POLARIS_CREDENTIAL")
     if credential is None:
-        client_id, client_secret = get_polaris_credentials(resolve_manifest_path(manifest_path))
+        manifest_config = _read_manifest_config(manifest_path)
+        client_id = manifest_config["client_id"]
+        client_secret = manifest_config["client_secret"]
         credential = f"{client_id}:{client_secret}"  # pragma: allowlist secret
         return credential, client_id, client_secret
 
@@ -1284,7 +1298,6 @@ _DBT_DEMO_PRODUCTS: dict[str, str] = {
 
 def _build_dbt_iceberg_profile(
     profile_name: str,
-    warehouse: str,
 ) -> str:
     """Build a dbt profiles.yml string for DuckDB + Iceberg via Polaris.
 
@@ -1300,12 +1313,12 @@ def _build_dbt_iceberg_profile(
     Referenced env vars (set by ``dbt_e2e_profile`` fixture):
         FLOE_E2E_POLARIS_ENDPOINT, FLOE_E2E_POLARIS_CLIENT_ID,
         FLOE_E2E_POLARIS_CLIENT_SECRET, FLOE_E2E_POLARIS_OAUTH2_URI,
+        FLOE_E2E_POLARIS_SCOPE, FLOE_E2E_POLARIS_WAREHOUSE,
         FLOE_E2E_S3_ENDPOINT, FLOE_E2E_S3_USE_SSL,
         AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION.
 
     Args:
         profile_name: dbt profile name (must match dbt_project.yml ``profile`` key).
-        warehouse: Polaris warehouse/catalog name (e.g. ``floe-e2e``).
 
     Returns:
         YAML string suitable for writing to ``profiles.yml``.
@@ -1326,7 +1339,7 @@ def _build_dbt_iceberg_profile(
         f"        - httpfs\n"
         f"        - iceberg\n"
         f"      attach:\n"
-        f"        - path: {warehouse}\n"
+        "        - path: \"{{ env_var('FLOE_E2E_POLARIS_WAREHOUSE') }}\"\n"
         f"          alias: ice\n"
         f"          type: iceberg\n"
         f"          options:\n"
@@ -1334,7 +1347,7 @@ def _build_dbt_iceberg_profile(
         "            CLIENT_ID: \"{{ env_var('FLOE_E2E_POLARIS_CLIENT_ID') }}\"\n"
         "            CLIENT_SECRET: \"{{ env_var('FLOE_E2E_POLARIS_CLIENT_SECRET') }}\"\n"
         "            OAUTH2_SERVER_URI: \"{{ env_var('FLOE_E2E_POLARIS_OAUTH2_URI') }}\"\n"
-        f"            OAUTH2_SCOPE: {_manifest_scope}\n"
+        "            OAUTH2_SCOPE: \"{{ env_var('FLOE_E2E_POLARIS_SCOPE') }}\"\n"
         f"            OAUTH2_GRANT_TYPE: client_credentials\n"
         f"            ACCESS_DELEGATION_MODE: none\n"
         f"      secrets:\n"
@@ -1377,6 +1390,7 @@ def dbt_e2e_profile(
     polaris_url = os.environ.get("POLARIS_URL", ServiceEndpoint("polaris").url)
     minio_url = os.environ.get("MINIO_URL", ServiceEndpoint("minio").url)
     _, client_id, client_secret = _resolve_polaris_credential()
+    scope = os.environ.get("POLARIS_SCOPE", _manifest_scope)
     warehouse = os.environ.get("POLARIS_WAREHOUSE", _manifest_warehouse)
 
     # Derive computed values
@@ -1391,6 +1405,8 @@ def dbt_e2e_profile(
         "FLOE_E2E_POLARIS_CLIENT_ID": client_id,
         "FLOE_E2E_POLARIS_CLIENT_SECRET": client_secret,
         "FLOE_E2E_POLARIS_OAUTH2_URI": f"{polaris_url}/api/catalog/v1/oauth/tokens",
+        "FLOE_E2E_POLARIS_SCOPE": scope,
+        "FLOE_E2E_POLARIS_WAREHOUSE": warehouse,
         "FLOE_E2E_S3_ENDPOINT": s3_endpoint,
         "FLOE_E2E_S3_USE_SSL": str(s3_use_ssl).lower(),
     }
@@ -1484,7 +1500,6 @@ def dbt_e2e_profile(
             # Write E2E profile (credentials via env_var, not plaintext)
             e2e_content = _build_dbt_iceberg_profile(
                 profile_name=profile_name,
-                warehouse=warehouse,
             )
             profile_path.write_text(e2e_content)  # codeql[py/clear-text-storage-sensitive-data]
             profile_paths[product_dir] = profile_path

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -152,8 +152,12 @@ def pytest_collection_modifyitems(
 
     for item in items:
         item_markers = {mark.name for mark in item.iter_markers()}
-        if "e2e" not in item_markers:
+        is_e2e_item = "e2e" in item_markers or item.nodeid.startswith("tests/e2e/")
+        if not is_e2e_item:
             continue
+        if "e2e" not in item_markers:
+            item.add_marker(pytest.mark.e2e)
+            item_markers.add("e2e")
         if item_markers.isdisjoint(lane_markers):
             item.add_marker(pytest.mark.platform_blackbox)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1587,7 +1587,7 @@ def dbt_pipeline_result(
     Yields:
         Tuple of ``(product, project_dir)`` for the parametrized product.
     """
-    from dbt_utils import NamespaceResetError, _purge_iceberg_namespace, run_dbt
+    from dbt_utils import _purge_iceberg_namespace, run_dbt
 
     product: str = request.param
     project_dir = project_root / "demo" / product
@@ -1622,17 +1622,17 @@ def dbt_pipeline_result(
         raise
     finally:
         # Clean up Iceberg namespaces to prevent resource leaks
-        teardown_error: NamespaceResetError | None = None
+        teardown_error: Exception | None = None
         for namespace in (namespace_raw, namespace_models):
             try:
                 _purge_iceberg_namespace(namespace, verify_empty=True)
-            except NamespaceResetError as exc:
+            except Exception as exc:
                 if primary_error is None:
                     if teardown_error is None:
                         teardown_error = exc
                     continue
                 logger.error(
-                    "Suppressed teardown namespace reset failure for %s after primary "
+                    "Suppressed teardown reset failure for %s after primary "
                     "dbt/test failure: %s",
                     namespace,
                     exc,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,7 +22,6 @@ from typing import Any
 
 import httpx
 import pytest
-import yaml
 
 # Re-exported for backwards compatibility — other E2E files import from here.
 from testing.fixtures.credentials import (
@@ -40,67 +39,34 @@ from testing.fixtures.services import ServiceEndpoint, get_effective_port
 logger = logging.getLogger(__name__)
 
 
-def _read_manifest_config(manifest_path: Path | None = None) -> dict[str, str]:
-    """Read Polaris config from the selected manifest path.
+_MANIFEST_PATH = resolve_manifest_path()
+_manifest_scope: str = get_polaris_scope(_MANIFEST_PATH)
+_manifest_warehouse: str = get_polaris_warehouse(_MANIFEST_PATH)
 
-    Extracts ``plugins.catalog.config`` fields so that test fixtures do not
-    carry hardcoded defaults that diverge from the canonical platform config.
 
-    Credentials (``client_id``, ``client_secret``) are returned alongside
-    non-secret config (``scope``, ``warehouse``).
+def _resolve_polaris_credential(
+    manifest_path: Path | None = None,
+) -> tuple[str, str, str]:
+    """Return the Polaris credential string and split client values.
 
-    Args:
-        manifest_path: Explicit path to manifest.yaml. Defaults to the shared
-            manifest resolver (explicit arg, ``FLOE_MANIFEST_PATH``, then repo
-            demo manifest).
-
-    Returns:
-        Dict with keys ``client_id``, ``client_secret``, ``scope``, and
-        ``warehouse``.  Falls back to hardcoded demo values with a warning
-        when the manifest file cannot be found.
+    Resolves the default credential lazily so non-secret manifest defaults can
+    be cached at module import without tainting unrelated values.
     """
-    manifest_path = resolve_manifest_path(manifest_path)
-    _polaris_id, _polaris_secret = get_polaris_credentials(manifest_path)
-    _fallback: dict[str, str] = {
-        "client_id": _polaris_id,
-        "client_secret": _polaris_secret,  # pragma: allowlist secret
-        "scope": get_polaris_scope(manifest_path),
-        "warehouse": get_polaris_warehouse(manifest_path),
-    }
+    credential = os.environ.get("POLARIS_CREDENTIAL")
+    if credential is None:
+        client_id, client_secret = get_polaris_credentials(resolve_manifest_path(manifest_path))
+        credential = f"{client_id}:{client_secret}"  # pragma: allowlist secret
+        return credential, client_id, client_secret
 
-    if not manifest_path.exists():
-        warnings.warn(
-            f"Manifest not found at {manifest_path}; using hardcoded fallback values "
-            "for Polaris credentials and warehouse.",
-            stacklevel=2,
+    parts = credential.split(":", 1)
+    if len(parts) != 2:
+        pytest.fail(
+            "POLARIS_CREDENTIAL must be 'client_id:client_secret'; "
+            f"got a value with {len(credential)} characters and no ':' separator"
         )
-        return _fallback
 
-    raw: dict[str, Any] = yaml.safe_load(manifest_path.read_text())
-    catalog_cfg: dict[str, Any] = raw.get("plugins", {}).get("catalog", {}).get("config", {})
-    oauth2: dict[str, Any] = catalog_cfg.get("oauth2", {})
-
-    return {
-        "client_id": str(oauth2.get("client_id", _fallback["client_id"])),
-        "client_secret": str(
-            oauth2.get("client_secret", _fallback["client_secret"])
-        ),  # pragma: allowlist secret
-        "scope": str(catalog_cfg.get("scope", oauth2.get("scope", _fallback["scope"]))),
-        "warehouse": str(catalog_cfg.get("warehouse", _fallback["warehouse"])),
-    }
-
-
-_manifest_cfg: dict[str, str] = _read_manifest_config()
-
-# Separate credential string from non-secret config to break CodeQL taint
-# propagation.  CodeQL tracks _manifest_cfg as sensitive because it contains
-# client_secret; splitting ensures downstream code that only uses scope or
-# warehouse is not flagged as "clear-text logging of sensitive data".
-_manifest_credential: str = (  # pragma: allowlist secret
-    f"{_manifest_cfg['client_id']}:{_manifest_cfg['client_secret']}"
-)
-_manifest_scope: str = _manifest_cfg["scope"]
-_manifest_warehouse: str = _manifest_cfg["warehouse"]
+    client_id, client_secret = parts
+    return credential, client_id, client_secret
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -162,9 +128,6 @@ def pytest_collection_modifyitems(
         items: List of collected test items.
     """
     import inspect
-    import re
-    import warnings
-
     lane_markers = {
         "bootstrap",
         "platform_blackbox",
@@ -700,12 +663,13 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
     # Demo credentials for local testing only - production uses K8s secrets
     minio_url = os.environ.get("MINIO_URL", ServiceEndpoint("minio").url)
     _minio_access, _minio_secret = get_minio_credentials()
+    polaris_credential, client_id, client_secret = _resolve_polaris_credential()
     catalog = pyiceberg_catalog.load_catalog(
         "polaris",
         **{
             "type": "rest",
             "uri": f"{polaris_url}/api/catalog",
-            "credential": os.environ.get("POLARIS_CREDENTIAL", _manifest_credential),
+            "credential": polaris_credential,
             "scope": _manifest_scope,
             "warehouse": os.environ.get("POLARIS_WAREHOUSE", _manifest_warehouse),
             "s3.endpoint": minio_url,
@@ -727,8 +691,6 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
     # bootstrap job's 5-step grant process: create principal role, assign
     # principal role to root, create catalog role, grant privilege,
     # assign catalog role to principal role.
-    cred = os.environ.get("POLARIS_CREDENTIAL", _manifest_credential)
-    client_id, client_secret = cred.split(":", 1)
     token_response = httpx.post(
         f"{polaris_url}/api/catalog/v1/oauth/tokens",
         data={
@@ -1414,14 +1376,7 @@ def dbt_e2e_profile(
     # so credentials are resolved at runtime, never written to disk.
     polaris_url = os.environ.get("POLARIS_URL", ServiceEndpoint("polaris").url)
     minio_url = os.environ.get("MINIO_URL", ServiceEndpoint("minio").url)
-    cred = os.environ.get("POLARIS_CREDENTIAL", _manifest_credential)
-    parts = cred.split(":", 1)
-    if len(parts) != 2:
-        pytest.fail(
-            "POLARIS_CREDENTIAL must be 'client_id:client_secret'; "
-            f"got a value with {len(cred)} characters and no ':' separator"
-        )
-    client_id, client_secret = parts
+    _, client_id, client_secret = _resolve_polaris_credential()
     warehouse = os.environ.get("POLARIS_WAREHOUSE", _manifest_warehouse)
 
     # Derive computed values

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1622,15 +1622,20 @@ def dbt_pipeline_result(
         raise
     finally:
         # Clean up Iceberg namespaces to prevent resource leaks
+        teardown_error: NamespaceResetError | None = None
         for namespace in (namespace_raw, namespace_models):
             try:
                 _purge_iceberg_namespace(namespace, verify_empty=True)
             except NamespaceResetError as exc:
                 if primary_error is None:
-                    raise
+                    if teardown_error is None:
+                        teardown_error = exc
+                    continue
                 logger.error(
                     "Suppressed teardown namespace reset failure for %s after primary "
                     "dbt/test failure: %s",
                     namespace,
                     exc,
                 )
+        if primary_error is None and teardown_error is not None:
+            raise teardown_error

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -250,8 +250,22 @@ def pytest_collection_modifyitems(
         print("=" * 70)
 
 
+def _selected_items_require_infrastructure_smoke_check(items: list[pytest.Item]) -> bool:
+    """Return whether the selected session needs live platform smoke checks.
+
+    The smoke check is only relevant when the selected items include tests in
+    lanes that require deployed platform connectivity.
+    """
+    required_markers = {"platform_blackbox", "destructive"}
+    for item in items:
+        item_markers = {mark.name for mark in item.iter_markers()}
+        if not item_markers.isdisjoint(required_markers):
+            return True
+    return False
+
+
 @pytest.fixture(scope="session", autouse=True)
-def infrastructure_smoke_check() -> None:
+def infrastructure_smoke_check(request: pytest.FixtureRequest) -> None:
     """Abort test session if core infrastructure is unreachable.
 
     Checks TCP connectivity to Dagster, Polaris, and MinIO before any
@@ -259,6 +273,9 @@ def infrastructure_smoke_check() -> None:
     the session with a clear message instead of producing 72+ ERRORs.
     """
     import socket
+
+    if not _selected_items_require_infrastructure_smoke_check(request.session.items):
+        return
 
     smoke_endpoints = {
         "Dagster": ServiceEndpoint("dagster-webserver"),

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -25,7 +25,13 @@ import pytest
 import yaml
 
 # Re-exported for backwards compatibility — other E2E files import from here.
-from testing.fixtures.credentials import get_minio_credentials, get_polaris_credentials
+from testing.fixtures.credentials import (
+    get_minio_credentials,
+    get_polaris_credentials,
+    get_polaris_scope,
+    get_polaris_warehouse,
+    resolve_manifest_path,
+)
 from testing.fixtures.kubernetes import run_helm as run_helm
 from testing.fixtures.kubernetes import run_kubectl as run_kubectl
 from testing.fixtures.polling import wait_for_condition
@@ -35,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 def _read_manifest_config(manifest_path: Path | None = None) -> dict[str, str]:
-    """Read Polaris config from the demo manifest.yaml.
+    """Read Polaris config from the selected manifest path.
 
     Extracts ``plugins.catalog.config`` fields so that test fixtures do not
     carry hardcoded defaults that diverge from the canonical platform config.
@@ -44,25 +50,23 @@ def _read_manifest_config(manifest_path: Path | None = None) -> dict[str, str]:
     non-secret config (``scope``, ``warehouse``).
 
     Args:
-        manifest_path: Explicit path to manifest.yaml.  Defaults to
-            ``<repo-root>/demo/manifest.yaml``.
+        manifest_path: Explicit path to manifest.yaml. Defaults to the shared
+            manifest resolver (explicit arg, ``FLOE_MANIFEST_PATH``, then repo
+            demo manifest).
 
     Returns:
         Dict with keys ``client_id``, ``client_secret``, ``scope``, and
         ``warehouse``.  Falls back to hardcoded demo values with a warning
         when the manifest file cannot be found.
     """
-    _default_scope = "PRINCIPAL_ROLE:ALL"
-    _polaris_id, _polaris_secret = get_polaris_credentials()
+    manifest_path = resolve_manifest_path(manifest_path)
+    _polaris_id, _polaris_secret = get_polaris_credentials(manifest_path)
     _fallback: dict[str, str] = {
         "client_id": _polaris_id,
         "client_secret": _polaris_secret,  # pragma: allowlist secret
-        "scope": _default_scope,
-        "warehouse": "floe-e2e",
+        "scope": get_polaris_scope(manifest_path),
+        "warehouse": get_polaris_warehouse(manifest_path),
     }
-
-    if manifest_path is None:
-        manifest_path = Path(__file__).resolve().parents[2] / "demo" / "manifest.yaml"
 
     if not manifest_path.exists():
         warnings.warn(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1602,8 +1602,8 @@ def dbt_pipeline_result(
 
     try:
         # Purge stale data from any prior run (P36: cleanup at setup)
-        _purge_iceberg_namespace(namespace_raw)
-        _purge_iceberg_namespace(namespace_models)
+        _purge_iceberg_namespace(namespace_raw, verify_empty=True)
+        _purge_iceberg_namespace(namespace_models, verify_empty=True)
 
         # Run dbt seed to load reference data
         seed_result = run_dbt(["seed"], project_dir)
@@ -1618,5 +1618,5 @@ def dbt_pipeline_result(
         yield (product, project_dir)
     finally:
         # Clean up Iceberg namespaces to prevent resource leaks
-        _purge_iceberg_namespace(namespace_raw)
-        _purge_iceberg_namespace(namespace_models)
+        _purge_iceberg_namespace(namespace_raw, verify_empty=True)
+        _purge_iceberg_namespace(namespace_models, verify_empty=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1587,7 +1587,7 @@ def dbt_pipeline_result(
     Yields:
         Tuple of ``(product, project_dir)`` for the parametrized product.
     """
-    from dbt_utils import _purge_iceberg_namespace, run_dbt
+    from dbt_utils import NamespaceResetError, _purge_iceberg_namespace, run_dbt
 
     product: str = request.param
     project_dir = project_root / "demo" / product
@@ -1599,6 +1599,7 @@ def dbt_pipeline_result(
     product_name = product.replace("-", "_")
     namespace_raw = f"{product_name}_raw"
     namespace_models = product_name
+    primary_error: BaseException | None = None
 
     try:
         # Purge stale data from any prior run (P36: cleanup at setup)
@@ -1616,7 +1617,20 @@ def dbt_pipeline_result(
             pytest.fail(f"dbt run failed for {product}:\n{run_result.stderr[-500:]}")
 
         yield (product, project_dir)
+    except BaseException as exc:
+        primary_error = exc
+        raise
     finally:
         # Clean up Iceberg namespaces to prevent resource leaks
-        _purge_iceberg_namespace(namespace_raw, verify_empty=True)
-        _purge_iceberg_namespace(namespace_models, verify_empty=True)
+        for namespace in (namespace_raw, namespace_models):
+            try:
+                _purge_iceberg_namespace(namespace, verify_empty=True)
+            except NamespaceResetError as exc:
+                if primary_error is None:
+                    raise
+                logger.error(
+                    "Suppressed teardown namespace reset failure for %s after primary "
+                    "dbt/test failure: %s",
+                    namespace,
+                    exc,
+                )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -142,6 +142,7 @@ def pytest_collection_modifyitems(
         items: List of collected test items.
     """
     import inspect
+
     lane_markers = {
         "bootstrap",
         "platform_blackbox",
@@ -1606,8 +1607,7 @@ def dbt_pipeline_result(
                         teardown_error = exc
                     continue
                 logger.error(
-                    "Suppressed teardown reset failure for %s after primary "
-                    "dbt/test failure: %s",
+                    "Suppressed teardown reset failure for %s after primary dbt/test failure: %s",
                     namespace,
                     exc,
                 )

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -59,10 +59,15 @@ def _get_polaris_catalog(*, fresh: bool = False) -> Any:
         _catalog_cache["catalog"] = None
         return None
 
-    polaris_url = os.environ.get("POLARIS_URI", f"{ServiceEndpoint('polaris').url}/api/catalog")
+    polaris_url = os.environ.get("POLARIS_URI")
+    if polaris_url is None:
+        polaris_url = f"{ServiceEndpoint('polaris').url}/api/catalog"
     _polaris_id, _polaris_secret = get_polaris_credentials()
     default_cred = f"{_polaris_id}:{_polaris_secret}"  # pragma: allowlist secret
     _minio_access, _minio_secret = get_minio_credentials()
+    minio_endpoint = os.environ.get("MINIO_ENDPOINT")
+    if minio_endpoint is None:
+        minio_endpoint = ServiceEndpoint("minio").url
 
     try:
         catalog = pyiceberg_catalog.load_catalog(
@@ -73,7 +78,7 @@ def _get_polaris_catalog(*, fresh: bool = False) -> Any:
                 "credential": os.environ.get("POLARIS_CREDENTIAL", default_cred),
                 "scope": "PRINCIPAL_ROLE:ALL",
                 "warehouse": os.environ.get("POLARIS_WAREHOUSE", "floe-e2e"),
-                "s3.endpoint": os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url),
+                "s3.endpoint": minio_endpoint,
                 "s3.access-key-id": os.environ.get(  # pragma: allowlist secret
                     "AWS_ACCESS_KEY_ID", _minio_access
                 ),
@@ -154,7 +159,9 @@ def _purge_iceberg_namespace(
     storage_cleanup_failure_reason: str | None = None
     if catalog is not None:
         # Collect S3 config from environment (same defaults as _get_polaris_catalog).
-        s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
+        s3_endpoint = os.environ.get("MINIO_ENDPOINT")
+        if s3_endpoint is None:
+            s3_endpoint = ServiceEndpoint("minio").url
         access_key, secret_key = get_minio_credentials()
 
         try:

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -58,18 +58,17 @@ def _get_polaris_catalog(*, fresh: bool = False) -> Any:
     except ImportError:
         _catalog_cache["catalog"] = None
         return None
-
-    polaris_url = os.environ.get("POLARIS_URI")
-    if polaris_url is None:
-        polaris_url = f"{ServiceEndpoint('polaris').url}/api/catalog"
     _polaris_id, _polaris_secret = get_polaris_credentials()
     default_cred = f"{_polaris_id}:{_polaris_secret}"  # pragma: allowlist secret
     _minio_access, _minio_secret = get_minio_credentials()
-    minio_endpoint = os.environ.get("MINIO_ENDPOINT")
-    if minio_endpoint is None:
-        minio_endpoint = ServiceEndpoint("minio").url
 
     try:
+        polaris_url = os.environ.get("POLARIS_URI")
+        if polaris_url is None:
+            polaris_url = f"{ServiceEndpoint('polaris').url}/api/catalog"
+        minio_endpoint = os.environ.get("MINIO_ENDPOINT")
+        if minio_endpoint is None:
+            minio_endpoint = ServiceEndpoint("minio").url
         catalog = pyiceberg_catalog.load_catalog(
             "polaris",
             **{
@@ -161,7 +160,20 @@ def _purge_iceberg_namespace(
         # Collect S3 config from environment (same defaults as _get_polaris_catalog).
         s3_endpoint = os.environ.get("MINIO_ENDPOINT")
         if s3_endpoint is None:
-            s3_endpoint = ServiceEndpoint("minio").url
+            try:
+                s3_endpoint = ServiceEndpoint("minio").url
+            except Exception as exc:
+                s3_endpoint = None
+                if verify_empty and storage_cleanup_failure_reason is None:
+                    storage_cleanup_failure_reason = (
+                        f"Could not resolve storage endpoint for cleanup in {namespace}: "
+                        f"{type(exc).__name__}"
+                    )
+                logger.warning(
+                    "Could not resolve storage endpoint for namespace %s cleanup: %s",
+                    namespace,
+                    type(exc).__name__,
+                )
         access_key, secret_key = get_minio_credentials()
 
         try:
@@ -195,6 +207,12 @@ def _purge_iceberg_namespace(
                 # Step 3: sweep S3 objects under the table's data prefix via boto3.
                 # boto3 handles AWS Signature V4 required by MinIO.
                 if location is not None:
+                    if s3_endpoint is None:
+                        logger.warning(
+                            "Skipping S3 cleanup for table %s: storage endpoint unavailable",
+                            fqn,
+                        )
+                        continue
                     try:
                         parsed = urlparse(location)
                         bucket: str = parsed.netloc

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -140,7 +140,7 @@ def _purge_iceberg_namespace(
         verify_empty: Whether to verify the namespace is empty after purge.
         retries: Number of verification attempts when ``verify_empty`` is true.
     """
-    catalog = _get_polaris_catalog()
+    catalog = _get_polaris_catalog(fresh=True)
     if catalog is not None:
         # Collect S3 config from environment (same defaults as _get_polaris_catalog).
         s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
@@ -217,16 +217,18 @@ def _purge_iceberg_namespace(
         return
 
     remaining: Any = []
+    failure_reason = "verification did not complete"
     for attempt in range(1, retries + 1):
         fresh_catalog = _get_polaris_catalog(fresh=True)
         if fresh_catalog is None:
+            failure_reason = "verification catalog unavailable"
             logger.warning(
                 "Could not verify namespace %s reset on attempt %d/%d: catalog unavailable",
                 namespace,
                 attempt,
                 retries,
             )
-            return
+            continue
 
         try:
             remaining = fresh_catalog.list_tables(namespace)
@@ -235,6 +237,7 @@ def _purge_iceberg_namespace(
                 exc, PyIcebergNoSuchNamespaceError
             ):
                 return
+            failure_reason = f"verification failed: {type(exc).__name__}"
             logger.warning(
                 "Could not verify namespace %s reset on attempt %d/%d: %s",
                 namespace,
@@ -242,11 +245,12 @@ def _purge_iceberg_namespace(
                 retries,
                 type(exc).__name__,
             )
-            return
+            continue
 
         if not remaining:
             return
 
+        failure_reason = f"remaining tables={remaining}"
         logger.warning(
             "Namespace %s still contains tables on attempt %d/%d: %s",
             namespace,
@@ -256,7 +260,7 @@ def _purge_iceberg_namespace(
         )
 
     raise NamespaceResetError(
-        f"Namespace reset incomplete for {namespace}: remaining tables={remaining}"
+        f"Namespace reset incomplete for {namespace}: {failure_reason}"
     )
 
 

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -141,6 +141,7 @@ def _purge_iceberg_namespace(
         retries: Number of verification attempts when ``verify_empty`` is true.
     """
     catalog = _get_polaris_catalog(fresh=True)
+    s3_cleanup_failure_reason: str | None = None
     if catalog is not None:
         # Collect S3 config from environment (same defaults as _get_polaris_catalog).
         s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
@@ -188,6 +189,10 @@ def _purge_iceberg_namespace(
                         deleted = _delete_s3_prefix(s3_client, bucket, prefix)
                         logger.info("Deleted %d S3 objects under %s", deleted, location)
                     except Exception as exc:
+                        if verify_empty and s3_cleanup_failure_reason is None:
+                            s3_cleanup_failure_reason = (
+                                f"S3 cleanup failed for {fqn}: {type(exc).__name__}"
+                            )
                         logger.warning(
                             "S3 cleanup failed for table %s: %s",
                             fqn,
@@ -217,6 +222,7 @@ def _purge_iceberg_namespace(
         return
 
     remaining: Any = []
+    verification_succeeded = False
     failure_reason = "verification did not complete"
     for attempt in range(1, retries + 1):
         fresh_catalog = _get_polaris_catalog(fresh=True)
@@ -236,7 +242,8 @@ def _purge_iceberg_namespace(
             if PyIcebergNoSuchNamespaceError is not None and isinstance(
                 exc, PyIcebergNoSuchNamespaceError
             ):
-                return
+                verification_succeeded = True
+                break
             failure_reason = f"verification failed: {type(exc).__name__}"
             logger.warning(
                 "Could not verify namespace %s reset on attempt %d/%d: %s",
@@ -248,7 +255,8 @@ def _purge_iceberg_namespace(
             continue
 
         if not remaining:
-            return
+            verification_succeeded = True
+            break
 
         failure_reason = f"remaining tables={remaining}"
         logger.warning(
@@ -258,6 +266,14 @@ def _purge_iceberg_namespace(
             retries,
             remaining,
         )
+
+    if s3_cleanup_failure_reason is not None:
+        raise NamespaceResetError(
+            f"Namespace reset incomplete for {namespace}: {s3_cleanup_failure_reason}"
+        )
+
+    if verification_succeeded:
+        return
 
     raise NamespaceResetError(
         f"Namespace reset incomplete for {namespace}: {failure_reason}"

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -17,7 +17,12 @@ from urllib.parse import urlparse
 
 import boto3
 
-from testing.fixtures.credentials import get_minio_credentials, get_polaris_credentials
+from testing.fixtures.credentials import (
+    get_minio_credentials,
+    get_polaris_credentials,
+    get_polaris_scope,
+    get_polaris_warehouse,
+)
 from testing.fixtures.services import ServiceEndpoint
 
 try:
@@ -75,8 +80,8 @@ def _get_polaris_catalog(*, fresh: bool = False) -> Any:
                 "type": "rest",
                 "uri": polaris_url,
                 "credential": os.environ.get("POLARIS_CREDENTIAL", default_cred),
-                "scope": "PRINCIPAL_ROLE:ALL",
-                "warehouse": os.environ.get("POLARIS_WAREHOUSE", "floe-e2e"),
+                "scope": os.environ.get("POLARIS_SCOPE", get_polaris_scope()),
+                "warehouse": os.environ.get("POLARIS_WAREHOUSE", get_polaris_warehouse()),
                 "s3.endpoint": minio_endpoint,
                 "s3.access-key-id": os.environ.get(  # pragma: allowlist secret
                     "AWS_ACCESS_KEY_ID", _minio_access

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -157,23 +157,6 @@ def _purge_iceberg_namespace(
     catalog = _get_polaris_catalog(fresh=True)
     storage_cleanup_failure_reason: str | None = None
     if catalog is not None:
-        # Collect S3 config from environment (same defaults as _get_polaris_catalog).
-        s3_endpoint = os.environ.get("MINIO_ENDPOINT")
-        if s3_endpoint is None:
-            try:
-                s3_endpoint = ServiceEndpoint("minio").url
-            except Exception as exc:
-                s3_endpoint = None
-                if verify_empty and storage_cleanup_failure_reason is None:
-                    storage_cleanup_failure_reason = (
-                        f"Could not resolve storage endpoint for cleanup in {namespace}: "
-                        f"{type(exc).__name__}"
-                    )
-                logger.warning(
-                    "Could not resolve storage endpoint for namespace %s cleanup: %s",
-                    namespace,
-                    type(exc).__name__,
-                )
         access_key, secret_key = get_minio_credentials()
 
         try:
@@ -207,6 +190,22 @@ def _purge_iceberg_namespace(
                 # Step 3: sweep S3 objects under the table's data prefix via boto3.
                 # boto3 handles AWS Signature V4 required by MinIO.
                 if location is not None:
+                    s3_endpoint = os.environ.get("MINIO_ENDPOINT")
+                    if s3_endpoint is None:
+                        try:
+                            s3_endpoint = ServiceEndpoint("minio").url
+                        except Exception as exc:
+                            s3_endpoint = None
+                            if verify_empty and storage_cleanup_failure_reason is None:
+                                storage_cleanup_failure_reason = (
+                                    "Could not resolve storage endpoint for cleanup in "
+                                    f"{namespace}: {type(exc).__name__}"
+                                )
+                            logger.warning(
+                                "Could not resolve storage endpoint for namespace %s cleanup: %s",
+                                namespace,
+                                type(exc).__name__,
+                            )
                     if s3_endpoint is None:
                         logger.warning(
                             "Skipping S3 cleanup for table %s: storage endpoint unavailable",

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -114,7 +114,17 @@ def _delete_s3_prefix(
         if not contents:
             continue
         objects = [{"Key": obj["Key"]} for obj in contents]
-        s3_client.delete_objects(Bucket=bucket, Delete={"Objects": objects, "Quiet": True})
+        response = s3_client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": objects, "Quiet": True},
+        )
+        errors = response.get("Errors", []) if isinstance(response, dict) else []
+        if errors:
+            failed_keys = ",".join(str(error.get("Key", "<unknown>")) for error in errors)
+            raise RuntimeError(
+                f"S3 delete_objects reported errors under s3://{bucket}/{prefix}: "
+                f"{failed_keys}"
+            )
         deleted += len(objects)
     return deleted
 
@@ -141,7 +151,7 @@ def _purge_iceberg_namespace(
         retries: Number of verification attempts when ``verify_empty`` is true.
     """
     catalog = _get_polaris_catalog(fresh=True)
-    s3_cleanup_failure_reason: str | None = None
+    storage_cleanup_failure_reason: str | None = None
     if catalog is not None:
         # Collect S3 config from environment (same defaults as _get_polaris_catalog).
         s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
@@ -158,6 +168,10 @@ def _purge_iceberg_namespace(
                     table = catalog.load_table(fqn)
                     location = table.metadata.location  # e.g. s3://warehouse/ns1/t1
                 except Exception as exc:
+                    if verify_empty and storage_cleanup_failure_reason is None:
+                        storage_cleanup_failure_reason = (
+                            f"Could not resolve storage location for {fqn}: {type(exc).__name__}"
+                        )
                     logger.warning(
                         "Could not load table %s for S3 location: %s",
                         fqn,
@@ -189,9 +203,9 @@ def _purge_iceberg_namespace(
                         deleted = _delete_s3_prefix(s3_client, bucket, prefix)
                         logger.info("Deleted %d S3 objects under %s", deleted, location)
                     except Exception as exc:
-                        if verify_empty and s3_cleanup_failure_reason is None:
-                            s3_cleanup_failure_reason = (
-                                f"S3 cleanup failed for {fqn}: {type(exc).__name__}"
+                        if verify_empty and storage_cleanup_failure_reason is None:
+                            storage_cleanup_failure_reason = (
+                                f"S3 cleanup failed for {fqn}: {exc}"
                             )
                         logger.warning(
                             "S3 cleanup failed for table %s: %s",
@@ -267,9 +281,9 @@ def _purge_iceberg_namespace(
             remaining,
         )
 
-    if s3_cleanup_failure_reason is not None:
+    if storage_cleanup_failure_reason is not None:
         raise NamespaceResetError(
-            f"Namespace reset incomplete for {namespace}: {s3_cleanup_failure_reason}"
+            f"Namespace reset incomplete for {namespace}: {storage_cleanup_failure_reason}"
         )
 
     if verification_succeeded:

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -20,6 +20,11 @@ import boto3
 from testing.fixtures.credentials import get_minio_credentials, get_polaris_credentials
 from testing.fixtures.services import ServiceEndpoint
 
+try:
+    from pyiceberg.exceptions import NoSuchNamespaceError as PyIcebergNoSuchNamespaceError
+except ImportError:
+    PyIcebergNoSuchNamespaceError = None
+
 logger = logging.getLogger(__name__)
 
 # Session-scoped catalog cache — persists across calls within a single
@@ -27,12 +32,24 @@ logger = logging.getLogger(__name__)
 _catalog_cache: dict[str, Any] = {}
 
 
-def _get_polaris_catalog() -> Any:
+class NamespaceResetError(RuntimeError):
+    """Raised when an Iceberg namespace cannot be reset to an empty state."""
+
+
+def _clear_catalog_cache() -> None:
+    """Drop cached Polaris catalog state so each reset can re-auth cleanly."""
+    _catalog_cache.clear()
+
+
+def _get_polaris_catalog(*, fresh: bool = False) -> Any:
     """Get or create a cached PyIceberg REST catalog for Polaris.
 
     Returns:
         PyIceberg catalog instance, or None if unavailable.
     """
+    if fresh:
+        _clear_catalog_cache()
+
     if "catalog" in _catalog_cache:
         return _catalog_cache["catalog"]
 
@@ -102,7 +119,11 @@ def _delete_s3_prefix(
     return deleted
 
 
-def _purge_iceberg_namespace(namespace: str) -> None:
+def _purge_iceberg_namespace(
+    namespace: str,
+    verify_empty: bool = False,
+    retries: int = 3,
+) -> None:
     """Purge all Iceberg tables in a namespace and delete their S3 data.
 
     Uses ``purge_table`` (which removes both catalog metadata and data files)
@@ -116,73 +137,129 @@ def _purge_iceberg_namespace(namespace: str) -> None:
 
     Args:
         namespace: Polaris namespace to purge (e.g. ``customer_360_raw``).
+        verify_empty: Whether to verify the namespace is empty after purge.
+        retries: Number of verification attempts when ``verify_empty`` is true.
     """
     catalog = _get_polaris_catalog()
-    if catalog is None:
-        return
+    if catalog is not None:
+        # Collect S3 config from environment (same defaults as _get_polaris_catalog).
+        s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
+        access_key, secret_key = get_minio_credentials()
 
-    # Collect S3 config from environment (same defaults as _get_polaris_catalog).
-    s3_endpoint = os.environ.get("MINIO_ENDPOINT", ServiceEndpoint("minio").url)
-    access_key, secret_key = get_minio_credentials()
+        try:
+            tables = catalog.list_tables(namespace)
+            for table_id in tables:
+                fqn = f"{table_id[0]}.{table_id[1]}"
 
-    try:
-        tables = catalog.list_tables(namespace)
-        for table_id in tables:
-            fqn = f"{table_id[0]}.{table_id[1]}"
+                # Step 1: read table location BEFORE purge (purge removes metadata).
+                location: str | None = None
+                try:
+                    table = catalog.load_table(fqn)
+                    location = table.metadata.location  # e.g. s3://warehouse/ns1/t1
+                except Exception as exc:
+                    logger.warning(
+                        "Could not load table %s for S3 location: %s",
+                        fqn,
+                        type(exc).__name__,
+                    )
 
-            # Step 1: read table location BEFORE purge (purge removes metadata).
-            location: str | None = None
+                # Step 2: purge via catalog (removes metadata + signals data removal)
+                try:
+                    catalog.purge_table(fqn)
+                    logger.info("Purged Iceberg table %s", fqn)
+                except Exception as exc:
+                    logger.warning("Could not purge table %s: %s", fqn, type(exc).__name__)
+
+                # Step 3: sweep S3 objects under the table's data prefix via boto3.
+                # boto3 handles AWS Signature V4 required by MinIO.
+                if location is not None:
+                    try:
+                        parsed = urlparse(location)
+                        bucket: str = parsed.netloc
+                        prefix: str = parsed.path.lstrip("/")
+
+                        s3_client = boto3.client(
+                            "s3",
+                            endpoint_url=s3_endpoint,
+                            aws_access_key_id=access_key,
+                            aws_secret_access_key=secret_key,
+                            region_name=os.environ.get("AWS_REGION", "us-east-1"),
+                        )
+                        deleted = _delete_s3_prefix(s3_client, bucket, prefix)
+                        logger.info("Deleted %d S3 objects under %s", deleted, location)
+                    except Exception as exc:
+                        logger.warning(
+                            "S3 cleanup failed for table %s: %s",
+                            fqn,
+                            type(exc).__name__,
+                        )
+
+            # Drop the namespace itself so dbt starts completely fresh.
+            # DuckDB's Iceberg extension cannot DROP TABLE CASCADE, so stale
+            # namespace metadata causes "Not implemented" errors on re-run.
             try:
-                table = catalog.load_table(fqn)
-                location = table.metadata.location  # e.g. s3://warehouse/ns1/t1
+                catalog.drop_namespace(namespace)
+                logger.info("Dropped namespace %s", namespace)
             except Exception as exc:
                 logger.warning(
-                    "Could not load table %s for S3 location: %s",
-                    fqn,
+                    "Could not drop namespace %s: %s",
+                    namespace,
                     type(exc).__name__,
                 )
-
-            # Step 2: purge via catalog (removes metadata + signals data removal)
-            try:
-                catalog.purge_table(fqn)
-                logger.info("Purged Iceberg table %s", fqn)
-            except Exception as exc:
-                logger.warning("Could not purge table %s: %s", fqn, type(exc).__name__)
-
-            # Step 3: sweep S3 objects under the table's data prefix via boto3.
-            # boto3 handles AWS Signature V4 required by MinIO.
-            if location is not None:
-                try:
-                    parsed = urlparse(location)
-                    bucket: str = parsed.netloc
-                    prefix: str = parsed.path.lstrip("/")
-
-                    s3_client = boto3.client(
-                        "s3",
-                        endpoint_url=s3_endpoint,
-                        aws_access_key_id=access_key,
-                        aws_secret_access_key=secret_key,
-                        region_name=os.environ.get("AWS_REGION", "us-east-1"),
-                    )
-                    deleted = _delete_s3_prefix(s3_client, bucket, prefix)
-                    logger.info("Deleted %d S3 objects under %s", deleted, location)
-                except Exception as exc:
-                    logger.warning("S3 cleanup failed for table %s: %s", fqn, type(exc).__name__)
-
-        # Drop the namespace itself so dbt starts completely fresh.
-        # DuckDB's Iceberg extension cannot DROP TABLE CASCADE, so stale
-        # namespace metadata causes "Not implemented" errors on re-run.
-        try:
-            catalog.drop_namespace(namespace)
-            logger.info("Dropped namespace %s", namespace)
         except Exception as exc:
+            logger.debug("Namespace purge skipped for %s: %s", namespace, exc)
+            if not verify_empty:
+                return
+    elif not verify_empty:
+        return
+
+    if not verify_empty:
+        return
+
+    remaining: Any = []
+    for attempt in range(1, retries + 1):
+        fresh_catalog = _get_polaris_catalog(fresh=True)
+        if fresh_catalog is None:
+            remaining = ["<catalog unavailable>"]
             logger.warning(
-                "Could not drop namespace %s: %s",
+                "Could not verify namespace %s reset on attempt %d/%d: catalog unavailable",
                 namespace,
+                attempt,
+                retries,
+            )
+            continue
+
+        try:
+            remaining = fresh_catalog.list_tables(namespace)
+        except Exception as exc:
+            if PyIcebergNoSuchNamespaceError is not None and isinstance(
+                exc, PyIcebergNoSuchNamespaceError
+            ):
+                return
+            remaining = [f"<verification failed: {type(exc).__name__}>"]
+            logger.warning(
+                "Could not verify namespace %s reset on attempt %d/%d: %s",
+                namespace,
+                attempt,
+                retries,
                 type(exc).__name__,
             )
-    except Exception as exc:
-        logger.debug("Namespace purge skipped for %s: %s", namespace, exc)
+            continue
+
+        if not remaining:
+            return
+
+        logger.warning(
+            "Namespace %s still contains tables on attempt %d/%d: %s",
+            namespace,
+            attempt,
+            retries,
+            remaining,
+        )
+
+    raise NamespaceResetError(
+        f"Namespace reset incomplete for {namespace}: remaining tables={remaining}"
+    )
 
 
 def run_dbt(
@@ -219,11 +296,11 @@ def run_dbt(
     if args and args[0] == "seed":
         # Purge seed namespace only — model tables may depend on seeds
         product_name = project_dir.name.replace("-", "_")
-        _purge_iceberg_namespace(f"{product_name}_raw")
+        _purge_iceberg_namespace(f"{product_name}_raw", verify_empty=True)
     elif args and args[0] == "run":
         # Purge model namespace only — preserve seed tables as sources
         product_name = project_dir.name.replace("-", "_")
-        _purge_iceberg_namespace(product_name)
+        _purge_iceberg_namespace(product_name, verify_empty=True)
 
     # Use the venv's dbt to avoid PATH conflicts with dbt-fusion or other
     # system-installed dbt binaries that may not support the duckdb adapter.

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -220,14 +220,13 @@ def _purge_iceberg_namespace(
     for attempt in range(1, retries + 1):
         fresh_catalog = _get_polaris_catalog(fresh=True)
         if fresh_catalog is None:
-            remaining = ["<catalog unavailable>"]
             logger.warning(
                 "Could not verify namespace %s reset on attempt %d/%d: catalog unavailable",
                 namespace,
                 attempt,
                 retries,
             )
-            continue
+            return
 
         try:
             remaining = fresh_catalog.list_tables(namespace)
@@ -236,7 +235,6 @@ def _purge_iceberg_namespace(
                 exc, PyIcebergNoSuchNamespaceError
             ):
                 return
-            remaining = [f"<verification failed: {type(exc).__name__}>"]
             logger.warning(
                 "Could not verify namespace %s reset on attempt %d/%d: %s",
                 namespace,
@@ -244,7 +242,7 @@ def _purge_iceberg_namespace(
                 retries,
                 type(exc).__name__,
             )
-            continue
+            return
 
         if not remaining:
             return

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -131,8 +131,7 @@ def _delete_s3_prefix(
         if errors:
             failed_keys = ",".join(str(error.get("Key", "<unknown>")) for error in errors)
             raise RuntimeError(
-                f"S3 delete_objects reported errors under s3://{bucket}/{prefix}: "
-                f"{failed_keys}"
+                f"S3 delete_objects reported errors under s3://{bucket}/{prefix}: {failed_keys}"
             )
         deleted += len(objects)
     return deleted
@@ -233,9 +232,7 @@ def _purge_iceberg_namespace(
                         logger.info("Deleted %d S3 objects under %s", deleted, location)
                     except Exception as exc:
                         if verify_empty and storage_cleanup_failure_reason is None:
-                            storage_cleanup_failure_reason = (
-                                f"S3 cleanup failed for {fqn}: {exc}"
-                            )
+                            storage_cleanup_failure_reason = f"S3 cleanup failed for {fqn}: {exc}"
                         logger.warning(
                             "S3 cleanup failed for table %s: %s",
                             fqn,
@@ -328,9 +325,7 @@ def _purge_iceberg_namespace(
     if verification_succeeded:
         return
 
-    raise NamespaceResetError(
-        f"Namespace reset incomplete for {namespace}: {failure_reason}"
-    )
+    raise NamespaceResetError(f"Namespace reset incomplete for {namespace}: {failure_reason}")
 
 
 def run_dbt(

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -226,6 +226,14 @@ def _purge_iceberg_namespace(
                     type(exc).__name__,
                 )
         except Exception as exc:
+            is_missing_namespace = PyIcebergNoSuchNamespaceError is not None and isinstance(
+                exc, PyIcebergNoSuchNamespaceError
+            )
+            if verify_empty and not is_missing_namespace and storage_cleanup_failure_reason is None:
+                storage_cleanup_failure_reason = (
+                    f"Could not enumerate tables for storage cleanup in {namespace}: "
+                    f"{type(exc).__name__}"
+                )
             logger.debug("Namespace purge skipped for %s: %s", namespace, exc)
             if not verify_empty:
                 return

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -213,9 +213,9 @@ def _purge_iceberg_namespace(
                             type(exc).__name__,
                         )
 
-            # Drop the namespace itself so dbt starts completely fresh.
-            # DuckDB's Iceberg extension cannot DROP TABLE CASCADE, so stale
-            # namespace metadata causes "Not implemented" errors on re-run.
+            # Try to drop the namespace so reruns start from a cleaner catalog
+            # state. Verified success still means the namespace is empty or
+            # absent, even if the drop itself fails.
             try:
                 catalog.drop_namespace(namespace)
                 logger.info("Dropped namespace %s", namespace)
@@ -229,6 +229,8 @@ def _purge_iceberg_namespace(
             is_missing_namespace = PyIcebergNoSuchNamespaceError is not None and isinstance(
                 exc, PyIcebergNoSuchNamespaceError
             )
+            if verify_empty and is_missing_namespace:
+                return
             if verify_empty and not is_missing_namespace and storage_cleanup_failure_reason is None:
                 storage_cleanup_failure_reason = (
                     f"Could not enumerate tables for storage cleanup in {namespace}: "

--- a/tests/e2e/test_governance.py
+++ b/tests/e2e/test_governance.py
@@ -62,6 +62,16 @@ KNOWN_NON_SECRET_ENV_VARS: frozenset[str] = frozenset(
 """Env vars excluded from secret-in-template scanning (false positives)."""
 
 
+def _find_repo_root() -> Path:
+    """Find repository root by looking for pyproject.toml."""
+    current = Path(__file__).parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    pytest.fail("Could not find repository root (no pyproject.toml)")
+
+
 class TestGovernance(IntegrationTestBase):
     """E2E tests for platform governance and security controls.
 
@@ -448,79 +458,6 @@ class TestGovernance(IntegrationTestBase):
         except FileNotFoundError:
             pytest.fail("bandit not found. Install with: uv pip install bandit[toml]")
 
-    @pytest.mark.developer_workflow
-    @pytest.mark.e2e
-    @pytest.mark.requirement("FR-064")
-    def test_pip_audit_clean(self) -> None:
-        """Test that pip-audit finds no critical/high vulnerabilities.
-
-        Runs pip-audit (via uv-secure) on dependencies and verifies
-        no critical or high severity vulnerabilities exist.
-
-        Strategy:
-        1. Run uv-secure vulnerability scan
-        2. Parse output for CRITICAL/HIGH vulnerabilities
-        3. Fail if vulnerabilities found (excluding documented exceptions)
-        """
-        repo_root = self._find_repo_root()
-
-        # Run uv-secure with same ignore list as CI.
-        # See .pre-commit-config.yaml for justification of ignored vulns.
-        # Scan only platform lock files — devtools/ has its own dependency
-        # lifecycle and is excluded from platform security governance.
-        lock_files = [
-            str(p)
-            for p in repo_root.rglob("uv.lock")
-            if "devtools" not in str(p) and ".venv" not in str(p)
-        ]
-        if not lock_files:
-            pytest.fail(
-                "No platform uv.lock files found — security scan requires at least one "
-                "lock file in packages/ or plugins/ (devtools/ is intentionally excluded)."
-            )
-        # Load shared ignore list — single source of truth with .pre-commit-config.yaml
-        vuln_ignore_path = repo_root / ".vuln-ignore"
-        if not vuln_ignore_path.exists():
-            pytest.fail(
-                ".vuln-ignore not found at repo root — shared vulnerability ignore "
-                "list is required for E2E security governance tests."
-            )
-        ignore_ids_list = [
-            line.strip()
-            for line in vuln_ignore_path.read_text().splitlines()
-            if line.strip() and not line.strip().startswith("#")
-        ]
-
-        cmd = [
-            "uv",
-            "run",
-            "uv-secure",
-            "--no-check-uv-tool",
-        ]
-        if ignore_ids_list:
-            cmd += ["--ignore-vulns", ",".join(ignore_ids_list)]
-        cmd += lock_files
-
-        try:
-            result = subprocess.run(
-                cmd,
-                shell=False,
-                check=False,
-                capture_output=True,
-                text=True,
-                cwd=repo_root,
-            )
-
-            # uv-secure exits with non-zero if vulnerabilities found
-            if result.returncode != 0:
-                pytest.fail(
-                    f"Vulnerability scan failed with vulnerabilities:\n"
-                    f"{result.stdout}\n{result.stderr}"
-                )
-
-        except FileNotFoundError:
-            pytest.fail("uv-secure not found. Install with: uv pip install uv-secure")
-
     @pytest.mark.e2e
     @pytest.mark.requirement("FR-065")
     def test_secretstr_usage(self) -> None:
@@ -840,12 +777,7 @@ class TestGovernance(IntegrationTestBase):
 
     def _find_repo_root(self) -> Path:
         """Find repository root by looking for pyproject.toml."""
-        current = Path(__file__).parent
-        while current != current.parent:
-            if (current / "pyproject.toml").exists():
-                return current
-            current = current.parent
-        pytest.fail("Could not find repository root (no pyproject.toml)")
+        return _find_repo_root()
 
     def _find_chart_root(self) -> Path:
         """Find charts directory root."""
@@ -913,3 +845,79 @@ class TestGovernance(IntegrationTestBase):
         import os
 
         return os.environ.get("POLARIS_URL", ServiceEndpoint("polaris").url)
+
+
+class TestDependencyGovernance:
+    """Repo-aware governance checks that do not require live platform services."""
+
+    @pytest.mark.developer_workflow
+    @pytest.mark.e2e
+    @pytest.mark.requirement("FR-064")
+    def test_pip_audit_clean(self) -> None:
+        """Test that pip-audit finds no critical/high vulnerabilities.
+
+        Runs pip-audit (via uv-secure) on dependencies and verifies
+        no critical or high severity vulnerabilities exist.
+
+        Strategy:
+        1. Run uv-secure vulnerability scan
+        2. Parse output for CRITICAL/HIGH vulnerabilities
+        3. Fail if vulnerabilities found (excluding documented exceptions)
+        """
+        repo_root = _find_repo_root()
+
+        # Run uv-secure with same ignore list as CI.
+        # See .pre-commit-config.yaml for justification of ignored vulns.
+        # Scan only platform lock files — devtools/ has its own dependency
+        # lifecycle and is excluded from platform security governance.
+        lock_files = [
+            str(p)
+            for p in repo_root.rglob("uv.lock")
+            if "devtools" not in str(p) and ".venv" not in str(p)
+        ]
+        if not lock_files:
+            pytest.fail(
+                "No platform uv.lock files found — security scan requires at least one "
+                "lock file in packages/ or plugins/ (devtools/ is intentionally excluded)."
+            )
+
+        vuln_ignore_path = repo_root / ".vuln-ignore"
+        if not vuln_ignore_path.exists():
+            pytest.fail(
+                ".vuln-ignore not found at repo root — shared vulnerability ignore "
+                "list is required for E2E security governance tests."
+            )
+        ignore_ids_list = [
+            line.strip()
+            for line in vuln_ignore_path.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+        cmd = [
+            "uv",
+            "run",
+            "uv-secure",
+            "--no-check-uv-tool",
+        ]
+        if ignore_ids_list:
+            cmd += ["--ignore-vulns", ",".join(ignore_ids_list)]
+        cmd += lock_files
+
+        try:
+            result = subprocess.run(
+                cmd,
+                shell=False,
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=repo_root,
+            )
+
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Vulnerability scan failed with vulnerabilities:\n"
+                    f"{result.stdout}\n{result.stderr}"
+                )
+
+        except FileNotFoundError:
+            pytest.fail("uv-secure not found. Install with: uv pip install uv-secure")

--- a/tests/e2e/test_governance.py
+++ b/tests/e2e/test_governance.py
@@ -448,6 +448,7 @@ class TestGovernance(IntegrationTestBase):
         except FileNotFoundError:
             pytest.fail("bandit not found. Install with: uv pip install bandit[toml]")
 
+    @pytest.mark.developer_workflow
     @pytest.mark.e2e
     @pytest.mark.requirement("FR-064")
     def test_pip_audit_clean(self) -> None:

--- a/tests/e2e/test_helm_workflow.py
+++ b/tests/e2e/test_helm_workflow.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+
+
 def _run_command(
     cmd: list[str],
     timeout: int = 900,

--- a/tests/e2e/test_helm_workflow.py
+++ b/tests/e2e/test_helm_workflow.py
@@ -242,8 +242,14 @@ class TestHelmWorkflow:
     @pytest.fixture(autouse=True)
     def check_cluster(self) -> None:
         """Verify kubectl access to cluster."""
-        result = _kubectl(["cluster-info"])
-        if result.returncode != 0:
+        cluster_ready = wait_for_condition(
+            lambda: _kubectl(["cluster-info"]).returncode == 0,
+            timeout=20.0,
+            interval=2.0,
+            description="kubectl cluster-info to succeed",
+            raise_on_timeout=False,
+        )
+        if not cluster_ready:
             pytest.fail("Kubernetes cluster not available.\nStart cluster with: make kind-up")
 
     @pytest.mark.requirement("E2E-001")

--- a/tests/e2e/test_platform_bootstrap.py
+++ b/tests/e2e/test_platform_bootstrap.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+
+
 def _run_kubectl(
     args: list[str],
     timeout: int = 60,

--- a/tests/e2e/test_platform_bootstrap.py
+++ b/tests/e2e/test_platform_bootstrap.py
@@ -1,4 +1,4 @@
-"""E2E tests for floe-platform Helm chart bootstrap validation.
+"""E2E tests for deployed floe-platform runtime validation.
 
 This module validates the complete platform deployment via Helm,
 ensuring all services are properly deployed, configured, and accessible.
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.bootstrap,
+    pytest.mark.platform_blackbox,
 ]
 
 
@@ -71,7 +71,7 @@ def _run_kubectl(
 @pytest.mark.requirement("FR-007")
 @pytest.mark.requirement("FR-049")
 class TestPlatformBootstrap(IntegrationTestBase):
-    """E2E tests for floe-platform Helm chart bootstrap validation.
+    """E2E tests for deployed floe-platform runtime validation.
 
     Validates the complete platform deployment lifecycle:
     1. Deploy floe-platform Helm chart

--- a/tests/e2e/test_platform_deployment_e2e.py
+++ b/tests/e2e/test_platform_deployment_e2e.py
@@ -39,6 +39,12 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.bootstrap,
+]
+
+
 # K8s namespace — set by test-e2e.sh or default to floe-test
 NAMESPACE = os.environ.get("FLOE_E2E_NAMESPACE", "floe-test")
 VALUES_TEST = Path(__file__).resolve().parents[2] / "charts" / "floe-platform" / "values-test.yaml"

--- a/tests/e2e/test_platform_deployment_e2e.py
+++ b/tests/e2e/test_platform_deployment_e2e.py
@@ -1,19 +1,19 @@
-"""E2E test: Full Platform Deployment Verification (AC-2.1).
+"""E2E test: Full platform blackbox deployment verification (AC-2.1).
 
 Validates that the floe-platform Helm chart deploys correctly and all services
 are healthy and accessible via their real health endpoints.
 
-This test uses the port-forward pattern (AD-2) — services are accessed via
-localhost URLs set up by `make test-e2e`. No IntegrationTestBase, no dual-mode
-networking, no custom TCP health checks.
+This test belongs to the deployed-product validation lane. It can run inside
+the in-cluster validation runner or under the legacy host harness when that
+runner has already established the required local service bridges.
 
 Workflow:
     helm install floe-platform → wait for pods → verify all services healthy
 
 Prerequisites:
     - Kind cluster running: make kind-up
-    - Platform deployed: make helm-install-test
-    - Port-forwards active: make test-e2e (manages lifecycle)
+    - Platform deployed: make helm-install-test or the in-cluster validation job
+    - Service reachability established by the chosen validation runner
 
 See Also:
     - .specwright/work/test-hardening-audit/spec.md: AC-2.1
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.bootstrap,
+    pytest.mark.platform_blackbox,
 ]
 
 

--- a/tests/e2e/test_profile_isolation.py
+++ b/tests/e2e/test_profile_isolation.py
@@ -16,6 +16,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = [pytest.mark.developer_workflow]
+
 # ---------------------------------------------------------------------------
 # AC-2: Demo profiles remain untouched; generated profiles written to
 #        correct location

--- a/tests/e2e/test_runtime_loader_e2e.py
+++ b/tests/e2e/test_runtime_loader_e2e.py
@@ -20,13 +20,13 @@ See Also:
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import httpx
 import pytest
 
-DAGSTER_HOST = "127.0.0.1"
-DAGSTER_PORT = 3000
+from testing.fixtures.services import ServiceEndpoint
 
 
 @pytest.fixture
@@ -39,7 +39,7 @@ def dagster_url() -> str:
     Raises:
         pytest.fail: If Dagster webserver is unreachable.
     """
-    url = f"http://{DAGSTER_HOST}:{DAGSTER_PORT}"
+    url = os.environ.get("DAGSTER_URL", ServiceEndpoint("dagster-webserver").url)
     try:
         resp = httpx.get(f"{url}/server_info", timeout=5.0)
         resp.raise_for_status()
@@ -50,6 +50,8 @@ def dagster_url() -> str:
     return url
 
 
+@pytest.mark.e2e
+@pytest.mark.platform_blackbox
 @pytest.mark.requirement("AC-1")
 @pytest.mark.requirement("AC-6")
 def test_dagster_discovers_code_location(dagster_url: str) -> None:
@@ -88,6 +90,8 @@ def test_dagster_discovers_code_location(dagster_url: str) -> None:
     assert len(loaded) >= 1, f"No code locations in LOADED status. Entries: {entries}"
 
 
+@pytest.mark.e2e
+@pytest.mark.platform_blackbox
 @pytest.mark.requirement("AC-1")
 @pytest.mark.requirement("AC-6")
 def test_dagster_discovers_assets(dagster_url: str) -> None:
@@ -120,6 +124,7 @@ def test_dagster_discovers_assets(dagster_url: str) -> None:
     )
 
 
+@pytest.mark.developer_workflow
 @pytest.mark.requirement("AC-6")
 def test_thin_definitions_are_deployed() -> None:
     """Verify the deployed definitions.py files are thin loader shims.

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -572,7 +572,7 @@ class TestDbtPipelineResultFixtureSemantics:
             "when a primary failure already exists."
         )
         assert all(
-            "Suppressed teardown namespace reset failure" in message for message in log_messages
+            "Suppressed teardown reset failure" in message for message in log_messages
         ), "Suppressed teardown reset failures must be surfaced in logs."
         assert purge_calls == [
             "customer_360_raw:True",
@@ -624,3 +624,67 @@ class TestDbtPipelineResultFixtureSemantics:
             "customer_360_raw:True",
             "customer_360:True",
         ], "Teardown must attempt both namespaces before raising the first reset error."
+
+    @pytest.mark.requirement("AC-1")
+    @pytest.mark.parametrize("phase", ["setup", "test_body"])
+    def test_runtime_raw_teardown_exception_does_not_mask_primary_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        phase: str,
+    ) -> None:
+        """Raw teardown exceptions must not replace an earlier dbt or test failure."""
+        import dbt_utils
+
+        runtime_conftest = _load_runtime_conftest_module()
+        fixture_func = runtime_conftest.dbt_pipeline_result.__wrapped__
+
+        project_root = tmp_path
+        project_dir = project_root / "demo" / "customer-360"
+        project_dir.mkdir(parents=True)
+        request = SimpleNamespace(param="customer-360")
+        log_messages: list[str] = []
+        purge_calls: list[str] = []
+
+        def _record_error(message: str, *args: object) -> None:
+            log_messages.append(message % args if args else message)
+
+        def _purge(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+            del retries
+            purge_calls.append(f"{namespace}:{verify_empty}")
+            if len(purge_calls) > 2:
+                raise RuntimeError(f"raw teardown failure for {namespace}")
+
+        def _run_dbt(args: list[str], project_dir_arg: Path) -> SimpleNamespace:
+            assert project_dir_arg == project_dir
+            if phase == "setup" and args == ["seed"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="seed exploded")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(runtime_conftest.logger, "error", _record_error)
+        monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _purge)
+        monkeypatch.setattr(dbt_utils, "run_dbt", _run_dbt)
+
+        generator = fixture_func(request, project_root, {})
+
+        if phase == "setup":
+            with pytest.raises(pytest.fail.Exception, match="dbt seed failed"):
+                next(generator)
+        else:
+            assert next(generator) == ("customer-360", project_dir)
+            with pytest.raises(RuntimeError, match="test body failed"):
+                generator.throw(RuntimeError("test body failed"))
+
+        assert len(log_messages) == 2, (
+            "Raw teardown exceptions should be logged for both namespaces when "
+            "a primary failure already exists."
+        )
+        assert all(
+            "Suppressed teardown reset failure" in message for message in log_messages
+        ), "Suppressed raw teardown failures must be surfaced in logs."
+        assert purge_calls == [
+            "customer_360_raw:True",
+            "customer_360:True",
+            "customer_360_raw:True",
+            "customer_360:True",
+        ]

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -615,7 +615,10 @@ class TestDbtPipelineResultFixtureSemantics:
         generator = fixture_func(request, project_root, {})
 
         assert next(generator) == ("customer-360", project_dir)
-        with pytest.raises(dbt_utils.NamespaceResetError, match="teardown failed for customer_360_raw"):
+        with pytest.raises(
+            dbt_utils.NamespaceResetError,
+            match="teardown failed for customer_360_raw",
+        ):
             next(generator)
 
         assert purge_calls == [

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -20,7 +20,10 @@ Test types:
 from __future__ import annotations
 
 import ast
+import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -51,6 +54,16 @@ def _parse_conftest() -> ast.Module:
     except SyntaxError as exc:
         pytest.fail(f"conftest.py has syntax error: {exc}")
         raise  # unreachable, satisfies mypy
+
+
+def _load_runtime_conftest_module() -> Any:
+    """Load tests/e2e/conftest.py as a standalone module for runtime tests."""
+    spec = importlib.util.spec_from_file_location("floe_e2e_conftest_runtime", _CONFTEST_PATH)
+    assert spec is not None, "Could not create import spec for tests/e2e/conftest.py"
+    assert spec.loader is not None, "Could not load tests/e2e/conftest.py"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _find_function_def(tree: ast.Module, name: str) -> ast.FunctionDef | None:
@@ -471,9 +484,9 @@ class TestDbtPipelineResultFixtureSemantics:
                 teardown_calls = _collect_purge_calls(node.finalbody)
                 break
 
-        assert len(teardown_calls) == 2, (
-            "dbt_pipeline_result teardown must call _purge_iceberg_namespace twice "
-            "for raw and model namespaces in finally."
+        assert teardown_calls, (
+            "dbt_pipeline_result teardown must call _purge_iceberg_namespace in finally "
+            "for raw and model namespace cleanup."
         )
         assert all(
             _call_has_keyword_bool(call, "verify_empty", True) for call in teardown_calls
@@ -503,3 +516,67 @@ class TestDbtPipelineResultFixtureSemantics:
             "The yield must be within try so that finally cleanup executes "
             "after the test module completes."
         )
+
+    @pytest.mark.requirement("AC-1")
+    @pytest.mark.parametrize("phase", ["setup", "test_body"])
+    def test_runtime_teardown_reset_failure_does_not_mask_primary_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        phase: str,
+    ) -> None:
+        """Teardown reset errors must not replace an earlier dbt or test failure."""
+        import dbt_utils
+
+        runtime_conftest = _load_runtime_conftest_module()
+        fixture_func = runtime_conftest.dbt_pipeline_result.__wrapped__
+
+        project_root = tmp_path
+        project_dir = project_root / "demo" / "customer-360"
+        project_dir.mkdir(parents=True)
+        request = SimpleNamespace(param="customer-360")
+        log_messages: list[str] = []
+        purge_calls: list[str] = []
+
+        def _record_error(message: str, *args: object) -> None:
+            log_messages.append(message % args if args else message)
+
+        def _purge(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+            del retries
+            purge_calls.append(f"{namespace}:{verify_empty}")
+            if len(purge_calls) > 2:
+                raise dbt_utils.NamespaceResetError(f"teardown failed for {namespace}")
+
+        def _run_dbt(args: list[str], project_dir_arg: Path) -> SimpleNamespace:
+            assert project_dir_arg == project_dir
+            if phase == "setup" and args == ["seed"]:
+                return SimpleNamespace(returncode=1, stdout="", stderr="seed exploded")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(runtime_conftest.logger, "error", _record_error)
+        monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _purge)
+        monkeypatch.setattr(dbt_utils, "run_dbt", _run_dbt)
+
+        generator = fixture_func(request, project_root, {})
+
+        if phase == "setup":
+            with pytest.raises(pytest.fail.Exception, match="dbt seed failed"):
+                next(generator)
+        else:
+            assert next(generator) == ("customer-360", project_dir)
+            with pytest.raises(RuntimeError, match="test body failed"):
+                generator.throw(RuntimeError("test body failed"))
+
+        assert len(log_messages) == 2, (
+            "Teardown NamespaceResetError should be logged for both namespaces "
+            "when a primary failure already exists."
+        )
+        assert all(
+            "Suppressed teardown namespace reset failure" in message for message in log_messages
+        ), "Suppressed teardown reset failures must be surfaced in logs."
+        assert purge_calls == [
+            "customer_360_raw:True",
+            "customer_360:True",
+            "customer_360_raw:True",
+            "customer_360:True",
+        ]

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -488,9 +488,9 @@ class TestDbtPipelineResultFixtureSemantics:
             "dbt_pipeline_result teardown must call _purge_iceberg_namespace in finally "
             "for raw and model namespace cleanup."
         )
-        assert all(
-            _call_has_keyword_bool(call, "verify_empty", True) for call in teardown_calls
-        ), "All teardown _purge_iceberg_namespace calls must pass verify_empty=True."
+        assert all(_call_has_keyword_bool(call, "verify_empty", True) for call in teardown_calls), (
+            "All teardown _purge_iceberg_namespace calls must pass verify_empty=True."
+        )
 
     @pytest.mark.requirement("AC-1")
     def test_yield_inside_try_block(self) -> None:
@@ -571,9 +571,9 @@ class TestDbtPipelineResultFixtureSemantics:
             "Teardown NamespaceResetError should be logged for both namespaces "
             "when a primary failure already exists."
         )
-        assert all(
-            "Suppressed teardown reset failure" in message for message in log_messages
-        ), "Suppressed teardown reset failures must be surfaced in logs."
+        assert all("Suppressed teardown reset failure" in message for message in log_messages), (
+            "Suppressed teardown reset failures must be surfaced in logs."
+        )
         assert purge_calls == [
             "customer_360_raw:True",
             "customer_360:True",
@@ -682,9 +682,9 @@ class TestDbtPipelineResultFixtureSemantics:
             "Raw teardown exceptions should be logged for both namespaces when "
             "a primary failure already exists."
         )
-        assert all(
-            "Suppressed teardown reset failure" in message for message in log_messages
-        ), "Suppressed raw teardown failures must be surfaced in logs."
+        assert all("Suppressed teardown reset failure" in message for message in log_messages), (
+            "Suppressed raw teardown failures must be surfaced in logs."
+        )
         assert purge_calls == [
             "customer_360_raw:True",
             "customer_360:True",

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -580,3 +580,47 @@ class TestDbtPipelineResultFixtureSemantics:
             "customer_360_raw:True",
             "customer_360:True",
         ]
+
+    @pytest.mark.requirement("AC-1")
+    def test_runtime_teardown_attempts_both_namespaces_before_raising_reset_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Without a prior primary failure, teardown should try both namespaces then raise."""
+        import dbt_utils
+
+        runtime_conftest = _load_runtime_conftest_module()
+        fixture_func = runtime_conftest.dbt_pipeline_result.__wrapped__
+
+        project_root = tmp_path
+        project_dir = project_root / "demo" / "customer-360"
+        project_dir.mkdir(parents=True)
+        request = SimpleNamespace(param="customer-360")
+        purge_calls: list[str] = []
+
+        def _purge(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+            del retries
+            purge_calls.append(f"{namespace}:{verify_empty}")
+            if len(purge_calls) == 3:
+                raise dbt_utils.NamespaceResetError(f"teardown failed for {namespace}")
+
+        def _run_dbt(args: list[str], project_dir_arg: Path) -> SimpleNamespace:
+            assert project_dir_arg == project_dir
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _purge)
+        monkeypatch.setattr(dbt_utils, "run_dbt", _run_dbt)
+
+        generator = fixture_func(request, project_root, {})
+
+        assert next(generator) == ("customer-360", project_dir)
+        with pytest.raises(dbt_utils.NamespaceResetError, match="teardown failed for customer_360_raw"):
+            next(generator)
+
+        assert purge_calls == [
+            "customer_360_raw:True",
+            "customer_360:True",
+            "customer_360_raw:True",
+            "customer_360:True",
+        ], "Teardown must attempt both namespaces before raising the first reset error."

--- a/tests/e2e/tests/test_dbt_pipeline_fixture.py
+++ b/tests/e2e/tests/test_dbt_pipeline_fixture.py
@@ -215,6 +215,28 @@ def _finally_calls_function(func: ast.FunctionDef, callee_name: str) -> bool:
     return False
 
 
+def _collect_purge_calls(
+    statements: list[ast.stmt],
+) -> list[ast.Call]:
+    """Collect _purge_iceberg_namespace calls from a statement list."""
+    calls: list[ast.Call] = []
+    for node in ast.walk(ast.Module(body=statements, type_ignores=[])):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        if isinstance(callee, ast.Name) and callee.id == "_purge_iceberg_namespace":
+            calls.append(node)
+    return calls
+
+
+def _call_has_keyword_bool(call: ast.Call, keyword: str, value: bool) -> bool:
+    """Return whether a call sets a bool keyword to the expected value."""
+    for kw in call.keywords:
+        if kw.arg == keyword and isinstance(kw.value, ast.Constant) and kw.value.value is value:
+            return True
+    return False
+
+
 # =========================================================================
 # Tests
 # =========================================================================
@@ -414,6 +436,48 @@ class TestDbtPipelineResultFixtureSemantics:
             "'_purge_iceberg_namespace'. Cleanup must use this function "
             "to properly remove Iceberg tables and namespace."
         )
+
+    @pytest.mark.requirement("AC-1")
+    def test_setup_purges_use_verified_reset(self) -> None:
+        """Setup purges must verify both raw and model namespaces are empty."""
+        tree = _parse_conftest()
+        func = _find_function_def(tree, "dbt_pipeline_result")
+        assert func is not None, "Function 'dbt_pipeline_result' not found."
+
+        setup_calls: list[ast.Call] = []
+        for node in func.body:
+            if isinstance(node, ast.Try):
+                setup_calls = _collect_purge_calls(node.body)
+                break
+
+        assert len(setup_calls) == 2, (
+            "dbt_pipeline_result setup must call _purge_iceberg_namespace twice "
+            "for raw and model namespaces before running dbt."
+        )
+        assert all(_call_has_keyword_bool(call, "verify_empty", True) for call in setup_calls), (
+            "All setup _purge_iceberg_namespace calls must pass verify_empty=True."
+        )
+
+    @pytest.mark.requirement("AC-1")
+    def test_teardown_purges_use_verified_reset(self) -> None:
+        """Teardown purges must verify both raw and model namespaces are empty."""
+        tree = _parse_conftest()
+        func = _find_function_def(tree, "dbt_pipeline_result")
+        assert func is not None, "Function 'dbt_pipeline_result' not found."
+
+        teardown_calls: list[ast.Call] = []
+        for node in func.body:
+            if isinstance(node, ast.Try):
+                teardown_calls = _collect_purge_calls(node.finalbody)
+                break
+
+        assert len(teardown_calls) == 2, (
+            "dbt_pipeline_result teardown must call _purge_iceberg_namespace twice "
+            "for raw and model namespaces in finally."
+        )
+        assert all(
+            _call_has_keyword_bool(call, "verify_empty", True) for call in teardown_calls
+        ), "All teardown _purge_iceberg_namespace calls must pass verify_empty=True."
 
     @pytest.mark.requirement("AC-1")
     def test_yield_inside_try_block(self) -> None:

--- a/tests/e2e/tests/test_polaris_jdbc_durability.py
+++ b/tests/e2e/tests/test_polaris_jdbc_durability.py
@@ -28,7 +28,11 @@ import pyarrow as pa
 import pytest
 
 from testing.base_classes.integration_test_base import IntegrationTestBase
-from testing.fixtures.credentials import get_minio_credentials
+from testing.fixtures.credentials import (
+    get_minio_credentials,
+    get_polaris_scope,
+    get_polaris_warehouse,
+)
 from testing.fixtures.polaris import (
     PolarisConfig,
     create_polaris_catalog,
@@ -43,7 +47,10 @@ def _minio_base_url() -> str:
 
 
 def _durability_polaris_config() -> PolarisConfig:
-    return PolarisConfig(warehouse=os.environ.get("POLARIS_WAREHOUSE", "floe-e2e"))
+    return PolarisConfig(
+        warehouse=os.environ.get("POLARIS_WAREHOUSE", get_polaris_warehouse()),
+        scope=os.environ.get("POLARIS_SCOPE", get_polaris_scope()),
+    )
 
 
 def _validated_identifier(value: str, label: str) -> str:

--- a/tests/unit/test_conftest_rbac.py
+++ b/tests/unit/test_conftest_rbac.py
@@ -448,10 +448,13 @@ class TestOAuthScopePreservation:
 
         'PRINCIPAL_ROLE:ALL' is a valid OAuth scope that requests permissions
         for all principal roles. This is different from using 'ALL' as an
-        entity name in a URL path. The scope MUST be preserved.
+        entity name in a URL path. The scope MUST be preserved, either as an
+        inline literal or via the shared manifest-driven helper.
         """
         # Match the scope value in the OAuth token request — may be inline
-        # literal or via a variable that holds "PRINCIPAL_ROLE:ALL".
+        # literal, via a variable that holds "PRINCIPAL_ROLE:ALL", or via the
+        # shared get_polaris_scope() helper that defaults missing values to the
+        # canonical OAuth scope.
         has_scope_literal = bool(
             re.search(r"""["']scope["']\s*:\s*["']PRINCIPAL_ROLE:ALL["']""", conftest_text)
         )
@@ -459,11 +462,16 @@ class TestOAuthScopePreservation:
             re.search(r"""["']PRINCIPAL_ROLE:ALL["']""", conftest_text)
             and re.search(r"""["']scope["']""", conftest_text)
         )
-        assert has_scope_literal or has_scope_variable, (
-            "E2E conftest must include 'scope': 'PRINCIPAL_ROLE:ALL' in the "
-            "OAuth token request data (inline or via variable). This is a valid "
-            "OAuth scope and must not be confused with the entity name 'ALL' "
-            "which is incorrect."
+        has_manifest_scope_helper = (
+            "get_polaris_scope" in conftest_text
+            and "_manifest_scope" in conftest_text
+            and bool(re.search(r"""["']scope["']\s*:\s*_manifest_scope""", conftest_text))
+        )
+        assert has_scope_literal or has_scope_variable or has_manifest_scope_helper, (
+            "E2E conftest must include an OAuth 'scope' field backed by "
+            "'PRINCIPAL_ROLE:ALL', either inline, via variable, or via the "
+            "shared manifest-driven get_polaris_scope() helper. This scope must "
+            "not be confused with the entity name 'ALL', which is incorrect."
         )
 
 

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -176,6 +176,50 @@ def test_purge_namespace_treats_missing_namespace_as_reset_success(
     dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
+def test_purge_namespace_initial_missing_namespace_returns_without_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeNoSuchNamespaceError(Exception):
+        """Test-only stand-in for PyIceberg's missing namespace exception."""
+
+    purge_catalog = Mock()
+    purge_catalog.list_tables.side_effect = FakeNoSuchNamespaceError("customer_360")
+    fresh_calls: list[bool] = []
+
+    def _get_catalog(*, fresh: bool = False) -> Mock | None:
+        fresh_calls.append(fresh)
+        return purge_catalog if len(fresh_calls) == 1 else None
+
+    monkeypatch.setattr(
+        dbt_utils,
+        "PyIcebergNoSuchNamespaceError",
+        FakeNoSuchNamespaceError,
+    )
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+    assert fresh_calls == [True]
+
+
+def test_purge_namespace_drop_failure_still_succeeds_when_verification_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = []
+    purge_catalog.drop_namespace.side_effect = RuntimeError("drop failed")
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
 def test_run_dbt_resets_raw_namespace_before_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -44,18 +44,45 @@ def test_purge_namespace_raises_when_verified_s3_cleanup_fails(
     verify_catalog = Mock()
     verify_catalog.list_tables.return_value = []
     catalogs = [purge_catalog, verify_catalog]
+    s3_client = Mock()
+    paginator = Mock()
+    paginator.paginate.return_value = [
+        {"Contents": [{"Key": "customer_360/stg_customers/data/file.parquet"}]}
+    ]
+    s3_client.get_paginator.return_value = paginator
+    s3_client.delete_objects.return_value = {
+        "Errors": [{"Key": "customer_360/stg_customers/data/file.parquet"}]
+    }
 
     def _get_catalog(*, fresh: bool = False) -> Mock:
         return catalogs.pop(0)
 
-    def _raise_s3_failure(*args: object, **kwargs: object) -> int:
-        raise RuntimeError("s3 boom")
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+    monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: s3_client)
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="delete_objects reported errors"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
+def test_purge_namespace_raises_when_storage_location_cannot_be_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
+    purge_catalog.load_table.side_effect = RuntimeError("load failed")
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
 
     monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
-    monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: Mock())
-    monkeypatch.setattr(dbt_utils, "_delete_s3_prefix", _raise_s3_failure)
 
-    with pytest.raises(dbt_utils.NamespaceResetError, match="S3 cleanup failed"):
+    with pytest.raises(
+        dbt_utils.NamespaceResetError,
+        match="Could not resolve storage location for customer_360.stg_customers",
+    ):
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -65,6 +65,26 @@ def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution
     ]
 
 
+def test_get_polaris_catalog_returns_none_when_service_endpoint_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyiceberg_module = ModuleType("pyiceberg")
+    pyiceberg_module.catalog = SimpleNamespace(load_catalog=lambda *args, **kwargs: object())
+
+    def _failing_service_endpoint(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("service lookup failed")
+
+    monkeypatch.setitem(sys.modules, "pyiceberg", pyiceberg_module)
+    monkeypatch.delenv("POLARIS_URI", raising=False)
+    monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
+    monkeypatch.setattr(dbt_utils, "ServiceEndpoint", _failing_service_endpoint)
+    monkeypatch.setattr(dbt_utils, "get_polaris_credentials", lambda: ("id", "secret"))
+    monkeypatch.setattr(dbt_utils, "get_minio_credentials", lambda: ("access", "secret"))
+    dbt_utils._clear_catalog_cache()
+
+    assert dbt_utils._get_polaris_catalog(fresh=True) is None
+
+
 def test_purge_namespace_raises_when_namespace_still_contains_tables(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -107,6 +127,35 @@ def test_purge_namespace_raises_when_verified_s3_cleanup_fails(
     monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: s3_client)
 
     with pytest.raises(dbt_utils.NamespaceResetError, match="delete_objects reported errors"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
+def test_purge_namespace_raises_when_storage_endpoint_cannot_be_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
+    table = Mock()
+    table.metadata.location = "s3://warehouse/customer_360/stg_customers"
+    purge_catalog.load_table.return_value = table
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    def _failing_service_endpoint(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("endpoint lookup failed")
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+    monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
+    monkeypatch.setattr(dbt_utils, "ServiceEndpoint", _failing_service_endpoint)
+
+    with pytest.raises(
+        dbt_utils.NamespaceResetError,
+        match="Could not resolve storage endpoint for cleanup in customer_360: RuntimeError",
+    ):
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -263,6 +263,7 @@ def test_purge_namespace_raises_when_fresh_catalog_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verified purges should fail when a fresh catalog cannot be created."""
+
     def _get_catalog(*, fresh: bool = False) -> None:
         return None
 
@@ -295,6 +296,7 @@ def test_purge_namespace_treats_missing_namespace_as_reset_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A missing namespace should count as an already-clean reset state."""
+
     class FakeNoSuchNamespaceError(Exception):
         """Test-only stand-in for PyIceberg's missing namespace exception."""
 
@@ -315,6 +317,7 @@ def test_purge_namespace_initial_missing_namespace_returns_without_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Initial missing namespaces should short-circuit without extra verification."""
+
     class FakeNoSuchNamespaceError(Exception):
         """Test-only stand-in for PyIceberg's missing namespace exception."""
 

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 
 import dbt_utils
+from testing.fixtures.credentials import get_polaris_scope, get_polaris_warehouse
 
 
 def test_clear_catalog_cache_drops_cached_catalog() -> None:
@@ -54,8 +55,8 @@ def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution
             "type": "rest",
             "uri": "http://example.test/api/catalog",
             "credential": "id:secret",
-            "scope": "PRINCIPAL_ROLE:ALL",
-            "warehouse": "floe-e2e",
+            "scope": get_polaris_scope(),
+            "warehouse": get_polaris_warehouse(),
             "s3.endpoint": "http://minio.test:9000",
             "s3.access-key-id": "access",
             "s3.secret-access-key": "secret",

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -33,6 +33,32 @@ def test_purge_namespace_raises_when_namespace_still_contains_tables(
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
+def test_purge_namespace_raises_when_verified_s3_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
+    table = Mock()
+    table.metadata.location = "s3://warehouse/customer_360/stg_customers"
+    purge_catalog.load_table.return_value = table
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    def _raise_s3_failure(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("s3 boom")
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+    monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: Mock())
+    monkeypatch.setattr(dbt_utils, "_delete_s3_prefix", _raise_s3_failure)
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="S3 cleanup failed"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
 def test_purge_namespace_uses_fresh_catalog_for_purge_and_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -124,3 +150,27 @@ def test_run_dbt_resets_raw_namespace_before_seed(
     dbt_utils.run_dbt(["seed"], project_dir)
 
     assert purge_calls == [("customer_360_raw", True)]
+
+
+def test_run_dbt_resets_model_namespace_before_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "customer-360"
+    project_dir.mkdir()
+
+    purge_calls: list[tuple[str, bool]] = []
+
+    def _record(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+        purge_calls.append((namespace, verify_empty))
+
+    monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _record)
+    monkeypatch.setattr(
+        dbt_utils.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    dbt_utils.run_dbt(["run"], project_dir)
+
+    assert purge_calls == [("customer_360", True)]

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -33,37 +33,54 @@ def test_purge_namespace_raises_when_namespace_still_contains_tables(
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
-def test_purge_namespace_returns_when_fresh_catalog_unavailable(
+def test_purge_namespace_uses_fresh_catalog_for_purge_and_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    stale_catalog = Mock()
-    stale_catalog.list_tables.return_value = []
-
-    def _get_catalog(*, fresh: bool = False) -> Mock | None:
-        if fresh:
-            return None
-        return stale_catalog
-
-    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
-
-    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
-
-
-def test_purge_namespace_returns_on_verification_exception(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    stale_catalog = Mock()
-    stale_catalog.list_tables.return_value = []
-    verification_catalog = Mock()
-    verification_catalog.list_tables.side_effect = RuntimeError("boom")
-    catalogs = [stale_catalog, verification_catalog]
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = []
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    fresh_calls: list[bool] = []
 
     def _get_catalog(*, fresh: bool = False) -> Mock:
-        return catalogs.pop(0) if fresh else stale_catalog
+        fresh_calls.append(fresh)
+        return purge_catalog if len(fresh_calls) == 1 else verify_catalog
 
     monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
 
     dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
+
+    assert fresh_calls == [True, True]
+
+
+def test_purge_namespace_raises_when_fresh_catalog_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _get_catalog(*, fresh: bool = False) -> None:
+        return None
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="verification catalog unavailable"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
+
+
+def test_purge_namespace_raises_on_verification_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = []
+    verification_catalog = Mock()
+    verification_catalog.list_tables.side_effect = RuntimeError("boom")
+    catalogs = [purge_catalog, verification_catalog, verification_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="verification failed: RuntimeError"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
 
 
 def test_purge_namespace_treats_missing_namespace_as_reset_success(

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -1,0 +1,76 @@
+"""Unit tests for Polaris/Iceberg namespace reset semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import dbt_utils
+
+
+def test_clear_catalog_cache_drops_cached_catalog() -> None:
+    dbt_utils._catalog_cache["catalog"] = object()
+
+    dbt_utils._clear_catalog_cache()
+
+    assert dbt_utils._catalog_cache == {}
+
+
+def test_purge_namespace_raises_when_namespace_still_contains_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_catalog = Mock()
+    fake_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", lambda fresh=False: fake_catalog)
+    monkeypatch.setattr(dbt_utils, "_delete_s3_prefix", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(dbt_utils.boto3, "client", lambda *args, **kwargs: Mock())
+
+    with pytest.raises(dbt_utils.NamespaceResetError, match="Namespace reset incomplete"):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
+def test_purge_namespace_treats_missing_namespace_as_reset_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeNoSuchNamespaceError(Exception):
+        """Test-only stand-in for PyIceberg's missing namespace exception."""
+
+    fake_catalog = Mock()
+    fake_catalog.list_tables.side_effect = FakeNoSuchNamespaceError("customer_360")
+
+    monkeypatch.setattr(
+        dbt_utils,
+        "PyIcebergNoSuchNamespaceError",
+        FakeNoSuchNamespaceError,
+    )
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", lambda fresh=False: fake_catalog)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
+def test_run_dbt_resets_raw_namespace_before_seed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "customer-360"
+    project_dir.mkdir()
+
+    purge_calls: list[tuple[str, bool]] = []
+
+    def _record(namespace: str, verify_empty: bool = False, retries: int = 3) -> None:
+        purge_calls.append((namespace, verify_empty))
+
+    monkeypatch.setattr(dbt_utils, "_purge_iceberg_namespace", _record)
+    monkeypatch.setattr(
+        dbt_utils.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    dbt_utils.run_dbt(["seed"], project_dir)
+
+    assert purge_calls == [("customer_360_raw", True)]

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -86,6 +86,27 @@ def test_purge_namespace_raises_when_storage_location_cannot_be_resolved(
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
+def test_purge_namespace_raises_when_purge_phase_table_enumeration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.side_effect = RuntimeError("catalog boom")
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    with pytest.raises(
+        dbt_utils.NamespaceResetError,
+        match="Could not enumerate tables for storage cleanup in customer_360: RuntimeError",
+    ):
+        dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
 def test_purge_namespace_uses_fresh_catalog_for_purge_and_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -33,6 +33,39 @@ def test_purge_namespace_raises_when_namespace_still_contains_tables(
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
+def test_purge_namespace_returns_when_fresh_catalog_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_catalog = Mock()
+    stale_catalog.list_tables.return_value = []
+
+    def _get_catalog(*, fresh: bool = False) -> Mock | None:
+        if fresh:
+            return None
+        return stale_catalog
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
+
+
+def test_purge_namespace_returns_on_verification_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_catalog = Mock()
+    stale_catalog.list_tables.return_value = []
+    verification_catalog = Mock()
+    verification_catalog.list_tables.side_effect = RuntimeError("boom")
+    catalogs = [stale_catalog, verification_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0) if fresh else stale_catalog
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=2)
+
+
 def test_purge_namespace_treats_missing_namespace_as_reset_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -17,6 +19,50 @@ def test_clear_catalog_cache_drops_cached_catalog() -> None:
     dbt_utils._clear_catalog_cache()
 
     assert dbt_utils._catalog_cache == {}
+
+
+def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_catalog = object()
+    pyiceberg_module = ModuleType("pyiceberg")
+    load_calls: list[dict[str, object]] = []
+
+    def _load_catalog(name: str, **kwargs: object) -> object:
+        assert name == "polaris"
+        load_calls.append(kwargs)
+        return fake_catalog
+
+    def _unexpected_service_endpoint(*args: object, **kwargs: object) -> object:
+        raise AssertionError("ServiceEndpoint should not be evaluated")
+
+    pyiceberg_module.catalog = SimpleNamespace(load_catalog=_load_catalog)
+
+    monkeypatch.setitem(sys.modules, "pyiceberg", pyiceberg_module)
+    monkeypatch.setenv("POLARIS_URI", "http://example.test/api/catalog")
+    monkeypatch.setenv("MINIO_ENDPOINT", "http://minio.test:9000")
+    monkeypatch.setattr(dbt_utils, "ServiceEndpoint", _unexpected_service_endpoint)
+    monkeypatch.setattr(dbt_utils, "get_polaris_credentials", lambda: ("id", "secret"))
+    monkeypatch.setattr(dbt_utils, "get_minio_credentials", lambda: ("access", "secret"))
+    dbt_utils._clear_catalog_cache()
+
+    catalog = dbt_utils._get_polaris_catalog(fresh=True)
+
+    assert catalog is fake_catalog
+    assert load_calls == [
+        {
+            "type": "rest",
+            "uri": "http://example.test/api/catalog",
+            "credential": "id:secret",
+            "scope": "PRINCIPAL_ROLE:ALL",
+            "warehouse": "floe-e2e",
+            "s3.endpoint": "http://minio.test:9000",
+            "s3.access-key-id": "access",
+            "s3.secret-access-key": "secret",
+            "s3.region": "us-east-1",
+            "s3.path-style-access": "true",
+        }
+    ]
 
 
 def test_purge_namespace_raises_when_namespace_still_contains_tables(

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -3,18 +3,23 @@
 from __future__ import annotations
 
 import sys
-from types import ModuleType
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
+import dbt_utils
 import pytest
 
-import dbt_utils
-from testing.fixtures.credentials import get_polaris_scope, get_polaris_warehouse
+from testing.fixtures.credentials import (
+    get_polaris_scope,
+    get_polaris_warehouse,
+)
+
+pytestmark = pytest.mark.requirement("VAL-RESET-IDEMPOTENCY")
 
 
 def test_clear_catalog_cache_drops_cached_catalog() -> None:
+    """Clearing the cache should remove any cached catalog instance."""
     dbt_utils._catalog_cache["catalog"] = object()
 
     dbt_utils._clear_catalog_cache()
@@ -25,6 +30,7 @@ def test_clear_catalog_cache_drops_cached_catalog() -> None:
 def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Explicit env endpoints should bypass ServiceEndpoint resolution."""
     fake_catalog = object()
     pyiceberg_module = ModuleType("pyiceberg")
     load_calls: list[dict[str, object]] = []
@@ -69,6 +75,7 @@ def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution
 def test_get_polaris_catalog_returns_none_when_service_endpoint_resolution_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Catalog loading should fail closed when service discovery blows up."""
     pyiceberg_module = ModuleType("pyiceberg")
     pyiceberg_module.catalog = SimpleNamespace(load_catalog=lambda *args, **kwargs: object())
 
@@ -89,6 +96,7 @@ def test_get_polaris_catalog_returns_none_when_service_endpoint_resolution_fails
 def test_purge_namespace_raises_when_namespace_still_contains_tables(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verification should fail if tables remain after a purge attempt."""
     fake_catalog = Mock()
     fake_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
 
@@ -103,6 +111,7 @@ def test_purge_namespace_raises_when_namespace_still_contains_tables(
 def test_purge_namespace_raises_when_verified_s3_cleanup_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verified purges should surface object-store deletion errors."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
     table = Mock()
@@ -134,6 +143,7 @@ def test_purge_namespace_raises_when_verified_s3_cleanup_fails(
 def test_purge_namespace_raises_when_storage_endpoint_cannot_be_resolved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verified purges should fail when cleanup cannot resolve storage."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
     table = Mock()
@@ -163,6 +173,7 @@ def test_purge_namespace_raises_when_storage_endpoint_cannot_be_resolved(
 def test_purge_namespace_empty_namespace_succeeds_when_storage_endpoint_resolution_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Empty namespaces should not fail cleanup just because storage lookup fails."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = []
     verify_catalog = Mock()
@@ -185,6 +196,7 @@ def test_purge_namespace_empty_namespace_succeeds_when_storage_endpoint_resoluti
 def test_purge_namespace_raises_when_storage_location_cannot_be_resolved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Purges should fail when table storage locations cannot be determined."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = [("customer_360", "stg_customers")]
     purge_catalog.load_table.side_effect = RuntimeError("load failed")
@@ -207,6 +219,7 @@ def test_purge_namespace_raises_when_storage_location_cannot_be_resolved(
 def test_purge_namespace_raises_when_purge_phase_table_enumeration_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Purges should fail when table enumeration fails during cleanup."""
     purge_catalog = Mock()
     purge_catalog.list_tables.side_effect = RuntimeError("catalog boom")
     verify_catalog = Mock()
@@ -228,6 +241,7 @@ def test_purge_namespace_raises_when_purge_phase_table_enumeration_fails(
 def test_purge_namespace_uses_fresh_catalog_for_purge_and_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verified purges should use fresh catalog clients for both phases."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = []
     verify_catalog = Mock()
@@ -248,6 +262,7 @@ def test_purge_namespace_uses_fresh_catalog_for_purge_and_verification(
 def test_purge_namespace_raises_when_fresh_catalog_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verified purges should fail when a fresh catalog cannot be created."""
     def _get_catalog(*, fresh: bool = False) -> None:
         return None
 
@@ -260,6 +275,7 @@ def test_purge_namespace_raises_when_fresh_catalog_unavailable(
 def test_purge_namespace_raises_on_verification_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verification exceptions should be surfaced as reset failures."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = []
     verification_catalog = Mock()
@@ -278,6 +294,7 @@ def test_purge_namespace_raises_on_verification_exception(
 def test_purge_namespace_treats_missing_namespace_as_reset_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A missing namespace should count as an already-clean reset state."""
     class FakeNoSuchNamespaceError(Exception):
         """Test-only stand-in for PyIceberg's missing namespace exception."""
 
@@ -297,6 +314,7 @@ def test_purge_namespace_treats_missing_namespace_as_reset_success(
 def test_purge_namespace_initial_missing_namespace_returns_without_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Initial missing namespaces should short-circuit without extra verification."""
     class FakeNoSuchNamespaceError(Exception):
         """Test-only stand-in for PyIceberg's missing namespace exception."""
 
@@ -323,6 +341,7 @@ def test_purge_namespace_initial_missing_namespace_returns_without_verification(
 def test_purge_namespace_drop_failure_still_succeeds_when_verification_is_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Drop failures should not matter once verification proves the namespace is empty."""
     purge_catalog = Mock()
     purge_catalog.list_tables.return_value = []
     purge_catalog.drop_namespace.side_effect = RuntimeError("drop failed")
@@ -342,6 +361,7 @@ def test_run_dbt_resets_raw_namespace_before_seed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """dbt seed should verify-reset the raw namespace before execution."""
     project_dir = tmp_path / "customer-360"
     project_dir.mkdir()
 
@@ -366,6 +386,7 @@ def test_run_dbt_resets_model_namespace_before_run(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """dbt run should verify-reset the model namespace before execution."""
     project_dir = tmp_path / "customer-360"
     project_dir.mkdir()
 

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -159,6 +159,28 @@ def test_purge_namespace_raises_when_storage_endpoint_cannot_be_resolved(
         dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
 
 
+def test_purge_namespace_empty_namespace_succeeds_when_storage_endpoint_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    purge_catalog = Mock()
+    purge_catalog.list_tables.return_value = []
+    verify_catalog = Mock()
+    verify_catalog.list_tables.return_value = []
+    catalogs = [purge_catalog, verify_catalog]
+
+    def _get_catalog(*, fresh: bool = False) -> Mock:
+        return catalogs.pop(0)
+
+    def _failing_service_endpoint(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("endpoint lookup failed")
+
+    monkeypatch.setattr(dbt_utils, "_get_polaris_catalog", _get_catalog)
+    monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
+    monkeypatch.setattr(dbt_utils, "ServiceEndpoint", _failing_service_endpoint)
+
+    dbt_utils._purge_iceberg_namespace("customer_360", verify_empty=True, retries=1)
+
+
 def test_purge_namespace_raises_when_storage_location_cannot_be_resolved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_demo_platform_catalog_contract.py
+++ b/tests/unit/test_demo_platform_catalog_contract.py
@@ -1,0 +1,63 @@
+"""Contract tests for demo manifest and test/demo chart catalog alignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_MANIFEST = REPO_ROOT / "demo" / "manifest.yaml"
+VALUES_DEMO = REPO_ROOT / "charts" / "floe-platform" / "values-demo.yaml"
+VALUES_TEST = REPO_ROOT / "charts" / "floe-platform" / "values-test.yaml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    parsed = yaml.safe_load(path.read_text())
+    assert isinstance(parsed, dict), f"{path} did not parse to a dict"
+    return parsed
+
+
+def _manifest_catalog_config() -> dict[str, Any]:
+    return _load_yaml(DEMO_MANIFEST)["plugins"]["catalog"]["config"]
+
+
+def _manifest_storage_config() -> dict[str, Any]:
+    return _load_yaml(DEMO_MANIFEST)["plugins"]["storage"]["config"]
+
+
+def _assert_bootstrap_alignment(values_path: Path) -> None:
+    values = _load_yaml(values_path)
+    bootstrap = values["polaris"]["bootstrap"]
+    auth = values["polaris"]["auth"]["bootstrapCredentials"]
+    manifest_catalog = _manifest_catalog_config()
+    manifest_storage = _manifest_storage_config()
+
+    expected_bucket_uri = f"s3://{manifest_storage['bucket']}"
+    assert bootstrap["catalogName"] == manifest_catalog["warehouse"], (
+        f"{values_path.name} polaris.bootstrap.catalogName must match "
+        f"demo/manifest.yaml plugins.catalog.config.warehouse"
+    )
+    assert bootstrap["defaultBaseLocation"] == expected_bucket_uri, (
+        f"{values_path.name} polaris.bootstrap.defaultBaseLocation must match "
+        f"demo/manifest.yaml plugins.storage.config.bucket"
+    )
+    assert expected_bucket_uri in bootstrap["allowedLocations"], (
+        f"{values_path.name} polaris.bootstrap.allowedLocations must include "
+        f"the manifest storage bucket URI"
+    )
+    assert auth["clientId"] == manifest_catalog["oauth2"]["client_id"], (
+        f"{values_path.name} Polaris bootstrap clientId must match the demo manifest"
+    )
+    assert auth["clientSecret"] == manifest_catalog["oauth2"]["client_secret"], (
+        f"{values_path.name} Polaris bootstrap clientSecret must match the demo manifest"
+    )
+
+
+def test_values_demo_aligns_with_demo_manifest_catalog_contract() -> None:
+    _assert_bootstrap_alignment(VALUES_DEMO)
+
+
+def test_values_test_aligns_with_demo_manifest_catalog_contract() -> None:
+    _assert_bootstrap_alignment(VALUES_TEST)

--- a/tests/unit/test_e2e_runner_devpod_path.py
+++ b/tests/unit/test_e2e_runner_devpod_path.py
@@ -106,9 +106,20 @@ def test_load_image_scopes_devpod_transport_to_devpod_paths_only() -> None:
     assert "devpod_remote_command" in devpod_branch.group(1), (
         "The explicit DevPod branch must use the shared DevPod transport helper."
     )
-    assert 'if [[ -n "${DEVPOD_WORKSPACE:-}" ]]; then' in body, (
-        "The auto branch must gate DevPod fallback on DEVPOD_WORKSPACE."
+    assert "if devpod_context_configured; then" in body, (
+        "The auto branch must gate DevPod fallback on the shared DevPod "
+        "context detection helper."
     )
+
+
+@pytest.mark.requirement("AC-3")
+def test_devpod_workspace_defaults_from_kubeconfig_when_env_unset() -> None:
+    """The runner must infer the workspace name from a synced DevPod kubeconfig."""
+    script = _read_script()
+
+    assert 'first_kubeconfig="${KUBECONFIG%%:*}"' in script
+    assert 'if [[ "${kubeconfig_name}" =~ ^devpod-(.+)\\.config$ ]]; then' in script
+    assert 'printf \'%s\\n\' "${BASH_REMATCH[1]}"' in script
 
 
 @pytest.mark.requirement("AC-4")

--- a/tests/unit/test_e2e_runner_devpod_path.py
+++ b/tests/unit/test_e2e_runner_devpod_path.py
@@ -107,8 +107,7 @@ def test_load_image_scopes_devpod_transport_to_devpod_paths_only() -> None:
         "The explicit DevPod branch must use the shared DevPod transport helper."
     )
     assert "if devpod_context_configured; then" in body, (
-        "The auto branch must gate DevPod fallback on the shared DevPod "
-        "context detection helper."
+        "The auto branch must gate DevPod fallback on the shared DevPod context detection helper."
     )
 
 
@@ -119,7 +118,7 @@ def test_devpod_workspace_defaults_from_kubeconfig_when_env_unset() -> None:
 
     assert 'first_kubeconfig="${KUBECONFIG%%:*}"' in script
     assert 'if [[ "${kubeconfig_name}" =~ ^devpod-(.+)\\.config$ ]]; then' in script
-    assert 'printf \'%s\\n\' "${BASH_REMATCH[1]}"' in script
+    assert "printf '%s\\n' \"${BASH_REMATCH[1]}\"" in script
 
 
 @pytest.mark.requirement("AC-4")

--- a/tests/unit/test_iceberg_purge.py
+++ b/tests/unit/test_iceberg_purge.py
@@ -149,6 +149,23 @@ class TestS3PrefixDeletion:
     """Verify S3 objects under the table prefix are deleted after purge."""
 
     @pytest.mark.requirement("AC-2")
+    def test_delete_s3_prefix_raises_on_partial_delete_errors(self) -> None:
+        """In-band delete_objects errors must raise instead of counting as success."""
+        mod = _load_dbt_utils()
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Contents": [{"Key": "ns1/t1/data/file1.parquet"}]},
+        ]
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_s3.delete_objects.return_value = {
+            "Errors": [{"Key": "ns1/t1/data/file1.parquet", "Code": "AccessDenied"}]
+        }
+
+        with pytest.raises(RuntimeError, match="delete_objects reported errors"):
+            mod._delete_s3_prefix(mock_s3, "warehouse", "ns1/t1")
+
+    @pytest.mark.requirement("AC-2")
     def test_s3_delete_called_after_purge(self) -> None:
         """After purge_table, S3 objects under the table prefix must be deleted."""
         mod = _load_dbt_utils()

--- a/tests/unit/test_unit_c_boundary_wrapper.py
+++ b/tests/unit/test_unit_c_boundary_wrapper.py
@@ -33,8 +33,10 @@ def test_boundary_wrapper_restores_demo_image_before_waiting_for_flux() -> None:
     script = _BOUNDARY_SCRIPT.read_text()
     assert "ensure_remote_demo_image_loaded()" in script
     assert "sync_devpod_checkout" in script
-    assert "floe-dagster-demo:latest" in script
-    assert "\"KIND_CLUSTER_NAME='${FLOE_KIND_CLUSTER}' make build-demo-image\"" in script
+    assert 'local demo_image="${FLOE_DEMO_IMAGE}"' in script
+    assert "FLOE_DEMO_IMAGE_REPOSITORY='${FLOE_DEMO_IMAGE_REPOSITORY}'" in script
+    assert "FLOE_DEMO_IMAGE_TAG='${FLOE_DEMO_IMAGE_TAG}'" in script
+    assert "KIND_CLUSTER_NAME='${FLOE_KIND_CLUSTER}' make build-demo-image" in script
     assert "\"kind load docker-image '${demo_image}' --name '${FLOE_KIND_CLUSTER}'\"" in script
 
 

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -1,11 +1,23 @@
-"""Structural tests for validation lane markers."""
+"""Tests for validation lane markers."""
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+E2E_CONFTEST_PATH = REPO_ROOT / "tests" / "e2e" / "conftest.py"
+
+_E2E_CONFTEST_SPEC = importlib.util.spec_from_file_location(
+    "tests.e2e.conftest_for_validation_markers",
+    E2E_CONFTEST_PATH,
+)
+assert _E2E_CONFTEST_SPEC is not None
+assert _E2E_CONFTEST_SPEC.loader is not None
+e2e_conftest = importlib.util.module_from_spec(_E2E_CONFTEST_SPEC)
+_E2E_CONFTEST_SPEC.loader.exec_module(e2e_conftest)
 
 
 def test_pyproject_registers_validation_lane_markers() -> None:
@@ -29,3 +41,68 @@ def test_e2e_conftest_defaults_unclassified_items_to_platform_blackbox() -> None
 
     assert "platform_blackbox" in conftest
     assert "item.add_marker(pytest.mark.platform_blackbox)" in conftest
+
+
+class _FakeConfig:
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, str]] = []
+        self.option = SimpleNamespace(reruns=0, reruns_delay=0, fail_on_flaky=False, only_rerun=[])
+
+    def addinivalue_line(self, section: str, value: str) -> None:
+        self.lines.append((section, value))
+
+
+class _FakeItem:
+    def __init__(self, nodeid: str, marker_names: list[str]) -> None:
+        self.nodeid = nodeid
+        self._markers = [SimpleNamespace(name=name) for name in marker_names]
+
+    def iter_markers(self) -> list[SimpleNamespace]:
+        return list(self._markers)
+
+    def add_marker(self, marker: object) -> None:
+        self._markers.append(SimpleNamespace(name=getattr(marker, "name", str(marker))))
+
+    @property
+    def marker_names(self) -> list[str]:
+        return [marker.name for marker in self._markers]
+
+
+def test_pytest_configure_registers_validation_lane_markers() -> None:
+    config = _FakeConfig()
+
+    e2e_conftest.pytest_configure(config)
+
+    assert (
+        "markers",
+        "bootstrap: mark test as bootstrap/admin validation",
+    ) in config.lines
+    assert (
+        "markers",
+        "platform_blackbox: mark test as deployed in-cluster product validation",
+    ) in config.lines
+    assert (
+        "markers",
+        "developer_workflow: mark test as repo-aware host validation",
+    ) in config.lines
+
+
+def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() -> None:
+    config = _FakeConfig()
+    items = [
+        _FakeItem("tests/e2e/test_unclassified.py::test_unclassified", ["e2e"]),
+        _FakeItem("tests/e2e/test_bootstrap.py::test_bootstrap", ["e2e", "bootstrap"]),
+        _FakeItem(
+            "tests/e2e/test_service_failure_resilience_e2e.py::test_destructive",
+            ["e2e"],
+        ),
+        _FakeItem("tests/unit/test_non_e2e.py::test_non_e2e", []),
+    ]
+
+    e2e_conftest.pytest_collection_modifyitems(config, items)
+
+    assert items[-1].nodeid == "tests/e2e/test_service_failure_resilience_e2e.py::test_destructive"
+    assert items[0].marker_names.count("platform_blackbox") == 1
+    assert items[1].marker_names == ["e2e", "bootstrap"]
+    assert items[2].marker_names == []
+    assert items[3].marker_names.count("platform_blackbox") == 1

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -106,3 +106,33 @@ def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() ->
     assert items[1].marker_names == ["e2e", "bootstrap"]
     assert items[2].marker_names == []
     assert items[3].marker_names.count("platform_blackbox") == 1
+
+
+def test_bootstrap_modules_are_explicitly_marked() -> None:
+    helm_workflow = (REPO_ROOT / "tests" / "e2e" / "test_helm_workflow.py").read_text()
+    platform_bootstrap = (REPO_ROOT / "tests" / "e2e" / "test_platform_bootstrap.py").read_text()
+    platform_deployment = (
+        REPO_ROOT / "tests" / "e2e" / "test_platform_deployment_e2e.py"
+    ).read_text()
+
+    assert "pytest.mark.bootstrap" in helm_workflow
+    assert "pytest.mark.bootstrap" in platform_bootstrap
+    assert "pytest.mark.bootstrap" in platform_deployment
+
+
+def test_developer_workflow_outliers_are_explicitly_marked() -> None:
+    profile_isolation = (REPO_ROOT / "tests" / "e2e" / "test_profile_isolation.py").read_text()
+    governance = (REPO_ROOT / "tests" / "e2e" / "test_governance.py").read_text()
+    runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
+
+    assert "pytest.mark.developer_workflow" in profile_isolation
+    assert "def test_pip_audit_clean" in governance
+    assert "@pytest.mark.developer_workflow" in governance
+    assert "pytest.mark.developer_workflow" in runtime_loader
+
+
+def test_runtime_loader_uses_service_contract_not_localhost_literal() -> None:
+    runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
+
+    assert 'ServiceEndpoint("dagster-webserver")' in runtime_loader
+    assert 'DAGSTER_HOST = "127.0.0.1"' not in runtime_loader

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -153,14 +153,18 @@ def test_selected_items_skip_smoke_check_for_bootstrap_and_developer_workflow_on
 
 def test_bootstrap_modules_are_explicitly_marked() -> None:
     helm_workflow = (REPO_ROOT / "tests" / "e2e" / "test_helm_workflow.py").read_text()
+
+    assert "pytest.mark.bootstrap" in helm_workflow
+
+
+def test_platform_runtime_modules_are_explicitly_marked_platform_blackbox() -> None:
     platform_bootstrap = (REPO_ROOT / "tests" / "e2e" / "test_platform_bootstrap.py").read_text()
     platform_deployment = (
         REPO_ROOT / "tests" / "e2e" / "test_platform_deployment_e2e.py"
     ).read_text()
 
-    assert "pytest.mark.bootstrap" in helm_workflow
-    assert "pytest.mark.bootstrap" in platform_bootstrap
-    assert "pytest.mark.bootstrap" in platform_deployment
+    assert "pytest.mark.platform_blackbox" in platform_bootstrap
+    assert "pytest.mark.platform_blackbox" in platform_deployment
 
 
 def test_developer_workflow_outliers_are_explicitly_marked() -> None:
@@ -169,7 +173,7 @@ def test_developer_workflow_outliers_are_explicitly_marked() -> None:
     runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
 
     assert "pytest.mark.developer_workflow" in profile_isolation
-    assert "def test_pip_audit_clean" in governance
+    assert "class TestDependencyGovernance" in governance
     assert "@pytest.mark.developer_workflow" in governance
     assert "pytest.mark.developer_workflow" in runtime_loader
 

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -1,0 +1,31 @@
+"""Structural tests for validation lane markers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_pyproject_registers_validation_lane_markers() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert '"bootstrap: Marks admin/bootstrap validation"' in pyproject
+    assert '"platform_blackbox: Marks in-cluster product validation"' in pyproject
+    assert '"developer_workflow: Marks repo-aware host validation"' in pyproject
+
+
+def test_e2e_conftest_registers_lane_markers() -> None:
+    conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
+
+    assert 'bootstrap: mark test as bootstrap/admin validation' in conftest
+    assert 'platform_blackbox: mark test as deployed in-cluster product validation' in conftest
+    assert 'developer_workflow: mark test as repo-aware host validation' in conftest
+
+
+def test_e2e_conftest_defaults_unclassified_items_to_platform_blackbox() -> None:
+    conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
+
+    assert "platform_blackbox" in conftest
+    assert "item.add_marker(pytest.mark.platform_blackbox)" in conftest

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -4,23 +4,31 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 E2E_CONFTEST_PATH = REPO_ROOT / "tests" / "e2e" / "conftest.py"
 
-_E2E_CONFTEST_SPEC = importlib.util.spec_from_file_location(
-    "tests.e2e.conftest_for_validation_markers",
-    E2E_CONFTEST_PATH,
-)
-assert _E2E_CONFTEST_SPEC is not None
-assert _E2E_CONFTEST_SPEC.loader is not None
-e2e_conftest = importlib.util.module_from_spec(_E2E_CONFTEST_SPEC)
-_E2E_CONFTEST_SPEC.loader.exec_module(e2e_conftest)
+pytestmark = pytest.mark.requirement("VAL-LANE-MARKERS")
+
+
+def _load_e2e_conftest() -> ModuleType:
+    """Load the E2E conftest module lazily for structural tests."""
+    spec = importlib.util.spec_from_file_location(
+        "tests.e2e.conftest_for_validation_markers",
+        E2E_CONFTEST_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_pyproject_registers_validation_lane_markers() -> None:
+    """Pyproject should declare the validation-lane markers."""
     pyproject = (REPO_ROOT / "pyproject.toml").read_text()
 
     assert '"bootstrap: Marks admin/bootstrap validation"' in pyproject
@@ -29,6 +37,7 @@ def test_pyproject_registers_validation_lane_markers() -> None:
 
 
 def test_e2e_conftest_registers_lane_markers() -> None:
+    """The E2E conftest should register the same lane markers at runtime."""
     conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
 
     assert 'bootstrap: mark test as bootstrap/admin validation' in conftest
@@ -37,6 +46,7 @@ def test_e2e_conftest_registers_lane_markers() -> None:
 
 
 def test_e2e_conftest_defaults_unclassified_items_to_platform_blackbox() -> None:
+    """Unclassified E2E tests should default into the platform lane."""
     conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
 
     assert "platform_blackbox" in conftest
@@ -69,9 +79,10 @@ class _FakeItem:
 
 
 def test_pytest_configure_registers_validation_lane_markers() -> None:
+    """Runtime pytest configuration should publish the lane markers."""
     config = _FakeConfig()
 
-    e2e_conftest.pytest_configure(config)
+    _load_e2e_conftest().pytest_configure(config)
 
     assert (
         "markers",
@@ -88,6 +99,7 @@ def test_pytest_configure_registers_validation_lane_markers() -> None:
 
 
 def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() -> None:
+    """Collection should default lanes and still keep destructive ordering."""
     config = _FakeConfig()
     items = [
         _FakeItem("tests/e2e/test_unclassified.py::test_unclassified", ["e2e"]),
@@ -99,7 +111,7 @@ def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() ->
         _FakeItem("tests/unit/test_non_e2e.py::test_non_e2e", []),
     ]
 
-    e2e_conftest.pytest_collection_modifyitems(config, items)
+    _load_e2e_conftest().pytest_collection_modifyitems(config, items)
 
     assert items[-1].nodeid == "tests/e2e/test_service_failure_resilience_e2e.py::test_destructive"
     assert items[0].marker_names.count("platform_blackbox") == 1
@@ -109,55 +121,62 @@ def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() ->
 
 
 def test_selected_items_require_smoke_check_for_platform_blackbox() -> None:
+    """Platform-blackbox selections should trigger the smoke check."""
     items = [
         _FakeItem("tests/e2e/test_platform.py::test_live", ["e2e", "platform_blackbox"]),
         _FakeItem("tests/e2e/test_dev.py::test_local", ["developer_workflow"]),
     ]
 
-    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is True
+    assert _load_e2e_conftest()._selected_items_require_infrastructure_smoke_check(items) is True
 
 
 def test_selected_items_require_smoke_check_for_destructive() -> None:
+    """Destructive selections should trigger the smoke check."""
     items = [
         _FakeItem("tests/e2e/test_destructive.py::test_breakage", ["e2e", "destructive"]),
     ]
 
-    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is True
+    assert _load_e2e_conftest()._selected_items_require_infrastructure_smoke_check(items) is True
 
 
 def test_selected_items_skip_smoke_check_for_developer_workflow_only() -> None:
+    """Developer-workflow-only selections should skip the smoke check."""
     items = [
         _FakeItem("tests/e2e/test_profile.py::test_repo", ["e2e", "developer_workflow"]),
         _FakeItem("tests/e2e/test_repo.py::test_governance", ["e2e", "developer_workflow"]),
     ]
 
-    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+    assert _load_e2e_conftest()._selected_items_require_infrastructure_smoke_check(items) is False
 
 
 def test_selected_items_skip_smoke_check_for_bootstrap_only() -> None:
+    """Bootstrap-only selections should skip the smoke check."""
     items = [
         _FakeItem("tests/e2e/test_bootstrap.py::test_admin", ["e2e", "bootstrap"]),
     ]
 
-    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+    assert _load_e2e_conftest()._selected_items_require_infrastructure_smoke_check(items) is False
 
 
 def test_selected_items_skip_smoke_check_for_bootstrap_and_developer_workflow_only() -> None:
+    """Bootstrap plus developer-workflow selections should skip the smoke check."""
     items = [
         _FakeItem("tests/e2e/test_bootstrap.py::test_admin", ["e2e", "bootstrap"]),
         _FakeItem("tests/e2e/test_profile.py::test_repo", ["e2e", "developer_workflow"]),
     ]
 
-    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+    assert _load_e2e_conftest()._selected_items_require_infrastructure_smoke_check(items) is False
 
 
 def test_bootstrap_modules_are_explicitly_marked() -> None:
+    """Bootstrap E2E modules should be explicitly labeled."""
     helm_workflow = (REPO_ROOT / "tests" / "e2e" / "test_helm_workflow.py").read_text()
 
     assert "pytest.mark.bootstrap" in helm_workflow
 
 
 def test_platform_runtime_modules_are_explicitly_marked_platform_blackbox() -> None:
+    """Runtime-heavy E2E modules should be explicitly labeled as platform blackbox."""
     platform_bootstrap = (REPO_ROOT / "tests" / "e2e" / "test_platform_bootstrap.py").read_text()
     platform_deployment = (
         REPO_ROOT / "tests" / "e2e" / "test_platform_deployment_e2e.py"
@@ -168,6 +187,7 @@ def test_platform_runtime_modules_are_explicitly_marked_platform_blackbox() -> N
 
 
 def test_developer_workflow_outliers_are_explicitly_marked() -> None:
+    """Repo-aware E2E outliers should be explicitly labeled."""
     profile_isolation = (REPO_ROOT / "tests" / "e2e" / "test_profile_isolation.py").read_text()
     governance = (REPO_ROOT / "tests" / "e2e" / "test_governance.py").read_text()
     runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
@@ -179,6 +199,7 @@ def test_developer_workflow_outliers_are_explicitly_marked() -> None:
 
 
 def test_runtime_loader_uses_service_contract_not_localhost_literal() -> None:
+    """Runtime-loader tests should use the service contract instead of localhost."""
     runtime_loader = (REPO_ROOT / "tests" / "e2e" / "test_runtime_loader_e2e.py").read_text()
 
     assert 'ServiceEndpoint("dagster-webserver")' in runtime_loader

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -120,6 +120,21 @@ def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() ->
     assert items[3].marker_names.count("platform_blackbox") == 1
 
 
+def test_pytest_collection_modifyitems_defaults_unmarked_e2e_paths() -> None:
+    """Unmarked tests under tests/e2e should still enter the platform lane."""
+    config = _FakeConfig()
+    items = [
+        _FakeItem("tests/e2e/test_asset_discovery.py::test_discovers_assets", []),
+        _FakeItem("tests/unit/test_non_e2e.py::test_non_e2e", []),
+    ]
+
+    _load_e2e_conftest().pytest_collection_modifyitems(config, items)
+
+    assert items[0].marker_names.count("e2e") == 1
+    assert items[0].marker_names.count("platform_blackbox") == 1
+    assert items[1].marker_names == []
+
+
 def test_selected_items_require_smoke_check_for_platform_blackbox() -> None:
     """Platform-blackbox selections should trigger the smoke check."""
     items = [

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -108,6 +108,49 @@ def test_pytest_collection_modifyitems_defaults_and_preserves_lane_ordering() ->
     assert items[3].marker_names.count("platform_blackbox") == 1
 
 
+def test_selected_items_require_smoke_check_for_platform_blackbox() -> None:
+    items = [
+        _FakeItem("tests/e2e/test_platform.py::test_live", ["e2e", "platform_blackbox"]),
+        _FakeItem("tests/e2e/test_dev.py::test_local", ["developer_workflow"]),
+    ]
+
+    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is True
+
+
+def test_selected_items_require_smoke_check_for_destructive() -> None:
+    items = [
+        _FakeItem("tests/e2e/test_destructive.py::test_breakage", ["e2e", "destructive"]),
+    ]
+
+    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is True
+
+
+def test_selected_items_skip_smoke_check_for_developer_workflow_only() -> None:
+    items = [
+        _FakeItem("tests/e2e/test_profile.py::test_repo", ["e2e", "developer_workflow"]),
+        _FakeItem("tests/e2e/test_repo.py::test_governance", ["e2e", "developer_workflow"]),
+    ]
+
+    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+
+
+def test_selected_items_skip_smoke_check_for_bootstrap_only() -> None:
+    items = [
+        _FakeItem("tests/e2e/test_bootstrap.py::test_admin", ["e2e", "bootstrap"]),
+    ]
+
+    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+
+
+def test_selected_items_skip_smoke_check_for_bootstrap_and_developer_workflow_only() -> None:
+    items = [
+        _FakeItem("tests/e2e/test_bootstrap.py::test_admin", ["e2e", "bootstrap"]),
+        _FakeItem("tests/e2e/test_profile.py::test_repo", ["e2e", "developer_workflow"]),
+    ]
+
+    assert e2e_conftest._selected_items_require_infrastructure_smoke_check(items) is False
+
+
 def test_bootstrap_modules_are_explicitly_marked() -> None:
     helm_workflow = (REPO_ROOT / "tests" / "e2e" / "test_helm_workflow.py").read_text()
     platform_bootstrap = (REPO_ROOT / "tests" / "e2e" / "test_platform_bootstrap.py").read_text()

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -40,9 +40,9 @@ def test_e2e_conftest_registers_lane_markers() -> None:
     """The E2E conftest should register the same lane markers at runtime."""
     conftest = (REPO_ROOT / "tests" / "e2e" / "conftest.py").read_text()
 
-    assert 'bootstrap: mark test as bootstrap/admin validation' in conftest
-    assert 'platform_blackbox: mark test as deployed in-cluster product validation' in conftest
-    assert 'developer_workflow: mark test as repo-aware host validation' in conftest
+    assert "bootstrap: mark test as bootstrap/admin validation" in conftest
+    assert "platform_blackbox: mark test as deployed in-cluster product validation" in conftest
+    assert "developer_workflow: mark test as repo-aware host validation" in conftest
 
 
 def test_e2e_conftest_defaults_unclassified_items_to_platform_blackbox() -> None:

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -37,3 +37,23 @@ def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive(
     assert "test-e2e-cluster.sh" in script
     assert "test-developer-workflow.sh" in script
     assert "TEST_SUITE=e2e-destructive" in script
+
+
+def test_full_runner_only_reuses_platform_image_after_successful_platform_lane() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
+
+    assert 'CAN_REUSE_PLATFORM_IMAGE=false' in script
+    assert 'CAN_REUSE_PLATFORM_IMAGE=true' in script
+    assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
+    assert 'SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive' in script
+    assert 'elif TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then' in script
+
+
+def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
+
+    assert 'CLEANUP_FAILED=false' in script
+    assert 'CLEANUP_FAILED=true' in script
+    assert 'DESTRUCTIVE_EXIT=1' in script
+    assert 'Skipping destructive tests because platform cleanup failed.' in script
+    assert 'Destructive: SKIPPED (cleanup failed)' in script

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -39,20 +39,20 @@ def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive(
     """The full runner should execute lanes in the documented order."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
-    assert 'BOOTSTRAP_EXIT=0' in script
-    assert 'PLATFORM_EXIT=0' in script
-    assert 'DEVELOPER_EXIT=0' in script
-    assert 'DESTRUCTIVE_EXIT=0' in script
+    assert "BOOTSTRAP_EXIT=0" in script
+    assert "PLATFORM_EXIT=0" in script
+    assert "DEVELOPER_EXIT=0" in script
+    assert "DESTRUCTIVE_EXIT=0" in script
 
     assert "test-bootstrap-validation.sh" in script
     assert "test-e2e-cluster.sh" in script
     assert "test-developer-workflow.sh" in script
     assert "TEST_SUITE=e2e-destructive" in script
 
-    bootstrap_index = script.index('test-bootstrap-validation.sh')
-    platform_index = script.index('Platform blackbox validation')
-    developer_index = script.index('test-developer-workflow.sh')
-    destructive_index = script.index('=== Phase 4: Destructive E2E Tests ===')
+    bootstrap_index = script.index("test-bootstrap-validation.sh")
+    platform_index = script.index("Platform blackbox validation")
+    developer_index = script.index("test-developer-workflow.sh")
+    destructive_index = script.index("=== Phase 4: Destructive E2E Tests ===")
 
     assert bootstrap_index < platform_index < developer_index < destructive_index
 
@@ -61,10 +61,10 @@ def test_full_runner_only_reuses_platform_image_after_successful_platform_lane()
     """Destructive reuse should only happen after a successful platform lane."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
-    assert 'CAN_REUSE_PLATFORM_IMAGE=false' in script
-    assert 'CAN_REUSE_PLATFORM_IMAGE=true' in script
+    assert "CAN_REUSE_PLATFORM_IMAGE=false" in script
+    assert "CAN_REUSE_PLATFORM_IMAGE=true" in script
     assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
-    assert 'SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive' in script
+    assert "SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive" in script
     assert 'if TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then' in script
 
 
@@ -72,15 +72,15 @@ def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
     """Cleanup failures should still be surfaced in the final summary path."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
-    assert 'CLEANUP_FAILED=false' in script
-    assert 'CLEANUP_FAILED=true' in script
-    assert 'DESTRUCTIVE_EXIT=1' in script
+    assert "CLEANUP_FAILED=false" in script
+    assert "CLEANUP_FAILED=true" in script
+    assert "DESTRUCTIVE_EXIT=1" in script
     assert (
         'if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" '
         "--no-headers 2>/dev/null | wc -l | tr -d ' '); then"
     ) in script
-    assert 'Skipping destructive tests because platform cleanup failed.' in script
-    assert 'Destructive: SKIPPED (cleanup failed)' in script
+    assert "Skipping destructive tests because platform cleanup failed." in script
+    assert "Destructive: SKIPPED (cleanup failed)" in script
     assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
 
 

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -55,5 +55,6 @@ def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
     assert 'CLEANUP_FAILED=false' in script
     assert 'CLEANUP_FAILED=true' in script
     assert 'DESTRUCTIVE_EXIT=1' in script
+    assert 'if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d \' \'); then' in script
     assert 'Skipping destructive tests because platform cleanup failed.' in script
     assert 'Destructive: SKIPPED (cleanup failed)' in script

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -71,3 +71,12 @@ def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
     assert 'Skipping destructive tests because platform cleanup failed.' in script
     assert 'Destructive: SKIPPED (cleanup failed)' in script
     assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
+
+
+def test_testing_guide_describes_validation_lanes() -> None:
+    guide = (REPO_ROOT / "TESTING.md").read_text()
+
+    assert "bootstrap" in guide
+    assert "platform_blackbox" in guide
+    assert "developer_workflow" in guide
+    assert "destructive" in guide

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -33,10 +33,22 @@ def test_developer_workflow_runner_uses_developer_marker() -> None:
 def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive() -> None:
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
+    assert 'BOOTSTRAP_EXIT=0' in script
+    assert 'PLATFORM_EXIT=0' in script
+    assert 'DEVELOPER_EXIT=0' in script
+    assert 'DESTRUCTIVE_EXIT=0' in script
+
     assert "test-bootstrap-validation.sh" in script
     assert "test-e2e-cluster.sh" in script
     assert "test-developer-workflow.sh" in script
     assert "TEST_SUITE=e2e-destructive" in script
+
+    bootstrap_index = script.index('test-bootstrap-validation.sh')
+    platform_index = script.index('Platform blackbox validation')
+    developer_index = script.index('test-developer-workflow.sh')
+    destructive_index = script.index('=== Phase 4: Destructive E2E Tests ===')
+
+    assert bootstrap_index < platform_index < developer_index < destructive_index
 
 
 def test_full_runner_only_reuses_platform_image_after_successful_platform_lane() -> None:
@@ -46,7 +58,7 @@ def test_full_runner_only_reuses_platform_image_after_successful_platform_lane()
     assert 'CAN_REUSE_PLATFORM_IMAGE=true' in script
     assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
     assert 'SKIP_BUILD=true IMAGE_LOAD_METHOD=skip TEST_SUITE=e2e-destructive' in script
-    assert 'elif TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then' in script
+    assert 'if TEST_SUITE=e2e-destructive "${SCRIPT_DIR}/test-e2e-cluster.sh"; then' in script
 
 
 def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
@@ -58,3 +70,4 @@ def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
     assert 'if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d \' \'); then' in script
     assert 'Skipping destructive tests because platform cleanup failed.' in script
     assert 'Destructive: SKIPPED (cleanup failed)' in script
+    assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+pytestmark = pytest.mark.requirement("VAL-LANE-RUNNERS")
 
 
 def test_chart_standard_runner_selects_platform_blackbox() -> None:
+    """The standard chart job should target the platform blackbox lane."""
     job_e2e = (
         REPO_ROOT / "charts" / "floe-platform" / "templates" / "tests" / "job-e2e.yaml"
     ).read_text()
@@ -17,6 +20,7 @@ def test_chart_standard_runner_selects_platform_blackbox() -> None:
 
 
 def test_bootstrap_runner_uses_bootstrap_marker() -> None:
+    """Bootstrap validation should explicitly select the bootstrap marker."""
     script = (REPO_ROOT / "testing" / "ci" / "test-bootstrap-validation.sh").read_text()
 
     assert "uv run pytest tests/e2e" in script
@@ -24,6 +28,7 @@ def test_bootstrap_runner_uses_bootstrap_marker() -> None:
 
 
 def test_developer_workflow_runner_uses_developer_marker() -> None:
+    """Developer-workflow validation should explicitly select its lane marker."""
     script = (REPO_ROOT / "testing" / "ci" / "test-developer-workflow.sh").read_text()
 
     assert "uv run pytest tests/e2e" in script
@@ -31,6 +36,7 @@ def test_developer_workflow_runner_uses_developer_marker() -> None:
 
 
 def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive() -> None:
+    """The full runner should execute lanes in the documented order."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
     assert 'BOOTSTRAP_EXIT=0' in script
@@ -52,6 +58,7 @@ def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive(
 
 
 def test_full_runner_only_reuses_platform_image_after_successful_platform_lane() -> None:
+    """Destructive reuse should only happen after a successful platform lane."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
     assert 'CAN_REUSE_PLATFORM_IMAGE=false' in script
@@ -62,18 +69,23 @@ def test_full_runner_only_reuses_platform_image_after_successful_platform_lane()
 
 
 def test_full_runner_records_cleanup_failure_without_skipping_summary() -> None:
+    """Cleanup failures should still be surfaced in the final summary path."""
     script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
 
     assert 'CLEANUP_FAILED=false' in script
     assert 'CLEANUP_FAILED=true' in script
     assert 'DESTRUCTIVE_EXIT=1' in script
-    assert 'if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" --no-headers 2>/dev/null | wc -l | tr -d \' \'); then' in script
+    assert (
+        'if ! pod_count=$(kubectl get pods -l test-type=e2e -n "${TEST_NAMESPACE}" '
+        "--no-headers 2>/dev/null | wc -l | tr -d ' '); then"
+    ) in script
     assert 'Skipping destructive tests because platform cleanup failed.' in script
     assert 'Destructive: SKIPPED (cleanup failed)' in script
     assert 'if [[ "${CAN_REUSE_PLATFORM_IMAGE}" == "true" ]]; then' in script
 
 
 def test_testing_guide_describes_validation_lanes() -> None:
+    """The testing guide should document every validation lane."""
     guide = (REPO_ROOT / "TESTING.md").read_text()
 
     assert "bootstrap" in guide

--- a/tests/unit/test_validation_runner_wiring.py
+++ b/tests/unit/test_validation_runner_wiring.py
@@ -1,0 +1,39 @@
+"""Structural tests for validation lane runner wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_chart_standard_runner_selects_platform_blackbox() -> None:
+    job_e2e = (
+        REPO_ROOT / "charts" / "floe-platform" / "templates" / "tests" / "job-e2e.yaml"
+    ).read_text()
+
+    assert '"pytestMarker" "platform_blackbox and not destructive"' in job_e2e
+
+
+def test_bootstrap_runner_uses_bootstrap_marker() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-bootstrap-validation.sh").read_text()
+
+    assert "uv run pytest tests/e2e" in script
+    assert '-m "bootstrap"' in script
+
+
+def test_developer_workflow_runner_uses_developer_marker() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-developer-workflow.sh").read_text()
+
+    assert "uv run pytest tests/e2e" in script
+    assert '-m "developer_workflow"' in script
+
+
+def test_full_runner_orchestrates_bootstrap_platform_developer_then_destructive() -> None:
+    script = (REPO_ROOT / "testing" / "ci" / "test-e2e-full.sh").read_text()
+
+    assert "test-bootstrap-validation.sh" in script
+    assert "test-e2e-cluster.sh" in script
+    assert "test-developer-workflow.sh" in script
+    assert "TEST_SUITE=e2e-destructive" in script

--- a/uv.lock
+++ b/uv.lock
@@ -15,9 +15,13 @@ prerelease-mode = "allow"
 
 [manifest]
 constraints = [
+    { name = "cryptography", specifier = ">=46.0.7" },
     { name = "diskcache", specifier = ">=5.6.4" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "protobuf", specifier = ">=6.33.5" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "rfc3161-client", specifier = ">=1.0.6" },
 ]
 
 [[package]]
@@ -626,62 +630,62 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.6"
+version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542 }
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401 },
-    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275 },
-    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320 },
-    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082 },
-    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514 },
-    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766 },
-    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535 },
-    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618 },
-    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802 },
-    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425 },
-    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530 },
-    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896 },
-    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348 },
-    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896 },
-    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147 },
-    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221 },
-    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952 },
-    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141 },
-    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178 },
-    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812 },
-    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923 },
-    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695 },
-    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785 },
-    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404 },
-    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549 },
-    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874 },
-    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511 },
-    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692 },
-    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776 },
-    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529 },
-    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827 },
-    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265 },
-    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800 },
-    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771 },
-    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333 },
-    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069 },
-    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358 },
-    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061 },
-    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103 },
-    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255 },
-    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660 },
-    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160 },
-    { url = "https://files.pythonhosted.org/packages/2e/84/7ccff00ced5bac74b775ce0beb7d1be4e8637536b522b5df9b73ada42da2/cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead", size = 3475444 },
-    { url = "https://files.pythonhosted.org/packages/bc/1f/4c926f50df7749f000f20eede0c896769509895e2648db5da0ed55db711d/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8", size = 4218227 },
-    { url = "https://files.pythonhosted.org/packages/c6/65/707be3ffbd5f786028665c3223e86e11c4cda86023adbc56bd72b1b6bab5/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0", size = 4381399 },
-    { url = "https://files.pythonhosted.org/packages/f3/6d/73557ed0ef7d73d04d9aba745d2c8e95218213687ee5e76b7d236a5030fc/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b", size = 4217595 },
-    { url = "https://files.pythonhosted.org/packages/9e/c5/e1594c4eec66a567c3ac4400008108a415808be2ce13dcb9a9045c92f1a0/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a", size = 4380912 },
-    { url = "https://files.pythonhosted.org/packages/1a/89/843b53614b47f97fe1abc13f9a86efa5ec9e275292c457af1d4a60dc80e0/cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e", size = 3409955 },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869 },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492 },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670 },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275 },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402 },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985 },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652 },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805 },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883 },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756 },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244 },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868 },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504 },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363 },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671 },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551 },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887 },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354 },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845 },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641 },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749 },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942 },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079 },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999 },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191 },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782 },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227 },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332 },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618 },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628 },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405 },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715 },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400 },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634 },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233 },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955 },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888 },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961 },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696 },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256 },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001 },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985 },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879 },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700 },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982 },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115 },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479 },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829 },
 ]
 
 [[package]]
@@ -1422,7 +1426,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0,<2.0" },
     { name = "oras", specifier = ">=0.2.38,<1.0" },
     { name = "pydantic", specifier = ">=2.12.5,<3.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
@@ -1955,7 +1959,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "mypy", specifier = ">=1.8" },
     { name = "pre-commit", specifier = ">=3.0" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-codspeed", specifier = ">=3.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
@@ -4523,7 +4527,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -4534,9 +4538,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
 ]
 
 [[package]]
@@ -4671,20 +4675,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230 },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101 },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579 },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847 },
 ]
 
 [[package]]
@@ -4992,25 +4996,29 @@ wheels = [
 
 [[package]]
 name = "rfc3161-client"
-version = "1.0.5"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/19/c04a07f9926943b6a6945ae6972dc2c3c79b7f02e2be6346e3010a48d5f5/rfc3161_client-1.0.5.tar.gz", hash = "sha256:f1a2e32e2a053455cee1ff9b325b88dbc7c66c8882dde60962add92f572df5c5", size = 60966 }
+sdist = { url = "https://files.pythonhosted.org/packages/66/a7/be3b086133a87d595e7b11564931d5e5283edeeabba05dfee636a34b4dab/rfc3161_client-1.0.6.tar.gz", hash = "sha256:9969262fe6c08ecce39f9fe3996cf412187793834a022a643803090db5aae6b4", size = 106710 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/11/96bc76086113b8d24291f7f72826739d4fc8d8e83683e27125b8966d0cea/rfc3161_client-1.0.5-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8a54fdb2f9e64481272b89137a7b71403cf1d30f5505c2e0c15a47a1cc100264", size = 473872 },
-    { url = "https://files.pythonhosted.org/packages/80/45/19224e046d76f214d056c40a2086d9147afb0bcadc0c823c2c8bd54d62aa/rfc3161_client-1.0.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d9ed8e597d0ee7387da1945e1583c4516b26f133770b3956e079606e2d90b69c", size = 458218 },
-    { url = "https://files.pythonhosted.org/packages/27/d7/0511f1423f1658b708cfa27043a21b06699ba7c2aef37ba465379b81c24d/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61c04b4953453e5c26a1949c20adac415b65cd062dab0960574d6c36240222d2", size = 2396335 },
-    { url = "https://files.pythonhosted.org/packages/bc/d3/f93d1af5d9a1fed348ef543d39418aff02b0badf019b772f128c3483321c/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31b6ee79f15b93d90952efd0395bb3f5ebf07941469c5c6eb32f9b64312cda6e", size = 1805162 },
-    { url = "https://files.pythonhosted.org/packages/69/51/0b30e3542fdf7adeb9f6afac1f095c543328a1a28c9d220f4e2207c6b845/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c53a6711bab0c3f77dc9cf1e2fd750da475ff7abbc40ffe0333d8c518a8a9c8", size = 2115530 },
-    { url = "https://files.pythonhosted.org/packages/2e/b9/4da9f80da4ac30b9645c9a3455e71c4f6652ed886f20e11bfb9a01bcacd0/rfc3161_client-1.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09c47582ecea2ca4a3debf8a1eda775cc3d5ae1379da40272cc065d32e639a7a", size = 2124925 },
-    { url = "https://files.pythonhosted.org/packages/46/ed/f173556ddbd667e9f4642f8f7eb0f920e3e3be4b7459ec98c73a5029200d/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d31d30e354d2349ae8483ce811ef61498a3780daf8622c0b79d8cd44d271b46b", size = 2695972 },
-    { url = "https://files.pythonhosted.org/packages/84/97/2ca7bdbb2d84b75fad7f572264a45c0b54446a7a65735172275c09293bd6/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:ae440461a310ae097417afe536d9d22fd71c95fbc9d21db3561b2707bed0aff0", size = 2096478 },
-    { url = "https://files.pythonhosted.org/packages/da/94/9e16134e04a45347eaad5680f8f52b0388664b45be09a0877daa196e1157/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:8fb34470e867a29cc15dc4987ea14f19d3bd25c863e132b6f75dca583e2cc67e", size = 2243602 },
-    { url = "https://files.pythonhosted.org/packages/c2/13/85b6a5b5247f79dfa75d80a2e8f8d415472ff7fd72b31d152e00f71198b9/rfc3161_client-1.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3106f3361a5a36789f43d2700e5678c847a9d3460a23f455f4c20cd39314c557", size = 2296304 },
-    { url = "https://files.pythonhosted.org/packages/e7/0a/f7991ff6158a00ed79d6e151ede63ae50bef650cf49436cea7226a0457dc/rfc3161_client-1.0.5-cp39-abi3-win32.whl", hash = "sha256:078e4bbf0770ddc472e2ca96cf1e23efd0c313e6682b4c2c9765e1fdf09f55a3", size = 1917793 },
-    { url = "https://files.pythonhosted.org/packages/47/28/140516906a2117e15c37505d54968e9cc9a8275d042b195728f5ffc2ad02/rfc3161_client-1.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:e904430e27e75a5a379fc4aac09bd60ba5f4b48054f0481b2fb417297e404047", size = 2313057 },
+    { url = "https://files.pythonhosted.org/packages/57/b1/262af0901e1507a4e21d268091f1f7b738b44bca424b9bd481981828a7e8/rfc3161_client-1.0.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9a98e9c7ff632d9571fcea25fb70bde0e8339b86368aef67a65f6a301f125733", size = 474975 },
+    { url = "https://files.pythonhosted.org/packages/8a/b6/da7caa10c2a3e01f244ad116ffe2cc87056fa71a7dd76453faab2fc2c6ad/rfc3161_client-1.0.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:0b3920334f7334ec3bb9c319d53a5d08cd43b6883f75e2669cfd869cd264d53a", size = 467442 },
+    { url = "https://files.pythonhosted.org/packages/64/dd/5c92004ca167ae182f543aedc7a7a8bebeb0668ade7263b82212e4b4c59d/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1671b1be16480ea54c0d36239efd0fb62c13dd572a9865a5e91fea39f1b95303", size = 2435049 },
+    { url = "https://files.pythonhosted.org/packages/c4/19/c44702336aed367c6513493c4df9e880db8c4df37d5cd8d525aac9aad827/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63355099d932851eac507806bb9d0937dab546a66d5857d888168799ec635f6d", size = 1850399 },
+    { url = "https://files.pythonhosted.org/packages/64/fa/5af9bbfd4dcd9926463a95c4de6ea137176252d7a1d0b96533f6c85f2742/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bc9835467f6166edd6f876470484e5b294ee141add6eff6a59f5047937aaa75", size = 2174593 },
+    { url = "https://files.pythonhosted.org/packages/53/3c/32a0c7de4d63a69eb97e2564e5f1d51879ec93232b0c5ac1ec444843acba/rfc3161_client-1.0.6-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3caffaebf43242b000c4a6659d60eaf19c3b161ccbe05b15634a856c9ea7e61", size = 2177997 },
+    { url = "https://files.pythonhosted.org/packages/e5/8d/4253affe1d1e221369ad3043f5d697fc3f5d7fcb439d21add84c65cafc53/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b7ad54288a49379b01b1d0d9d15167d2b7c6c7f940332ab85eeb4a6e844da8c7", size = 2745033 },
+    { url = "https://files.pythonhosted.org/packages/1c/f0/eed22d6ed52d36b1eab3dfe56b9f507e22a328e3d018b84d48877ad7abe7/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:85a1d71d1eb2c9bced2b3eb75e96f9fe49732ec2567b5dafa1dd889fff42b7fe", size = 2145631 },
+    { url = "https://files.pythonhosted.org/packages/a2/bb/feeacd1859e364080729b9cded1129b740eeea54c6d61ff12daceed4b7dd/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:1be4e1133f0f7fe875629f2c358285503c1cfc79cebfbc3fb4e28b8a57d6f1a4", size = 2328742 },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/2df8e402f069a6af2db1f21d1c88d5a929398923265189a0141709a6f25c/rfc3161_client-1.0.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:bc379167238df32cbcc1dc9c324088559c1734331030f5293d75f4fd37b5f4f6", size = 2386899 },
+    { url = "https://files.pythonhosted.org/packages/a5/1b/f78c75c6c92a0f5de46a86b7f39cf9bb8fb5980fbd684a56f46f031dbce6/rfc3161_client-1.0.6-cp39-abi3-win32.whl", hash = "sha256:8631f7db7c1327bf87ee6a9a8681b4cd6bc2a90aae651388f29d045cd9ff1ac9", size = 1966796 },
+    { url = "https://files.pythonhosted.org/packages/26/10/6e54860ae82e4ed5665fd3f1d798a8f68f7bac321431f444640da6f93600/rfc3161_client-1.0.6-cp39-abi3-win_amd64.whl", hash = "sha256:4ef4b096abe7d55b020526e39932c2721939a6c55e9a5cd3b3e77897a0942937", size = 2386738 },
+    { url = "https://files.pythonhosted.org/packages/f1/59/34be30cd647de25af4ef7ca5980c124205893248db40d93831afad53dbcf/rfc3161_client-1.0.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102165201c5224cf6e6634bfd68c6a39e8f800601188216f8210face4861215", size = 2432818 },
+    { url = "https://files.pythonhosted.org/packages/44/f6/99d15883d564235b14c8d429fda4c8a9145af2bd5157cce506d2dcb30cc0/rfc3161_client-1.0.6-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e16ed34f6f33fd62aa3b1f83615ecf2f96e1b1f57df4e1a36570b3f895333972", size = 1848117 },
+    { url = "https://files.pythonhosted.org/packages/06/c8/b486981966e9d4e754c6720bdaeeef2b59bc176cbeef5f3b30aa718c89a0/rfc3161_client-1.0.6-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78cdc6bde331492cb94f69328831d5c56b271012b00c6f1784c2e4b33837d585", size = 2168684 },
+    { url = "https://files.pythonhosted.org/packages/e1/c2/08be1373dd4ca4382472a4e97be300a9db3f974f35093b33e54abbced4e1/rfc3161_client-1.0.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940e1fc95ec0ca734927a82bcb5363fa988ef1a085d238ff0c861f29c0cfb746", size = 2174296 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- harden validation lane boundaries so developer-workflow, bootstrap, and platform-blackbox checks stop contaminating one another
- make Polaris config resolution shared and explicit across shell and Python via manifest-derived helpers and `FLOE_MANIFEST_PATH`
- replace implicit demo image assumptions with a shared demo-image resolver, explicit deploy overrides, and Kind image eviction before reload
- fix the Dagster Iceberg exporter to use the configured catalog plugin instance directly

## Root Cause
The debugging churn was coming from a few concrete design faults rather than an unknown platform-wide failure:
- validation suites were mixing incompatible execution contexts
- shell and Python resolved manifest-derived config differently
- mutable demo image refs plus Kind cache reuse let stale payloads survive rebuilds
- the Dagster exporter still used the catalog plugin with the wrong call pattern

## Validation
- `bash -n testing/ci/common.sh testing/ci/test-e2e.sh testing/ci/wait-for-services.sh testing/ci/polaris-auth.sh testing/ci/test-unit-c-boundary.sh testing/k8s/setup-cluster.sh`
- `helm template floe-platform charts/floe-platform --values charts/floe-platform/values-test.yaml --set dagster.dagsterWebserver.image.repository=floe-dagster-demo --set dagster.dagsterWebserver.image.tag=$(python3 testing/ci/resolve-demo-image-ref.py --field tag) --set dagster.dagsterDaemon.image.repository=floe-dagster-demo --set dagster.dagsterDaemon.image.tag=$(python3 testing/ci/resolve-demo-image-ref.py --field tag) --set dagster.runLauncher.config.k8sRunLauncher.image.repository=floe-dagster-demo --set dagster.runLauncher.config.k8sRunLauncher.image.tag=$(python3 testing/ci/resolve-demo-image-ref.py --field tag)`
- `uv run floe platform deploy --env test --chart charts/floe-platform --dry-run ...` with the explicit demo image overrides
- `uv run pytest testing/tests/unit/test_polaris_manifest_settings.py testing/tests/unit/test_polaris_fixture.py testing/tests/unit/test_credentials.py testing/ci/tests/test_extract_manifest_config.py testing/ci/tests/test_e2e_sh_manifest_wiring.py tests/e2e/tests/test_conftest_manifest_wiring.py tests/unit/test_dbt_namespace_reset.py tests/unit/test_demo_platform_catalog_contract.py plugins/floe-orchestrator-dagster/tests/unit/test_export_iceberg.py testing/tests/unit/test_demo_packaging.py tests/unit/test_unit_c_boundary_wrapper.py tests/unit/test_e2e_runner_devpod_path.py testing/tests/unit/test_data_pipeline_retention.py tests/unit/test_validation_boundary_markers.py -q` → `329 passed`

## Remaining Product Failures
These changes are aimed at removing harness and contract noise so the remaining failures can be catalogued cleanly. The main product-side follow-ups still look to be:
- Polaris/Iceberg stale metadata cleanup across reruns
- remaining materialization/runtime assertions outside the focused slice
- OpenLineage `parentRun` emission
