### PR TITLE
Patch Mako security advisory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ prerelease = "allow"
 constraint-dependencies = [
     "cryptography>=46.0.7",
     "diskcache>=5.6.4",
+    "mako>=1.3.11",
     "pillow>=12.1.1",
     "protobuf>=6.33.5",
     "python-dotenv>=1.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ prerelease-mode = "allow"
 constraints = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "diskcache", specifier = ">=5.6.4" },
+    { name = "mako", specifier = ">=1.3.11" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -3068,14 +3069,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474 }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509 },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- constrain Mako to >=1.3.11 to pick up GHSA-v92g-xgxw-vvmm / CVE-2026-41205 fix
- refresh uv.lock so Alembic/Dagster resolves Mako 1.3.11
- leave diskcache advisory dismissed as tolerable risk: internal devtool-only cognee transitive dependency, no patched version listed, existing uv-secure ignore documents rationale

Closes #264

## Validation
- uv tree --invert --package mako -> mako v1.3.11
- ./testing/ci/uv-security-audit.sh
- uv lock --check
- make lint
- pre-push hook suite: lint, format, mypy, dbt requirements, bandit, uv-secure, unit tests, contract tests, traceability, helm lint