### PR TITLE
Fix Dagster ingress service port drift

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -418,7 +418,7 @@
         "filename": "charts/floe-platform/values-prod.yaml",
         "hashed_secret": "b59fcabeefc541ac69de1590608279758227829a",
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 178,
         "is_secret": false
       }
     ],
@@ -428,7 +428,7 @@
         "filename": "charts/floe-platform/values-staging.yaml",
         "hashed_secret": "bd65c58ccee87d8f147ef00c145b66f783ca9fe1",
         "is_verified": false,
-        "line_number": 161,
+        "line_number": 168,
         "is_secret": false
       }
     ],
@@ -2451,5 +2451,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-28T07:53:30Z"
+  "generated_at": "2026-04-28T21:54:51Z"
 }

--- a/charts/floe-platform/templates/ingress.yaml
+++ b/charts/floe-platform/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
                 name: {{ $fullname }}-{{ .service }}
                 {{- end }}
                 port:
-                  {{- if and (eq .service "dagster-webserver") (not .port) }}
+                  {{- if eq .service "dagster-webserver" }}
                   number: {{ include "floe-platform.dagster.webserverPort" $ }}
                   {{- else }}
                   number: {{ .port | default 80 }}

--- a/charts/floe-platform/tests/fixtures/ingress-stale-dagster-port.yaml
+++ b/charts/floe-platform/tests/fixtures/ingress-stale-dagster-port.yaml
@@ -1,0 +1,9 @@
+ingress:
+  enabled: true
+  hosts:
+    - host: floe.local
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dagster-webserver
+          port: 9999

--- a/charts/floe-platform/tests/ingress_test.yaml
+++ b/charts/floe-platform/tests/ingress_test.yaml
@@ -1,0 +1,35 @@
+# Verifies ingress backends follow service helpers instead of stale literals.
+suite: ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: routes Dagster ingress to the default webserver service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-dagster-webserver
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80
+
+  - it: routes Dagster ingress to an overridden webserver service port
+    set:
+      ingress.enabled: true
+      dagster.dagsterWebserver.service.port: 3000
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-dagster-webserver
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 3000
+
+  - it: ignores stale per-path ports for Dagster ingress
+    values:
+      - fixtures/ingress-stale-dagster-port.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80

--- a/charts/floe-platform/values-prod.yaml
+++ b/charts/floe-platform/values-prod.yaml
@@ -174,7 +174,6 @@ ingress:
         - path: /
           pathType: Prefix
           service: dagster-webserver
-          port: 3000
   tls:
     - secretName: floe-prod-tls
       hosts:

--- a/charts/floe-platform/values-staging.yaml
+++ b/charts/floe-platform/values-staging.yaml
@@ -164,7 +164,6 @@ ingress:
         - path: /
           pathType: Prefix
           service: dagster-webserver
-          port: 3000
   tls:
     - secretName: floe-staging-tls
       hosts:

--- a/charts/floe-platform/values.yaml
+++ b/charts/floe-platform/values.yaml
@@ -855,7 +855,6 @@ ingress:
         - path: /
           pathType: Prefix
           service: dagster-webserver
-          port: 3000
 
   # TLS configuration
   tls: []

--- a/testing/tests/unit/test_helm_ci_diagnostics.py
+++ b/testing/tests/unit/test_helm_ci_diagnostics.py
@@ -19,7 +19,9 @@ def _load_workflow() -> dict[str, object]:
         return cast(dict[str, object], yaml.safe_load(handle))
 
 
+@pytest.mark.requirement("9b-FR-084")
 def test_helm_ci_invokes_shared_diagnostics_on_install_failure() -> None:
+    """Verify install failures invoke shared Helm diagnostics before cleanup."""
     workflow_text = WORKFLOW.read_text()
 
     assert "testing/ci/helm_diagnostics.sh floe-test floe-test" in workflow_text
