### PR TITLE
Fix Helm test Dagster service port

### DIFF
--- a/charts/floe-platform/templates/NOTES.txt
+++ b/charts/floe-platform/templates/NOTES.txt
@@ -20,7 +20,7 @@ DAGSTER WEBSERVER:
   URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ (index .Values.ingress.hosts 0).host }}
 {{- else }}
   To access the Dagster UI, run:
-    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "floe-platform.dagster.webserverName" . }} 3000:80
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "floe-platform.dagster.webserverName" . }} 3000:{{ include "floe-platform.dagster.webserverPort" . }}
   Then open: http://localhost:3000
 {{- end }}
 {{- end }}

--- a/charts/floe-platform/templates/_helpers.tpl
+++ b/charts/floe-platform/templates/_helpers.tpl
@@ -220,6 +220,15 @@ parent chart fullnameOverride.
 {{- end }}
 
 {{/*
+Dagster webserver service port.
+Kept behind a helper so tests, notes, and ingress stay aligned with the
+upstream Dagster subchart values selected by the active values stack.
+*/}}
+{{- define "floe-platform.dagster.webserverPort" -}}
+{{- required "dagster.dagsterWebserver.service.port is required" .Values.dagster.dagsterWebserver.service.port }}
+{{- end }}
+
+{{/*
 MinIO component name.
 */}}
 {{- define "floe-platform.minio.fullname" -}}

--- a/charts/floe-platform/templates/ingress.yaml
+++ b/charts/floe-platform/templates/ingress.yaml
@@ -45,7 +45,11 @@ spec:
                 name: {{ $fullname }}-{{ .service }}
                 {{- end }}
                 port:
+                  {{- if and (eq .service "dagster-webserver") (not .port) }}
+                  number: {{ include "floe-platform.dagster.webserverPort" $ }}
+                  {{- else }}
                   number: {{ .port | default 80 }}
