### PR TITLE
Fix Helm test service name drift

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -492,7 +492,13 @@ jobs:
 
       - name: Run Helm tests
         run: |
+          set +e
           helm test floe-test --namespace floe-test --timeout 5m
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            testing/ci/helm_diagnostics.sh floe-test floe-test
+          fi
+          exit "$status"
 
       - name: Get pod status on failure
         if: failure()

--- a/charts/floe-platform/templates/NOTES.txt
+++ b/charts/floe-platform/templates/NOTES.txt
@@ -20,7 +20,7 @@ DAGSTER WEBSERVER:
   URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ (index .Values.ingress.hosts 0).host }}
 {{- else }}
   To access the Dagster UI, run:
-    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ $fullname }}-dagster-webserver 3000:80
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "floe-platform.dagster.webserverName" . }} 3000:80
   Then open: http://localhost:3000
 {{- end }}
 {{- end }}

--- a/charts/floe-platform/templates/_helpers.tpl
+++ b/charts/floe-platform/templates/_helpers.tpl
@@ -212,9 +212,11 @@ Marquez component name.
 
 {{/*
 Dagster webserver service name.
+The upstream Dagster subchart prefixes resources with .Release.Name, not the
+parent chart fullnameOverride.
 */}}
 {{- define "floe-platform.dagster.webserverName" -}}
-{{- printf "%s-dagster-webserver" (include "floe-platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-dagster-webserver" .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/floe-platform/templates/hpa.yaml
+++ b/charts/floe-platform/templates/hpa.yaml
@@ -15,7 +15,7 @@ Requirements:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "floe-platform.fullname" . }}-dagster-webserver
+  name: {{ include "floe-platform.dagster.webserverName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "floe-platform.labels" . | nindent 4 }}

--- a/charts/floe-platform/templates/hpa.yaml
+++ b/charts/floe-platform/templates/hpa.yaml
@@ -24,7 +24,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Release.Name }}-dagster-webserver
+    name: {{ include "floe-platform.dagster.webserverName" . }}
   minReplicas: {{ .Values.autoscaling.dagster.minReplicas | default 1 }}
   maxReplicas: {{ .Values.autoscaling.dagster.maxReplicas | default 5 }}
   metrics:

--- a/charts/floe-platform/templates/ingress.yaml
+++ b/charts/floe-platform/templates/ingress.yaml
@@ -36,7 +36,7 @@ spec:
             backend:
               service:
                 {{- if eq .service "dagster-webserver" }}
-                name: {{ $fullname }}-dagster-webserver
+                name: {{ include "floe-platform.dagster.webserverName" $ }}
                 {{- else if eq .service "polaris" }}
                 name: {{ $fullname }}-polaris
                 {{- else if eq .service "otel" }}

--- a/charts/floe-platform/templates/tests/test-connection.yaml
+++ b/charts/floe-platform/templates/tests/test-connection.yaml
@@ -35,7 +35,7 @@ spec:
         - -c
         - |
           echo "Testing Dagster webserver connectivity..."
-          DAGSTER_URL="http://{{ .Release.Name }}-dagster-webserver:80"
+          DAGSTER_URL="http://{{ include "floe-platform.dagster.webserverName" . }}:80"
           for i in 1 2 3 4 5; do
             if curl -sf "${DAGSTER_URL}/server_info" > /dev/null 2>&1; then
               echo "SUCCESS: Dagster webserver is reachable"
@@ -93,8 +93,8 @@ spec:
         - -c
         - |
           echo "Testing PostgreSQL connectivity..."
-          PG_HOST="{{ .Release.Name }}-postgresql"
-          PG_PORT="5432"
+          PG_HOST="{{ include "floe-platform.postgresql.host" . }}"
+          PG_PORT="{{ include "floe-platform.postgresql.port" . }}"
           for i in 1 2 3 4 5; do
             if pg_isready -h "${PG_HOST}" -p "${PG_PORT}" > /dev/null 2>&1; then
               echo "SUCCESS: PostgreSQL is reachable"
@@ -123,7 +123,7 @@ spec:
         - -c
         - |
           echo "Testing MinIO S3 connectivity..."
-          MINIO_URL="http://{{ .Release.Name }}-minio:9000"
+          MINIO_URL="http://{{ include "floe-platform.minio.fullname" . }}:9000"
           for i in 1 2 3 4 5; do
             if curl -sf "${MINIO_URL}/minio/health/live" > /dev/null 2>&1; then
               echo "SUCCESS: MinIO S3 is reachable"

--- a/charts/floe-platform/tests/test-connection_test.yaml
+++ b/charts/floe-platform/tests/test-connection_test.yaml
@@ -47,6 +47,9 @@ tests:
       - matchRegex:
           path: spec.containers[0].command[2]
           pattern: "curl.*server_info"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: 'DAGSTER_URL="http://.*-dagster-webserver:80"'
 
   - it: MinIO test should curl /minio/health/live endpoint
     set:
@@ -61,6 +64,32 @@ tests:
       - matchRegex:
           path: spec.containers[0].command[2]
           pattern: "curl.*minio/health/live"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: 'MINIO_URL="http://floe-platform-minio:9000"'
+
+  - it: test connection should use parent helper service names under fullnameOverride
+    set:
+      dagster.enabled: true
+      polaris.enabled: true
+      postgresql.enabled: true
+      minio.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.containers[2].command[2]
+          pattern: 'PG_HOST="floe-platform-postgresql"'
+      - matchRegex:
+          path: spec.containers[2].command[2]
+          pattern: 'PG_PORT="5432"'
+      - matchRegex:
+          path: spec.containers[3].command[2]
+          pattern: 'MINIO_URL="http://floe-platform-minio:9000"'
+      - notMatchRegex:
+          path: spec.containers[2].command[2]
+          pattern: 'PG_HOST=".*-test-postgresql"'
+      - notMatchRegex:
+          path: spec.containers[3].command[2]
+          pattern: 'MINIO_URL="http://.*-test-minio:9000"'
 
   # --- Fallback container when all services disabled ---
   - it: should have exactly one no-op container when all services disabled

--- a/testing/ci/helm_diagnostics.sh
+++ b/testing/ci/helm_diagnostics.sh
@@ -23,6 +23,21 @@ kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp || true
 section "Pod descriptions"
 kubectl describe pods -n "$NAMESPACE" || true
 
+section "Helm test pod logs"
+for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep test || true); do
+  kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true
+done
+
+section "Polaris logs"
+for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep polaris || true); do
+  kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true
+done
+
+section "MinIO logs"
+for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep minio || true); do
+  kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true
+done
+
 section "Dagster webserver logs"
 for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep dagster-webserver || true); do
   kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true