@@ -29,6 +31,7 @@ def test_helm_ci_invokes_shared_diagnostics_on_install_failure() -> None:
 
 @pytest.mark.requirement("9b-FR-084")
 def test_helm_ci_invokes_shared_diagnostics_on_helm_test_failure() -> None:
+    """Verify Helm test failures preserve diagnostics and propagate failure."""
     workflow_text = WORKFLOW.read_text()
 
     run_helm_tests_section = workflow_text.split("- name: Run Helm tests", maxsplit=1)[1]
@@ -42,7 +45,9 @@ def test_helm_ci_invokes_shared_diagnostics_on_helm_test_failure() -> None:
     assert 'exit "$status"' in run_helm_tests_section
 
 
+@pytest.mark.requirement("9b-FR-084")
 def test_helm_diagnostics_script_collects_dagster_marquez_and_events() -> None:
+    """Verify diagnostics include platform pods, events, and Helm state."""
     script = DIAGNOSTICS.read_text()
 
     required_fragments = [
@@ -63,7 +68,9 @@ def test_helm_diagnostics_script_collects_dagster_marquez_and_events() -> None:
         assert fragment in script, f"Missing diagnostic fragment: {fragment}"
 
 
+@pytest.mark.requirement("9b-FR-084")
 def test_helm_diagnostics_collects_helm_test_logs_per_container() -> None:
+    """Verify Helm test pod logs are collected for every container."""
     script = DIAGNOSTICS.read_text()
 
     assert "Helm test pod logs" in script
@@ -71,7 +78,9 @@ def test_helm_diagnostics_collects_helm_test_logs_per_container() -> None:
     assert '-c "$container"' in script
 
 
+@pytest.mark.requirement("9b-FR-084")
 def test_helm_ci_has_integration_test_job() -> None:
+    """Verify Helm CI keeps the Kind-backed integration test job."""
     workflow = _load_workflow()
     jobs = cast(Mapping[str, Mapping[str, Any]], workflow["jobs"])
 


### PR DESCRIPTION
## Summary
- Make Dagster ingress route to `floe-platform.dagster.webserverPort` unconditionally, so ingress follows the actual Dagster service port instead of stale per-path literals.
- Remove stale `port: 3000` Dagster ingress values from default, staging, and production values.
- Add Helm unittest coverage for default, overridden, and stale per-path Dagster ingress port cases.
- Add requirement markers and docstrings to Helm CI diagnostics unit tests called out in review.

## Review comment validation
- The ingress review comment was valid and more than a nit: default/staging/prod rendered ingress backend port `3000` while the Dagster service defaulted to `80`.
- The test marker/docstring comment was partially overstated for all unit tests globally, but the file was inconsistent and the cleanup is low-risk and aligned with local traceability/docstring gates.
- Older HPA/service-name review comments on already-merged PRs were checked against current `main` and appear stale; current templates use the shared Dagster webserver helper consistently.

## Validation
- `helm unittest charts/floe-platform -f 'tests/ingress_test.yaml'`
- `helm unittest charts/floe-platform`
- `helm lint charts/floe-platform`
- `uv run pytest testing/tests/unit/test_helm_ci_diagnostics.py -q`
- Rendered default/staging/prod/test values and confirmed Dagster ingress backend port equals Dagster service port in each case.
- `uv run pre-commit run --files charts/floe-platform/templates/ingress.yaml charts/floe-platform/values.yaml charts/floe-platform/values-staging.yaml charts/floe-platform/values-prod.yaml charts/floe-platform/tests/ingress_test.yaml charts/floe-platform/tests/fixtures/ingress-stale-dagster-port.yaml testing/tests/unit/test_helm_ci_diagnostics.py`
- Local pre-push hook passed on push, including mypy, security audit, unit tests, contract tests, requirement traceability, and Helm lint.

## Note
A repo-wide `uv run pre-commit run detect-secrets --all-files` still reports pre-existing false positives outside this change set. The changed-file `detect-secrets` hook passes.