+                  {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/floe-platform/templates/tests/test-connection.yaml
+++ b/charts/floe-platform/templates/tests/test-connection.yaml
@@ -35,9 +35,9 @@ spec:
         - -c
         - |
           echo "Testing Dagster webserver connectivity..."
-          DAGSTER_URL="http://{{ include "floe-platform.dagster.webserverName" . }}:80"
+          DAGSTER_URL="http://{{ include "floe-platform.dagster.webserverName" . }}:{{ include "floe-platform.dagster.webserverPort" . }}"
           for i in 1 2 3 4 5; do
-            if curl -sf "${DAGSTER_URL}/server_info" > /dev/null 2>&1; then
+            if curl --connect-timeout 3 --max-time 10 -sf "${DAGSTER_URL}/server_info" > /dev/null 2>&1; then
               echo "SUCCESS: Dagster webserver is reachable"
               exit 0
             fi
@@ -66,7 +66,7 @@ spec:
           echo "Testing Polaris health connectivity..."
           POLARIS_HEALTH_URL="http://{{ include "floe-platform.polaris.fullname" . }}:{{ .Values.polaris.service.managementPort | default 8182 }}"
           for i in 1 2 3 4 5; do
-            if curl -sf "${POLARIS_HEALTH_URL}/q/health/ready" > /dev/null 2>&1; then
+            if curl --connect-timeout 3 --max-time 10 -sf "${POLARIS_HEALTH_URL}/q/health/ready" > /dev/null 2>&1; then
               echo "SUCCESS: Polaris is healthy"
               exit 0
             fi
@@ -125,7 +125,7 @@ spec:
           echo "Testing MinIO S3 connectivity..."
           MINIO_URL="http://{{ include "floe-platform.minio.fullname" . }}:9000"
           for i in 1 2 3 4 5; do
-            if curl -sf "${MINIO_URL}/minio/health/live" > /dev/null 2>&1; then
+            if curl --connect-timeout 3 --max-time 10 -sf "${MINIO_URL}/minio/health/live" > /dev/null 2>&1; then
               echo "SUCCESS: MinIO S3 is reachable"
               exit 0
             fi

--- a/charts/floe-platform/tests/test-connection_test.yaml
+++ b/charts/floe-platform/tests/test-connection_test.yaml
@@ -34,9 +34,10 @@ tests:
           path: spec.containers[0].command[2]
           pattern: "curl.*q/health/ready"
 
-  - it: Dagster test should curl /server_info endpoint
+  - it: Dagster test should curl /server_info endpoint using configured service port
     set:
       dagster.enabled: true
+      dagster.dagsterWebserver.service.port: 3000
       polaris.enabled: false
       postgresql.enabled: false
       minio.enabled: false
@@ -49,7 +50,10 @@ tests:
           pattern: "curl.*server_info"
       - matchRegex:
           path: spec.containers[0].command[2]
-          pattern: 'DAGSTER_URL="http://.*-dagster-webserver:80"'
+          pattern: 'DAGSTER_URL="http://.*-dagster-webserver:3000"'
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "curl --connect-timeout [0-9]+ --max-time [0-9]+ -sf"
 
   - it: MinIO test should curl /minio/health/live endpoint
     set:

--- a/testing/ci/helm_diagnostics.sh
+++ b/testing/ci/helm_diagnostics.sh
@@ -25,7 +25,11 @@ kubectl describe pods -n "$NAMESPACE" || true
 
 section "Helm test pod logs"
 for pod in $(kubectl get pods -n "$NAMESPACE" -o name | grep -- "-test-connection" || true); do
-  kubectl logs -n "$NAMESPACE" "$pod" --all-containers=true --tail=300 || true
+  while IFS= read -r container; do
+    [ -n "$container" ] || continue
+    section "Helm test pod logs: $pod / $container"
+    kubectl logs -n "$NAMESPACE" "$pod" -c "$container" --tail=300 || true
+  done < <(kubectl get -n "$NAMESPACE" "$pod" -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' || true)
 done
 
 section "Polaris logs"

--- a/testing/tests/unit/test_helm_ci_diagnostics.py
+++ b/testing/tests/unit/test_helm_ci_diagnostics.py
@@ -63,6 +63,14 @@ def test_helm_diagnostics_script_collects_dagster_marquez_and_events() -> None:
         assert fragment in script, f"Missing diagnostic fragment: {fragment}"
 
 
+def test_helm_diagnostics_collects_helm_test_logs_per_container() -> None:
+    script = DIAGNOSTICS.read_text()
+
+    assert "Helm test pod logs" in script
+    assert "jsonpath='{range .spec.containers[*]}{.name}" in script
+    assert '-c "$container"' in script
+
+
 def test_helm_ci_has_integration_test_job() -> None:
     workflow = _load_workflow()
     jobs = cast(Mapping[str, Mapping[str, Any]], workflow["jobs"])


### PR DESCRIPTION
## Summary
- derive the Helm test Dagster URL from dagster.dagsterWebserver.service.port instead of hardcoding :80
- add bounded curl timeouts to Helm test probes so helm test cannot hang on a single request
- align Dagster notes/ingress fallback with the same service-port helper
- improve Helm CI diagnostics by logging test pod containers individually

## Validation
- helm unittest charts/floe-platform -f 'tests/test-connection_test.yaml'
- uv run pytest testing/tests/unit/test_helm_ci_diagnostics.py -q
- make helm-lint
- make helm-validate
- make helm-test-unit
- make helm-template ENV=dev
- make helm-template ENV=staging
- make helm-template ENV=prod
- pre-push hook passed: ruff, mypy, bandit, uv-secure, unit tests + coverage, contract tests, traceability, helm lint

## Notes
- Main Helm CI run 25050214590 showed the Dagster service exposed 3000/TCP while the Helm test pod curled :80 and remained InProgress until the helm test timeout.
- Local make helm-security is not representative on Apple Silicon because the pinned kubesec image lacks arm64 support; GitHub Helm CI performs its own kubesec scan on ubuntu-latest.