--- a/testing/ci/helm_diagnostics.sh
+++ b/testing/ci/helm_diagnostics.sh
@@ -24,7 +24,7 @@ section "Pod descriptions"
 kubectl describe pods -n "$NAMESPACE" || true
 
 section "Helm test pod logs"
-for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep test || true); do
+for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep -- "-test-connection" || true); do
   kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true
 done
 

--- a/testing/tests/unit/test_helm_ci_diagnostics.py
+++ b/testing/tests/unit/test_helm_ci_diagnostics.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -26,6 +27,7 @@ def test_helm_ci_invokes_shared_diagnostics_on_install_failure() -> None:
     assert "--cleanup-on-fail" not in workflow_text
 
 
+@pytest.mark.requirement("9b-FR-084")
 def test_helm_ci_invokes_shared_diagnostics_on_helm_test_failure() -> None:
     workflow_text = WORKFLOW.read_text()
 

--- a/testing/tests/unit/test_helm_ci_diagnostics.py
+++ b/testing/tests/unit/test_helm_ci_diagnostics.py
@@ -26,6 +26,20 @@ def test_helm_ci_invokes_shared_diagnostics_on_install_failure() -> None:
     assert "--cleanup-on-fail" not in workflow_text
 
 
+def test_helm_ci_invokes_shared_diagnostics_on_helm_test_failure() -> None:
+    workflow_text = WORKFLOW.read_text()
+
+    run_helm_tests_section = workflow_text.split("- name: Run Helm tests", maxsplit=1)[1]
+    run_helm_tests_section = run_helm_tests_section.split(
+        "- name: Get pod status on failure",
+        maxsplit=1,
+    )[0]
+
+    assert "helm test floe-test --namespace floe-test --timeout 5m" in run_helm_tests_section
+    assert "testing/ci/helm_diagnostics.sh floe-test floe-test" in run_helm_tests_section
+    assert 'exit "$status"' in run_helm_tests_section
+
+
 def test_helm_diagnostics_script_collects_dagster_marquez_and_events() -> None:
     script = DIAGNOSTICS.read_text()
 
@@ -34,6 +48,9 @@ def test_helm_diagnostics_script_collects_dagster_marquez_and_events() -> None:
         "kubectl get events -n",
         "kubectl describe pods -n",
         "kubectl logs -n",
+        "Helm test pod logs",
+        "polaris",
+        "minio",
         "dagster-webserver",
         "dagster-daemon",
         "marquez",


### PR DESCRIPTION
## Summary\n- Align Helm test PostgreSQL and MinIO probes with parent chart helper names under `fullnameOverride`.\n- Correct the Dagster webserver helper to match the upstream Dagster subchart's `.Release.Name` service naming, then reuse it in Helm tests, ingress, HPA target, notes, and E2E test-runner env.\n- Add Helm test failure diagnostics so future `helm test` failures include test pod, Polaris, MinIO, Dagster, Marquez, events, and pod descriptions instead of only a truncated pod summary.\n\n## Root Cause\nMain Helm CI run https://github.com/Obsidian-Owl/floe/actions/runs/25046995113 got past image load and chart install, then failed in `helm test`. Rendering showed the test pod still targeted `floe-test-postgresql` and `floe-test-minio`, but the installed services are `floe-platform-postgresql` and `floe-platform-minio` due to the parent chart `fullnameOverride` and MinIO subchart override.\n\n## Validation\n- `helm unittest charts/floe-platform -f 'tests/test-connection_test.yaml'`\n- `make helm-test-unit`\n- `uv run pytest testing/tests/unit/test_minio_chart_bump_contract.py testing/tests/unit/test_helm_ci_diagnostics.py -q`\n- `helm lint charts/floe-platform --values charts/floe-platform/values.yaml --values charts/floe-platform/values-test.yaml`\n- `make helm-validate`\n- `make lint`\n- full pre-push hook suite\n\nCloses #265