### PR TITLE
Harden Customer 360 alpha validation

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -159,11 +159,28 @@ jobs:
         env:
           ENVIRONMENT: ${{ matrix.environment }}
         run: |
+          preview_rendered_yaml() {
+            local directory="$1"
+            local max_files="$2"
+            local max_lines="$3"
+
+            mapfile -t files < <(find "$directory" -name '*.yaml' | sort)
+            local count=0
+            for file in "${files[@]}"; do
+              if [ "$count" -ge "$max_files" ]; then
+                break
+              fi
+              count=$((count + 1))
+              echo "Validating: ${file}"
+              sed -n "1,${max_lines}p" "$file"
+            done
+          }
+
           echo "=== floe-platform templates ==="
-          find /tmp/rendered-platform-${ENVIRONMENT} -name '*.yaml' -exec echo "Validating: {}" \; -exec cat {} \; | head -100
+          preview_rendered_yaml "/tmp/rendered-platform-${ENVIRONMENT}" 20 100
           echo ""
           echo "=== floe-jobs templates ==="
-          find /tmp/rendered-jobs-${ENVIRONMENT} -name '*.yaml' -exec echo "Validating: {}" \; -exec cat {} \; | head -50
+          preview_rendered_yaml "/tmp/rendered-jobs-${ENVIRONMENT}" 20 50
           echo ""
           echo "Template rendering successful for ${ENVIRONMENT}"
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -446,7 +446,7 @@
         "filename": "charts/floe-platform/values.yaml",
         "hashed_secret": "d2a8d1ddfa75398366cff06545380c73481ec17d",
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 275,
         "is_secret": false
       },
       {
@@ -454,7 +454,7 @@
         "filename": "charts/floe-platform/values.yaml",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 536,
         "is_secret": false
       }
     ],
@@ -2451,5 +2451,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-28T21:54:51Z"
+  "generated_at": "2026-04-29T09:04:57Z"
 }

--- a/charts/floe-platform/tests/dagster_run_launcher_test.yaml
+++ b/charts/floe-platform/tests/dagster_run_launcher_test.yaml
@@ -28,3 +28,23 @@ tests:
       - notMatchRegex:
           path: data["dagster.yaml"]
           pattern: 'job_image:'
+
+  - it: should wire dev demo Dagster storage to the shared platform PostgreSQL
+    values:
+      - ../values-dev.yaml
+      - ../values-demo.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["dagster.yaml"]
+          pattern: 'hostname: "floe-platform-postgresql"'
+      - matchRegex:
+          path: data["dagster.yaml"]
+          pattern: 'username: floe'
+      - matchRegex:
+          path: data["dagster.yaml"]
+          pattern: 'db_name: dagster'
+      - notMatchRegex:
+          path: data["dagster.yaml"]
+          pattern: 'hostname: ""'

--- a/charts/floe-platform/values-demo.yaml
+++ b/charts/floe-platform/values-demo.yaml
@@ -51,13 +51,23 @@ dagster:
     replicaCount: 1
     image:
       <<: *dagsterDemoImage
+    service:
+      type: ClusterIP
+      port: 3000
+    readinessProbe:
+      httpGet:
+        path: /server_info
+        port: 3000
+      periodSeconds: 20
+      timeoutSeconds: 10
+      failureThreshold: 3
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
         memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1536Mi
 
   # Dagster daemon configuration
   dagsterDaemon:
@@ -67,13 +77,14 @@ dagster:
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
         memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1536Mi
     # Demo scheduling: 10-minute intervals
     env:
-      DAGSTER_DEFAULT_SCHEDULE_CRON: "*/10 * * * *"
+      - name: DAGSTER_DEFAULT_SCHEDULE_CRON
+        value: "*/10 * * * *"
 
   # Run launcher configuration
   runLauncher:
@@ -83,14 +94,26 @@ dagster:
         image:
           <<: *dagsterDemoImage
         imagePullPolicy: Never
+        # Run pods execute dbt, which writes partial-parse and run artifacts
+        # into /app/demo/*/target. Keep this aligned with values-test.yaml.
+        runK8sConfig:
+          containerConfig:
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              runAsNonRoot: true
+              runAsUser: 1000
+              capabilities:
+                drop:
+                  - ALL
         # Resources for run pods (light for demo)
         resources:
           requests:
             cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 1000m
+            memory: 1Gi
 
 # =============================================================================
 # Polaris Configuration (Iceberg Catalog - Demo)
@@ -99,7 +122,7 @@ polaris:
   enabled: true
   replicaCount: 1
   image:
-    tag: "1.3.0-incubating"
+    tag: "1.2.0-incubating"
   resources:
     requests:
       cpu: 100m
@@ -137,6 +160,13 @@ polaris:
     defaultBaseLocation: "s3://floe-iceberg"
     allowedLocations:
       - "s3://floe-iceberg"
+    grants:
+      enabled: true
+      catalogRole: "catalog_admin"
+      principalRole: "floe-pipeline"
+      bootstrapPrincipal: "root"
+      privileges:
+        - CATALOG_MANAGE_CONTENT
 
 # =============================================================================
 # OpenTelemetry Collector Configuration (Observability)
@@ -151,6 +181,28 @@ otel:
     limits:
       cpu: 500m
       memory: 512Mi
+  config:
+    exporters:
+      debug:
+        verbosity: detailed
+      otlp/jaeger:
+        endpoint: "{{ .Release.Name }}-jaeger-collector:4317"
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug, otlp/jaeger]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
 
 # =============================================================================
 # PostgreSQL Configuration (Metadata Store)
@@ -186,6 +238,15 @@ minio:
   persistence:
     enabled: true
     size: 5Gi  # Reduced for demo
+  auth:
+    rootUser: minioadmin
+    rootPassword: minioadmin123  # pragma: allowlist secret
+  provisioning:
+    # The upstream minio/minio image does not honor the Bitnami chart's
+    # defaultBuckets bootstrap contract. Keep demo aligned with the validated
+    # E2E profile by using the chart-owned fallback hook, which derives the
+    # warehouse bucket from polaris.bootstrap.defaultBaseLocation.
+    fallbackJob: true
   # Keep this list aligned with demo/manifest.yaml so the demo install path
   # exposes the same bucket contract the data-product manifest advertises.
   defaultBuckets: "floe-iceberg,floe-artifacts"

--- a/charts/floe-platform/values.yaml
+++ b/charts/floe-platform/values.yaml
@@ -258,6 +258,11 @@ dagster:
   # Disable subchart's PostgreSQL - we use parent chart's PostgreSQL
   postgresql:
     enabled: false
+    # Dagster subchart uses these nested keys for storage config and init checks.
+    postgresqlHost: floe-platform-postgresql
+    postgresqlPort: 5432
+    postgresqlDatabase: dagster
+    postgresqlUsername: floe
 
   # External PostgreSQL configuration (uses parent chart's PostgreSQL)
   generatePostgresqlPasswordSecret: false

--- a/demo/customer-360/scripts/customer360_metric.py
+++ b/demo/customer-360/scripts/customer360_metric.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from collections.abc import Sequence
+from contextlib import redirect_stdout
+from pathlib import Path
 
 import duckdb
+import pyarrow.compute as pc
+from floe_core.schemas.compiled_artifacts import CompiledArtifacts
+from floe_orchestrator_dagster.validation.iceberg_outputs import (
+    _connect_catalog_from_artifacts,
+    expected_iceberg_tables,
+)
 
 DEFAULT_DATABASE = "/tmp/floe/customer_360.duckdb"
 DEFAULT_TABLE = "mart_customer_360"
@@ -25,6 +34,8 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the Customer 360 metric query parser."""
     parser = argparse.ArgumentParser(description="Query Customer 360 demo metrics")
     parser.add_argument("metric", choices=("customer-count", "total-lifetime-value"))
+    parser.add_argument("--source", choices=("duckdb", "iceberg"), default="duckdb")
+    parser.add_argument("--artifacts-path", type=Path)
     parser.add_argument("--database", default=DEFAULT_DATABASE)
     parser.add_argument(
         "--table",
@@ -41,12 +52,29 @@ def build_parser() -> argparse.ArgumentParser:
 
 def query_metric(
     *,
+    source: str,
+    artifacts_path: Path | None,
     database: str,
     table: str,
     metric: str,
     lifetime_value_column: str,
 ) -> object:
-    """Return a Customer 360 business metric from the configured DuckDB table."""
+    """Return a Customer 360 business metric from the configured source."""
+    if source == "iceberg":
+        if artifacts_path is None:
+            raise ValueError("--artifacts-path is required when --source=iceberg")
+        artifacts = CompiledArtifacts.model_validate_json(artifacts_path.read_text())
+        table_identifier = expected_iceberg_tables(artifacts, [table])[0]
+        iceberg_table = _connect_catalog_from_artifacts(artifacts).load_table(table_identifier)
+        if metric == "customer-count":
+            arrow_table = iceberg_table.scan(selected_fields=("customer_id",)).to_arrow()
+            return arrow_table.num_rows
+        if metric == "total-lifetime-value":
+            arrow_table = iceberg_table.scan(selected_fields=(lifetime_value_column,)).to_arrow()
+            result = pc.sum(arrow_table[lifetime_value_column]).as_py()
+            return result or 0
+        raise ValueError(f"Unsupported metric: {metric}")
+
     with duckdb.connect(database, read_only=True) as conn:
         if metric == "customer-count":
             count_row = conn.execute(f"select count(*) from {table}").fetchone()
@@ -66,14 +94,16 @@ def query_metric(
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the Customer 360 metric query CLI."""
     args = build_parser().parse_args(argv)
-    print(
-        query_metric(
+    with redirect_stdout(sys.stderr):
+        value = query_metric(
             database=args.database,
             table=args.table,
             metric=args.metric,
+            source=args.source,
+            artifacts_path=args.artifacts_path,
             lifetime_value_column=args.lifetime_value_column,
         )
-    )
+    print(value)
     return 0
 
 

--- a/demo/customer-360/scripts/customer360_metric.py
+++ b/demo/customer-360/scripts/customer360_metric.py
@@ -8,14 +8,9 @@ import sys
 from collections.abc import Sequence
 from contextlib import redirect_stdout
 from pathlib import Path
+from typing import Any
 
 import duckdb
-import pyarrow.compute as pc
-from floe_core.schemas.compiled_artifacts import CompiledArtifacts
-from floe_orchestrator_dagster.validation.iceberg_outputs import (
-    connect_catalog_from_artifacts,
-    expected_iceberg_tables,
-)
 
 DEFAULT_DATABASE = "/tmp/floe/customer_360.duckdb"
 DEFAULT_TABLE = "mart_customer_360"
@@ -28,6 +23,18 @@ def _identifier(value: str, field_name: str) -> str:
     if not IDENTIFIER_RE.fullmatch(value):
         raise argparse.ArgumentTypeError(f"{field_name} must be a simple SQL identifier")
     return value
+
+
+def _load_iceberg_dependencies() -> tuple[Any, type[Any], Any, Any]:
+    """Load Iceberg-only dependencies when the Iceberg metric source is selected."""
+    import pyarrow.compute as pc
+    from floe_core.schemas.compiled_artifacts import CompiledArtifacts
+    from floe_orchestrator_dagster.validation.iceberg_outputs import (
+        connect_catalog_from_artifacts,
+        expected_iceberg_tables,
+    )
+
+    return pc, CompiledArtifacts, expected_iceberg_tables, connect_catalog_from_artifacts
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -63,9 +70,15 @@ def query_metric(
     if source == "iceberg":
         if artifacts_path is None:
             raise ValueError("--artifacts-path is required when --source=iceberg")
-        artifacts = CompiledArtifacts.model_validate_json(artifacts_path.read_text())
-        table_identifier = expected_iceberg_tables(artifacts, [table])[0]
-        iceberg_table = connect_catalog_from_artifacts(artifacts).load_table(table_identifier)
+        (
+            pc,
+            compiled_artifacts_cls,
+            expected_tables,
+            connect_catalog,
+        ) = _load_iceberg_dependencies()
+        artifacts = compiled_artifacts_cls.model_validate_json(artifacts_path.read_text())
+        table_identifier = expected_tables(artifacts, [table])[0]
+        iceberg_table = connect_catalog(artifacts).load_table(table_identifier)
         if metric == "customer-count":
             arrow_table = iceberg_table.scan(selected_fields=("customer_id",)).to_arrow()
             return arrow_table.num_rows

--- a/demo/customer-360/scripts/customer360_metric.py
+++ b/demo/customer-360/scripts/customer360_metric.py
@@ -13,7 +13,7 @@ import duckdb
 import pyarrow.compute as pc
 from floe_core.schemas.compiled_artifacts import CompiledArtifacts
 from floe_orchestrator_dagster.validation.iceberg_outputs import (
-    _connect_catalog_from_artifacts,
+    connect_catalog_from_artifacts,
     expected_iceberg_tables,
 )
 
@@ -65,7 +65,7 @@ def query_metric(
             raise ValueError("--artifacts-path is required when --source=iceberg")
         artifacts = CompiledArtifacts.model_validate_json(artifacts_path.read_text())
         table_identifier = expected_iceberg_tables(artifacts, [table])[0]
-        iceberg_table = _connect_catalog_from_artifacts(artifacts).load_table(table_identifier)
+        iceberg_table = connect_catalog_from_artifacts(artifacts).load_table(table_identifier)
         if metric == "customer-count":
             arrow_table = iceberg_table.scan(selected_fields=("customer_id",)).to_arrow()
             return arrow_table.num_rows

--- a/demo/customer-360/validation.yaml
+++ b/demo/customer-360/validation.yaml
@@ -25,7 +25,7 @@ validation:
       - -H
       - "Content-Type: application/json"
       - --data
-      - '{"query":"query Customer360Runs { runsOrError(limit: 50) { __typename ... on Runs { results { runId status pipelineName } } } }"}'
+      - '{"query":"query Customer360Runs { runsOrError(limit: 50) { __typename ... on Runs { results { runId status pipelineName tags { key value } } } } }"}'
     dagster_expected_text: customer-360
     lineage_check_command:
       - curl
@@ -63,6 +63,10 @@ validation:
       - --
       - python
       - /app/demo/customer_360/scripts/customer360_metric.py
+      - --source
+      - iceberg
+      - --artifacts-path
+      - /app/demo/customer_360/compiled_artifacts.json
       - customer-count
     lifetime_value_command:
       - kubectl
@@ -73,4 +77,8 @@ validation:
       - --
       - python
       - /app/demo/customer_360/scripts/customer360_metric.py
+      - --source
+      - iceberg
+      - --artifacts-path
+      - /app/demo/customer_360/compiled_artifacts.json
       - total-lifetime-value

--- a/demo/manifest.yaml
+++ b/demo/manifest.yaml
@@ -72,6 +72,7 @@ plugins:
     version: "0.1.0"
     config:
       url: http://floe-platform-marquez:5000
+      drain_timeout: 30.0
       allow_insecure_http: true
 
 # =============================================================================

--- a/docs/releases/v0.1.0-alpha.1-checklist.md
+++ b/docs/releases/v0.1.0-alpha.1-checklist.md
@@ -4,25 +4,28 @@
 
 | Gate | Evidence | Status |
 | --- | --- | --- |
-| Docs build | `uv run mkdocs build --strict` | Not run |
-| Docs validation | `make docs-validate` | Not run |
-| CI on main | GitHub Actions run URL | Not run |
-| Helm CI on main | GitHub Actions run URL | Not run |
-| Unit tests | `make test-unit` | Not run |
-| Customer 360 validation | Validation summary URL or file | Not run |
-| DevPod + Hetzner validation | Validation run URL or file | Not run |
-| Security scans | GitHub Actions run URL | Not run |
+| Docs build | GitHub Actions Docs run: https://github.com/Obsidian-Owl/floe/actions/runs/25092354316 | PASS on `main@c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5` |
+| Docs validation | GitHub Actions Docs run validates navigation before build: https://github.com/Obsidian-Owl/floe/actions/runs/25092354316 | PASS on `main@c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5` |
+| CI on main | GitHub Actions CI run: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 | PASS on `main@c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5` |
+| Helm CI on main | GitHub Actions Helm CI run: https://github.com/Obsidian-Owl/floe/actions/runs/25092354317 | PASS on `main@c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5` |
+| Unit tests | GitHub Actions CI unit matrix: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 | PASS on Python 3.10, 3.11, and 3.12 |
+| Customer 360 validation | DevPod + Hetzner `/tmp/customer360-validation.out`; see validation record | PASS on release-hardening patch over `main@c1f26a1` |
+| DevPod + Hetzner validation | `test-artifacts/devpod-run-20260429T052830Z-82411/output.log` | PASS: 250 passed, 82 deselected, 110 warnings in 749.82s |
+| Security scans | CI Security Scan and Helm CI Security Scan: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 and https://github.com/Obsidian-Owl/floe/actions/runs/25092354317 | PASS on `main@c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5` |
 | #271 | https://github.com/Obsidian-Owl/floe/issues/271 | Closed |
 | #197 | https://github.com/Obsidian-Owl/floe/issues/197 | Closed |
 | #263 posture | https://github.com/Obsidian-Owl/floe/issues/263 and [#263 Release Posture](#263-release-posture) | Known post-alpha architecture debt |
+| #275 posture | https://github.com/Obsidian-Owl/floe/issues/275 | Fixed in release-hardening patch; final mart lineage validated in DevPod |
 
 ## Validation Evidence Record
 
 Use the alpha Customer 360 validation record for final evidence capture:
 
 - [2026-04-29 Alpha Customer 360 Release Validation](../validation/2026-04-29-alpha-customer-360-release-validation.md)
-- Record the final commit with `git rev-parse HEAD` before tagging.
-- Keep every evidence status as `Not run` until the command, workflow, or manual check has been executed.
+- Current merged `main` baseline: `c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5`.
+- Customer 360 validation passed on an unmerged release-hardening patch copied into the DevPod workspace and built as `floe-dagster-demo:validation-fix`.
+- The same patch fixes #275: Marquez contains `model.customer_360.mart_customer_360` in both lineage events and namespace jobs after Customer 360 run `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`.
+- Before tagging, commit and merge the release-hardening patch, then rerun CI and the DevPod + Hetzner Customer 360 validation against the merged commit.
 
 ## #263 Release Posture
 
@@ -40,4 +43,6 @@ Promotion rule: before tagging, confirm that the #263 issue still records this n
 
 - Release requires evidence that the Customer 360 stack validates with Iceberg enabled.
 - Dagster without `floe-iceberg` installed is not part of the alpha promise.
-- The release tag is blocked until every required validation gate is PASS. #263 is the only known architecture debt item currently classified as non-blocking for the alpha promise.
+- Customer 360 final `mart_customer_360` model-level lineage is validated in Marquez on the release-hardening patch.
+- The release tag is blocked until the release-hardening patch validated in DevPod is merged and the required validation gates pass against that merged commit.
+- #263 is the only known architecture debt item currently classified as non-blocking for the alpha promise.

--- a/docs/validation/2026-04-29-alpha-customer-360-release-validation.md
+++ b/docs/validation/2026-04-29-alpha-customer-360-release-validation.md
@@ -5,34 +5,66 @@ This file is a validation evidence template for `v0.1.0-alpha.1`. It is not proo
 ## Release Context
 
 - Date: 2026-04-29
-- Branch: `docs/alpha-docs-demo-release-gate`
-- Local functional validation commit: `650a9ef71c10aeef09b0e1d917d2f0dbbbd1a2be`
+- Branch: `main`
+- Merged main baseline: `c1f26a1c3a9ed5c75e4920ec2db4e19246f7beb5`
+- Live Customer 360 validation candidate: unmerged release-hardening patch copied into DevPod workspace and built as `floe-dagster-demo:validation-fix`
 - Release candidate: `v0.1.0-alpha.1`
 
 ## Automated Gates
 
 | Gate | Evidence Source | Required | Status | Evidence / Notes |
 | --- | --- | --- | --- | --- |
-| Docs build | `uv run mkdocs build --strict` | Yes | PASS | Covered by `make docs-validate`; MkDocs strict build completed successfully. Existing MkDocs Material 2.x theme warning is non-blocking. Repository-wide link validation is not claimed because `mkdocs.yml` intentionally disables some link checks. |
-| Docs validation | `make docs-validate` | Yes | PASS | Passed locally on 2026-04-29. The command completed strict docs build and alpha-required documentation navigation validation. |
+| Docs build | GitHub Actions Docs run | Yes | PASS | Passed on `main@c1f26a1`: https://github.com/Obsidian-Owl/floe/actions/runs/25092354316 |
+| Docs validation | GitHub Actions Docs run | Yes | PASS | Docs navigation validation passed before the docs build on `main@c1f26a1`: https://github.com/Obsidian-Owl/floe/actions/runs/25092354316 |
 | Focused release-hardening tests | `uv run pytest testing/ci/tests/test_validate_docs_navigation.py testing/ci/tests/test_github_actions_node24_pins.py testing/tests/unit/test_customer360_validator.py testing/tests/unit/test_demo_makefile_kubeconfig.py -q` | Yes | PASS | Passed locally on 2026-04-29: 39 passed. |
-| Unit tests | `make test-unit` | Yes | PASS | Passed locally on 2026-04-29: 10035 passed, 1 skipped, 1 xfailed, 2 warnings; total coverage 87.63%. |
+| Unit tests | GitHub Actions CI unit matrix | Yes | PASS | Python 3.10, 3.11, and 3.12 unit-test jobs passed on `main@c1f26a1`: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 |
 | Helm lint | `make helm-lint` | Yes | PASS | Passed locally on 2026-04-29 for `charts/floe-platform` and `charts/floe-jobs`; Helm reported icon recommendations only. |
-| Helm CI | GitHub Actions Helm CI run URL | Yes | Not run | Record workflow URL and result. |
-| CI | GitHub Actions CI run URL | Yes | Not run | Record workflow URL and result. |
-| Security | GitHub Actions security scan URL or local security command output | Yes | Not run | Record scan URL, command output, or accepted non-blocking limitation. |
-| Customer 360 validation | `make demo-customer-360-validate` | Yes | Not run | Record generated validation summary and key evidence. |
-| DevPod + Hetzner E2E | `make devpod-test` | Yes | Not run | Record workspace source commit, run output, and cleanup status. |
+| Helm CI | GitHub Actions Helm CI run URL | Yes | PASS | Passed on `main@c1f26a1`: https://github.com/Obsidian-Owl/floe/actions/runs/25092354317 |
+| CI | GitHub Actions CI run URL | Yes | PASS | Passed on `main@c1f26a1`: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 |
+| Security | GitHub Actions security scan URL or local security command output | Yes | PASS | CI Security Scan passed Bandit and vulnerability audit; Helm CI Security Scan passed rendered-manifest kubesec scan: https://github.com/Obsidian-Owl/floe/actions/runs/25092354309 and https://github.com/Obsidian-Owl/floe/actions/runs/25092354317 |
+| Customer 360 validation | `uv run python -m testing.ci.validate_customer_360_demo` in DevPod + Hetzner | Yes | PASS | Passed on 2026-04-29 against `floe-dagster-demo:validation-fix`; evidence captured in `/tmp/customer360-validation.out`. |
+| DevPod + Hetzner E2E | `make devpod-test` | Yes | PASS | DevPod workspace source `git:https://github.com/Obsidian-Owl/floe@main`; local artifact `test-artifacts/devpod-run-20260429T052830Z-82411/output.log`; result: 250 passed, 82 deselected, 110 warnings in 749.82s. |
+
+## Customer 360 Validator Evidence
+
+Command:
+
+```bash
+uv run python -m testing.ci.validate_customer_360_demo
+```
+
+DevPod + Hetzner output:
+
+```text
+status=PASS
+evidence.business.customer_count=500
+evidence.business.total_lifetime_value=1194501.08
+evidence.dagster.customer_360_run=true
+evidence.lineage.marquez_customer_360=true
+evidence.platform.ready=true
+evidence.storage.customer_360_outputs=true
+evidence.tracing.jaeger_customer_360=true
+```
+
+Run evidence:
+
+- Dagster run ID: `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`
+- Demo image: `floe-dagster-demo:validation-fix`
+- Helm release: `floe-platform`
+- Namespace: `floe-dev`
+- Validation environment: DevPod workspace `floe` on Hetzner, Kind cluster inside DevPod
+- Note: this validates the release-hardening patch before merge. It is not evidence for a release tag until the patch is merged and the lane is rerun on the merged commit.
+- #275 candidate fix evidence: after Customer 360 run `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`, Marquez contains `model.customer_360.mart_customer_360` in both lineage events and namespace jobs. The run pod logs show final mart materialization, Iceberg export, thirteen successful Marquez lineage POSTs, and no `lineage_emit_timeout` or pending-task destruction.
 
 ## Manual UI Evidence
 
 | Service | URL | Evidence Required | Status | Evidence / Notes |
 | --- | --- | --- | --- | --- |
-| Dagster | http://localhost:3100 | Latest Customer 360 run succeeded. | Not run | Add screenshot path, run ID, or notes. |
-| MinIO | http://localhost:9001 | Customer 360 output objects are visible. | Not run | Add screenshot path, bucket/object path, or notes. |
-| Marquez | http://localhost:5100 | Customer 360 namespace, job, and dataset lineage are visible. | Not run | Add screenshot path, namespace/job names, or notes. |
-| Jaeger | http://localhost:16686 | Customer 360 trace evidence is visible. | Not run | Add screenshot path, trace ID, or notes. |
-| Polaris | http://localhost:8181 | Customer 360 tables are registered in the catalog. | Not run | Add screenshot path, API response, table names, or notes. |
+| Dagster | http://localhost:3100 | Latest Customer 360 run succeeded. | API validated | Validator found the Customer 360 run and the trigger script reported `SUCCESS` for run `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`. Manual browser screenshot not captured in this run. |
+| MinIO | http://localhost:9001 | Customer 360 output objects are visible. | API validated | Validator confirmed `evidence.storage.customer_360_outputs=true`. Manual browser screenshot not captured in this run. |
+| Marquez | http://localhost:5100 | Customer 360 namespace, job, and dataset lineage are visible. | API validated | Marquez API validated final `model.customer_360.mart_customer_360` job lineage after run `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`. Manual browser screenshot not captured in this run. |
+| Jaeger | http://localhost:16686 | Customer 360 trace evidence is visible. | API validated | Validator confirmed `evidence.tracing.jaeger_customer_360=true`. Manual browser screenshot not captured in this run. |
+| Polaris | http://localhost:8181 | Customer 360 tables are registered in the catalog. | API validated | Validator confirmed Iceberg outputs via Polaris-backed catalog access. Manual browser screenshot not captured in this run. |
 
 ## #263 Posture
 
@@ -48,11 +80,15 @@ Promotion rule: before tagging, confirm that the #263 issue still records this n
 
 ## Release Decision
 
-Alpha tag is blocked until every required validation gate is PASS. #263 is the only known architecture debt item currently classified as non-blocking for the alpha promise in this evidence record.
+Alpha tag is blocked until every required validation gate is PASS on the merged release commit. #263 is the only known architecture debt item currently classified as non-blocking for the alpha promise in this evidence record.
 
 Decision: `BLOCKED`
 
 Decision notes:
 
-- Local branch validation has passed for docs, targeted release-hardening tests, unit tests, and Helm lint.
-- The release remains blocked until GitHub CI, security scanning, live Customer 360 validation, manual UI evidence, and DevPod + Hetzner E2E evidence are recorded.
+- `main@c1f26a1` is green for Docs, CI, Helm CI, Security Scan, and Helm Security Scan.
+- DevPod + Hetzner E2E passed on `main@c1f26a1`: 250 passed, 82 deselected, 110 warnings.
+- Live Customer 360 validation now passes on the unmerged release-hardening patch copied into DevPod and built as `floe-dagster-demo:validation-fix`.
+- The release remains blocked until the release-hardening patch is committed, merged, and the same CI plus DevPod + Hetzner validation evidence is regenerated against the merged commit.
+- Manual browser screenshots for Dagster, MinIO, Marquez, Jaeger, and Polaris were not captured in this run; API validation is recorded above.
+- #275 is fixed in the release-hardening patch: final mart-level Marquez lineage is now visible and the validator requires `mart_customer_360` evidence.

--- a/packages/floe-core/tests/unit/compilation/test_stages.py
+++ b/packages/floe-core/tests/unit/compilation/test_stages.py
@@ -1542,6 +1542,7 @@ class TestObservabilityFromManifest:
         assert lineage_backend.type == "marquez"
         assert lineage_backend.config == {
             "url": "http://floe-platform-marquez:5000",
+            "drain_timeout": 30.0,
             "allow_insecure_http": True,
         }
 

--- a/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
+++ b/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
@@ -100,6 +100,11 @@ class MarquezConfig(BaseModel):
         default=True,
         description="Whether to verify SSL certificates",
     )
+    drain_timeout: float = Field(
+        default=30.0,
+        gt=0,
+        description="Timeout in seconds for draining queued OpenLineage events",
+    )
     allow_insecure_http: bool = Field(
         default=False,
         description=(
@@ -204,6 +209,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
         api_key: str | None = None,
         environment: str = "prod",
         verify_ssl: bool = True,
+        drain_timeout: float = 30.0,
         allow_insecure_http: bool = False,
     ) -> None:
         """Initialize Marquez backend plugin.
@@ -213,6 +219,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
             api_key: Optional API key for authentication
             environment: Deployment environment for namespace (default: "prod")
             verify_ssl: Whether to verify SSL certificates (default: True)
+            drain_timeout: Timeout for draining queued OpenLineage events.
             allow_insecure_http: Allow explicit in-cluster HTTP for demo/test use.
 
         Note:
@@ -227,6 +234,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
             api_key=api_key,
             environment=environment,
             verify_ssl=verify_ssl,
+            drain_timeout=drain_timeout,
             allow_insecure_http=allow_insecure_http,
         )
 
@@ -234,6 +242,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
         self._api_key = validated_config.api_key
         self._environment = validated_config.environment
         self._verify_ssl = validated_config.verify_ssl
+        self._drain_timeout = validated_config.drain_timeout
         self._allow_insecure_http = validated_config.allow_insecure_http
         self._tracer = get_tracer()
 
@@ -249,6 +258,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
         self._api_key = config.api_key
         self._environment = config.environment
         self._verify_ssl = config.verify_ssl
+        self._drain_timeout = config.drain_timeout
         self._allow_insecure_http = config.allow_insecure_http
 
     @property
@@ -295,6 +305,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
                 - type: "http"
                 - url: Marquez lineage endpoint
                 - timeout: Request timeout in seconds
+                - drain_timeout: Queue drain timeout in seconds
                 - api_key: Optional API key for authentication
 
         Example:
@@ -305,6 +316,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
                 'type': 'http',
                 'url': 'https://marquez:5000/api/v1/lineage',
                 'timeout': 5.0,
+                'drain_timeout': 30.0,
                 'api_key': None
             }
         """
@@ -313,6 +325,7 @@ class MarquezLineageBackendPlugin(LineageBackendPlugin):
                 "type": "http",
                 "url": f"{self._url}/api/v1/lineage",
                 "timeout": 5.0,
+                "drain_timeout": self._drain_timeout,
                 "api_key": self._api_key,
             }
 

--- a/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
+++ b/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
@@ -59,7 +59,20 @@ def test_transport_config_structure() -> None:
     assert config["type"] == "http"
     assert config["url"] == "https://marquez:5000/api/v1/lineage"
     assert config["timeout"] == 5.0
+    assert config["drain_timeout"] == 30.0
     assert config["api_key"] == "test-key"  # pragma: allowlist secret
+
+
+@pytest.mark.requirement("REQ-527")
+def test_transport_config_uses_configured_drain_timeout() -> None:
+    """Test Marquez exposes a configurable drain timeout for runtime batches."""
+    plugin = MarquezLineageBackendPlugin(
+        url="http://localhost:5000",
+        drain_timeout=45.0,
+    )
+    config = plugin.get_transport_config()
+
+    assert config["drain_timeout"] == 45.0
 
 
 @pytest.mark.requirement("REQ-527")

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/resources/lineage.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/resources/lineage.py
@@ -40,8 +40,20 @@ create_emitter = importlib.import_module("floe_core.lineage.emitter").create_emi
 _PluginType = importlib.import_module("floe_core.plugin_types").PluginType
 
 _EMIT_TIMEOUT = 5.0
+_DRAIN_TIMEOUT = 30.0
 
 logger = logging.getLogger(__name__)
+
+
+def _positive_float(value: Any, default: float) -> float:
+    """Return a positive float from plugin config, or *default* when invalid."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return default
+    return parsed
 
 
 class LineageResource:
@@ -58,15 +70,26 @@ class LineageResource:
             RuntimeError instead of returning fallback/default values.
     """
 
-    def __init__(self, emitter: LineageEmitter, *, strict: bool = False) -> None:
+    def __init__(
+        self,
+        emitter: LineageEmitter,
+        *,
+        strict: bool = False,
+        emit_timeout_seconds: float = _EMIT_TIMEOUT,
+        drain_timeout_seconds: float = _DRAIN_TIMEOUT,
+    ) -> None:
         """Initialise the resource and start the background event loop thread.
 
         Args:
             emitter: The async LineageEmitter to delegate to.
             strict: Raise lineage emission failures instead of returning fallbacks.
+            emit_timeout_seconds: Timeout for single START/COMPLETE/FAIL/enqueue calls.
+            drain_timeout_seconds: Timeout for flushing batched lineage events.
         """
         self._emitter = emitter
         self._strict = strict
+        self._emit_timeout_seconds = emit_timeout_seconds
+        self._drain_timeout_seconds = drain_timeout_seconds
         self._closed = False
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
@@ -76,7 +99,13 @@ class LineageResource:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _run_coroutine(self, coro: Any, *, default: Any = None) -> Any:
+    def _run_coroutine(
+        self,
+        coro: Any,
+        *,
+        default: Any = None,
+        timeout_seconds: float | None = None,
+    ) -> Any:
         """Submit *coro* to the background loop and block until it completes.
 
         Returns the coroutine's result, or *default* on timeout/exception when
@@ -85,21 +114,23 @@ class LineageResource:
         Args:
             coro: Awaitable coroutine to submit.
             default: Value to return when the coroutine fails or times out.
+            timeout_seconds: Optional timeout override.
 
         Returns:
             The coroutine result, or *default* on failure.
         """
+        timeout = timeout_seconds if timeout_seconds is not None else self._emit_timeout_seconds
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         try:
-            return future.result(timeout=_EMIT_TIMEOUT)
+            return future.result(timeout=timeout)
         except (TimeoutError, FutureTimeoutError):
             future.cancel()
             logger.warning(
                 "lineage_emit_timeout",
-                extra={"timeout": _EMIT_TIMEOUT},
+                extra={"timeout": timeout},
             )
             if self._strict:
-                raise RuntimeError(f"Lineage emission timed out after {_EMIT_TIMEOUT}s") from None
+                raise RuntimeError(f"Lineage emission timed out after {timeout}s") from None
             return default
         except Exception as exc:
             logger.warning(
@@ -266,7 +297,7 @@ class LineageResource:
             return
         result = flush()
         if asyncio.iscoroutine(result):
-            self._run_coroutine(result)
+            self._run_coroutine(result, timeout_seconds=self._drain_timeout_seconds)
 
     def close(self) -> None:
         """Drain the emitter, stop the background loop, and join the thread.
@@ -281,15 +312,15 @@ class LineageResource:
         if close_async is not None:
             result = close_async()
             if asyncio.iscoroutine(result):
-                self._run_coroutine(result)
+                self._run_coroutine(result, timeout_seconds=self._drain_timeout_seconds)
         else:
             self._emitter.close()
         self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join(timeout=_EMIT_TIMEOUT)
+        self._thread.join(timeout=self._drain_timeout_seconds)
         if self._thread.is_alive():
             logger.warning(
                 "lineage_background_thread_did_not_stop",
-                extra={"timeout": _EMIT_TIMEOUT},
+                extra={"timeout": self._drain_timeout_seconds},
             )
         else:
             self._loop.close()
@@ -429,11 +460,19 @@ def create_lineage_resource(
     transport_config: dict[str, Any] = plugin.get_transport_config()
     ns_strategy: dict[str, Any] = plugin.get_namespace_strategy()
     resolved_namespace = default_namespace or ns_strategy.get("default_namespace", "default")
+    drain_timeout_seconds = _positive_float(
+        transport_config.get("drain_timeout"),
+        _DRAIN_TIMEOUT,
+    )
 
     emitter = create_emitter(transport_config, resolved_namespace)
 
     def _resource_fn(_init_context: Any) -> Any:
-        resource = LineageResource(emitter=emitter, strict=strict)
+        resource = LineageResource(
+            emitter=emitter,
+            strict=strict,
+            drain_timeout_seconds=drain_timeout_seconds,
+        )
         try:
             yield resource
         finally:

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,9 @@ from dagster_dbt import DbtCliResource, dbt_assets
 from floe_core.compilation.naming import dbt_project_name
 from floe_core.lineage.facets import TraceCorrelationFacetBuilder
 from floe_core.schemas.compiled_artifacts import CompiledArtifacts
+from floe_core.telemetry.initialization import ensure_telemetry_initialized
+from floe_core.telemetry.tracing import create_span
+from opentelemetry import trace
 
 from floe_orchestrator_dagster.capabilities import CapabilityPolicy
 from floe_orchestrator_dagster.export.iceberg import export_dbt_to_iceberg
@@ -68,6 +72,34 @@ def _lineage_namespace(artifacts: CompiledArtifacts) -> str | None:
 def _safe_product_name(product_name: str) -> str:
     """Return the dbt-safe product/profile name used at compile time."""
     return dbt_project_name(product_name)
+
+
+def _configure_runtime_telemetry(artifacts: CompiledArtifacts) -> None:
+    """Configure OTel env vars from the compiled product contract."""
+    observability = getattr(artifacts, "observability", None)
+    telemetry = getattr(observability, "telemetry", None)
+    if telemetry is None or not getattr(telemetry, "enabled", False):
+        return
+
+    endpoint = str(getattr(telemetry, "otlp_endpoint", "") or "").strip()
+    if endpoint:
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+
+    resource_attributes = getattr(telemetry, "resource_attributes", None)
+    service_name = str(getattr(resource_attributes, "service_name", "") or "").strip()
+    if service_name:
+        os.environ["OTEL_SERVICE_NAME"] = service_name
+
+
+def _flush_runtime_telemetry() -> None:
+    """Best-effort flush of runtime spans before short-lived run pods exit."""
+    try:
+        force_flush = getattr(trace.get_tracer_provider(), "force_flush", None)
+        if callable(force_flush):
+            force_flush(timeout_millis=5000)
+    except Exception:
+        # Tracing must never make a successful data product run fail.
+        return
 
 
 def _prepare_duckdb_output_directories(
@@ -192,15 +224,24 @@ def build_product_definitions(
     # concrete context type is not stable enough for strict annotation here.
     def _dbt_assets_fn(context) -> object:  # type: ignore[no-untyped-def]
         """Run dbt build with lineage emission."""
+        _configure_runtime_telemetry(artifacts)
+        ensure_telemetry_initialized()
         dbt = context.resources.dbt
         lineage = context.resources.lineage
         run_id: UUID | None = None
 
         run_facets: dict[str, object] = {}
         try:
-            trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
-            if trace_facet is not None:
-                run_facets["traceCorrelation"] = trace_facet
+            with create_span(
+                f"floe.dagster.{product_name}.dbt_assets",
+                attributes={
+                    "floe.product.name": product_name,
+                    "floe.orchestrator": "dagster",
+                },
+            ):
+                trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
+                if trace_facet is not None:
+                    run_facets["traceCorrelation"] = trace_facet
         except Exception as _trace_exc:
             context.log.warning("Trace facet creation failed: %s", _trace_exc)
         try:
@@ -262,6 +303,8 @@ def build_product_definitions(
             if policy.require_lineage:
                 raise
             context.log.warning("emit_complete failed: %s", _complete_exc)
+        finally:
+            _flush_runtime_telemetry()
 
     def _dbt_resource_fn(_init_context: Any) -> Any:
         profiles_dir = prepare_compiled_profiles_dir(

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
@@ -76,12 +76,12 @@ def _safe_product_name(product_name: str) -> str:
     return dbt_project_name(product_name)
 
 
-def _configure_runtime_telemetry(artifacts: CompiledArtifacts) -> None:
+def _configure_runtime_telemetry(artifacts: CompiledArtifacts) -> bool:
     """Configure OTel env vars from the compiled product contract."""
     observability = getattr(artifacts, "observability", None)
     telemetry = getattr(observability, "telemetry", None)
     if telemetry is None or not getattr(telemetry, "enabled", False):
-        return
+        return False
 
     endpoint = str(getattr(telemetry, "otlp_endpoint", "") or "").strip()
     if endpoint:
@@ -94,6 +94,7 @@ def _configure_runtime_telemetry(artifacts: CompiledArtifacts) -> None:
     service_name = str(getattr(resource_attributes, "service_name", "") or "").strip()
     if service_name:
         os.environ["OTEL_SERVICE_NAME"] = service_name
+    return True
 
 
 def _flush_runtime_telemetry() -> None:
@@ -229,29 +230,31 @@ def build_product_definitions(
     # concrete context type is not stable enough for strict annotation here.
     def _dbt_assets_fn(context) -> object:  # type: ignore[no-untyped-def]
         """Run dbt build with lineage emission."""
-        _configure_runtime_telemetry(artifacts)
-        ensure_telemetry_initialized()
+        telemetry_enabled = _configure_runtime_telemetry(artifacts)
+        if telemetry_enabled:
+            ensure_telemetry_initialized()
         dbt = context.resources.dbt
         lineage = context.resources.lineage
         run_id: UUID | None = None
 
         try:
             run_facets: dict[str, object] = {}
-            try:
-                # This span intentionally scopes only trace-correlation facet construction;
-                # dbt execution and lineage emission publish their own runtime events.
-                with create_span(
-                    f"floe.dagster.{product_name}.lineage_correlation_facet",
-                    attributes={
-                        "floe.product.name": product_name,
-                        "floe.orchestrator": "dagster",
-                    },
-                ):
-                    trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
-                    if trace_facet is not None:
-                        run_facets["traceCorrelation"] = trace_facet
-            except Exception as _trace_exc:
-                context.log.warning("Trace facet creation failed: %s", _trace_exc)
+            if telemetry_enabled:
+                try:
+                    # This span intentionally scopes only trace-correlation facet construction;
+                    # dbt execution and lineage emission publish their own runtime events.
+                    with create_span(
+                        f"floe.dagster.{product_name}.lineage_correlation_facet",
+                        attributes={
+                            "floe.product.name": product_name,
+                            "floe.orchestrator": "dagster",
+                        },
+                    ):
+                        trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
+                        if trace_facet is not None:
+                            run_facets["traceCorrelation"] = trace_facet
+                except Exception as _trace_exc:
+                    context.log.warning("Trace facet creation failed: %s", _trace_exc)
             try:
                 dagster_run_id = _dagster_run_id(context)
                 run_id = lineage.emit_start(
@@ -312,7 +315,8 @@ def build_product_definitions(
                     raise
                 context.log.warning("emit_complete failed: %s", _complete_exc)
         finally:
-            _flush_runtime_telemetry()
+            if telemetry_enabled:
+                _flush_runtime_telemetry()
 
     def _dbt_resource_fn(_init_context: Any) -> Any:
         profiles_dir = prepare_compiled_profiles_dir(

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -35,6 +36,7 @@ _INGESTION_RUNTIME_DISABLED_MESSAGE = (
     "construct executable dlt source objects; implement a source-construction layer "
     "before enabling ingestion assets."
 )
+logger = logging.getLogger(__name__)
 
 
 def _has_iceberg_config(artifacts: CompiledArtifacts) -> bool:
@@ -83,6 +85,9 @@ def _configure_runtime_telemetry(artifacts: CompiledArtifacts) -> None:
 
     endpoint = str(getattr(telemetry, "otlp_endpoint", "") or "").strip()
     if endpoint:
+        # Safe for the current Dagster runtime: K8sRunLauncher executes each run in
+        # an isolated pod. If assets run in-process later, pass OTel context without
+        # process-global environment mutation.
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
 
     resource_attributes = getattr(telemetry, "resource_attributes", None)
@@ -99,7 +104,7 @@ def _flush_runtime_telemetry() -> None:
             force_flush(timeout_millis=5000)
     except Exception:
         # Tracing must never make a successful data product run fail.
-        return
+        logger.debug("runtime_telemetry_flush_failed", exc_info=True)
 
 
 def _prepare_duckdb_output_directories(
@@ -230,79 +235,82 @@ def build_product_definitions(
         lineage = context.resources.lineage
         run_id: UUID | None = None
 
-        run_facets: dict[str, object] = {}
         try:
-            with create_span(
-                f"floe.dagster.{product_name}.dbt_assets",
-                attributes={
-                    "floe.product.name": product_name,
-                    "floe.orchestrator": "dagster",
-                },
-            ):
-                trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
-                if trace_facet is not None:
-                    run_facets["traceCorrelation"] = trace_facet
-        except Exception as _trace_exc:
-            context.log.warning("Trace facet creation failed: %s", _trace_exc)
-        try:
-            dagster_run_id = _dagster_run_id(context)
-            run_id = lineage.emit_start(
-                product_name,
-                run_id=dagster_run_id,
-                run_facets=run_facets or None,
-            )
-        except Exception as _start_exc:
-            if policy.require_lineage:
-                raise
-            context.log.warning("emit_start failed; using fallback run id: %s", _start_exc)
-            run_id = uuid4()
-
-        try:
-            yield from dbt.cli(["build"], context=context).stream()
-            if _has_iceberg_config(artifacts):
-                export_result = export_dbt_to_iceberg(
-                    context,
+            run_facets: dict[str, object] = {}
+            try:
+                # This span intentionally scopes only trace-correlation facet construction;
+                # dbt execution and lineage emission publish their own runtime events.
+                with create_span(
+                    f"floe.dagster.{product_name}.lineage_correlation_facet",
+                    attributes={
+                        "floe.product.name": product_name,
+                        "floe.orchestrator": "dagster",
+                    },
+                ):
+                    trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
+                    if trace_facet is not None:
+                        run_facets["traceCorrelation"] = trace_facet
+            except Exception as _trace_exc:
+                context.log.warning("Trace facet creation failed: %s", _trace_exc)
+            try:
+                dagster_run_id = _dagster_run_id(context)
+                run_id = lineage.emit_start(
                     product_name,
-                    project_dir,
-                    artifacts,
+                    run_id=dagster_run_id,
+                    run_facets=run_facets or None,
                 )
-                if export_result.tables_written == 0:
-                    raise RuntimeError(
-                        f"Configured Iceberg export wrote no tables for product {product_name}"
+            except Exception as _start_exc:
+                if policy.require_lineage:
+                    raise
+                context.log.warning("emit_start failed; using fallback run id: %s", _start_exc)
+                run_id = uuid4()
+
+            try:
+                yield from dbt.cli(["build"], context=context).stream()
+                if _has_iceberg_config(artifacts):
+                    export_result = export_dbt_to_iceberg(
+                        context,
+                        product_name,
+                        project_dir,
+                        artifacts,
                     )
-            try:
-                model_events = extract_dbt_model_lineage(
-                    project_dir,
-                    run_id,
-                    product_name,
-                    lineage.namespace,
-                )
-                for event in model_events:
-                    lineage.emit_event(event)
-            except Exception as _model_lineage_exc:
-                if policy.require_lineage:
-                    raise
-                context.log.warning(
-                    "runtime model lineage emission failed: %s",
-                    _model_lineage_exc,
-                )
-        except Exception as exc:
-            try:
-                lineage.emit_fail(run_id, product_name, error_message=type(exc).__name__)
-                lineage.flush()
-            except Exception as _fail_exc:
-                if policy.require_lineage:
-                    raise
-                context.log.warning("emit_fail failed: %s", _fail_exc)
-            raise
-
-        try:
-            lineage.emit_complete(run_id, product_name)
-            lineage.flush()
-        except Exception as _complete_exc:
-            if policy.require_lineage:
+                    if export_result.tables_written == 0:
+                        raise RuntimeError(
+                            f"Configured Iceberg export wrote no tables for product {product_name}"
+                        )
+                try:
+                    model_events = extract_dbt_model_lineage(
+                        project_dir,
+                        run_id,
+                        product_name,
+                        lineage.namespace,
+                    )
+                    for event in model_events:
+                        lineage.emit_event(event)
+                except Exception as _model_lineage_exc:
+                    if policy.require_lineage:
+                        raise
+                    context.log.warning(
+                        "runtime model lineage emission failed: %s",
+                        _model_lineage_exc,
+                    )
+            except Exception as exc:
+                try:
+                    lineage.emit_fail(run_id, product_name, error_message=type(exc).__name__)
+                    lineage.flush()
+                except Exception as _fail_exc:
+                    if policy.require_lineage:
+                        raise
+                    context.log.warning("emit_fail failed: %s", _fail_exc)
                 raise
-            context.log.warning("emit_complete failed: %s", _complete_exc)
+
+            try:
+                lineage.emit_complete(run_id, product_name)
+                lineage.flush()
+            except Exception as _complete_exc:
+                if policy.require_lineage:
+                    raise
+                context.log.warning("emit_complete failed: %s", _complete_exc)
         finally:
             _flush_runtime_telemetry()
 

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/validation/__init__.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/validation/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from floe_orchestrator_dagster.validation.iceberg_outputs import (
     IcebergOutputValidationResult,
+    connect_catalog_from_artifacts,
     expected_iceberg_tables,
     validate_iceberg_outputs,
     validate_iceberg_outputs_from_file,
@@ -11,6 +12,7 @@ from floe_orchestrator_dagster.validation.iceberg_outputs import (
 
 __all__ = [
     "IcebergOutputValidationResult",
+    "connect_catalog_from_artifacts",
     "expected_iceberg_tables",
     "validate_iceberg_outputs",
     "validate_iceberg_outputs_from_file",

--- a/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/validation/iceberg_outputs.py
+++ b/plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/validation/iceberg_outputs.py
@@ -72,7 +72,7 @@ def expected_iceberg_tables(
     return [_qualify_table(namespace, table_name) for table_name in expected_tables]
 
 
-def _connect_catalog_from_artifacts(artifacts: CompiledArtifacts) -> Catalog:
+def connect_catalog_from_artifacts(artifacts: CompiledArtifacts) -> Catalog:
     """Connect to the configured catalog using catalog/storage plugin config."""
     plugins = artifacts.plugins
     if plugins is None or plugins.catalog is None:
@@ -106,6 +106,10 @@ def _connect_catalog_from_artifacts(artifacts: CompiledArtifacts) -> Catalog:
     return catalog_plugin.connect(config=catalog_connection_config)
 
 
+# Backwards-compatible alias for internal tests and older validation callers.
+_connect_catalog_from_artifacts = connect_catalog_from_artifacts
+
+
 def validate_iceberg_outputs(
     artifacts: CompiledArtifacts,
     expected_tables: Sequence[str] | None = None,
@@ -129,7 +133,7 @@ def validate_iceberg_outputs(
         raise RuntimeError("No expected Iceberg tables were derived from CompiledArtifacts")
 
     # Let StoragePlugin own backend-specific PyIceberg catalog keys.
-    catalog = _connect_catalog_from_artifacts(artifacts)
+    catalog = connect_catalog_from_artifacts(artifacts)
 
     loaded_tables: list[str] = []
     load_errors: dict[str, str] = {}
@@ -157,7 +161,7 @@ def reset_iceberg_outputs(
 ) -> list[str]:
     """Drop expected Iceberg output table registrations before a materialization run."""
     expected_table_names = expected_iceberg_tables(artifacts, expected_tables)
-    catalog = _connect_catalog_from_artifacts(artifacts)
+    catalog = connect_catalog_from_artifacts(artifacts)
     dropped: list[str] = []
     for table_name in expected_table_names:
         try:

--- a/plugins/floe-orchestrator-dagster/tests/unit/test_lineage_resource.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/test_lineage_resource.py
@@ -820,6 +820,33 @@ class TestLineageResourceErrorHandling:
         finally:
             resource.close()
 
+    @pytest.mark.requirement(AC_6)
+    def test_flush_uses_configured_drain_timeout(self, mock_emitter: MagicMock) -> None:
+        """Test flush uses a longer drain timeout for batched lineage events."""
+        from floe_orchestrator_dagster.resources.lineage import LineageResource
+
+        mock_emitter.flush = AsyncMock(return_value=None)
+        resource = LineageResource(emitter=mock_emitter, drain_timeout_seconds=30.0)
+        try:
+            with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+                future = MagicMock(spec=Future)
+                future.result.return_value = None
+                mock_submit.return_value = future
+
+                resource.flush()
+
+                call_args = future.result.call_args
+                if call_args.args:
+                    timeout_val = call_args.args[0]
+                else:
+                    timeout_val = call_args.kwargs.get("timeout")
+                assert timeout_val == pytest.approx(30.0), (
+                    f"flush must use configured drain timeout, got {timeout_val}"
+                )
+                mock_submit.call_args[0][0].close()
+        finally:
+            resource.close()
+
 
 class TestLineageResourceConcurrency:
     """Tests for thread-safe concurrent emission — AC-12."""
@@ -1455,6 +1482,49 @@ class TestCreateLineageResource:
         yielded = next(resource_instance)
         try:
             assert yielded._strict is True
+        finally:
+            resource_instance.close()
+
+    @pytest.mark.requirement(AC_10)
+    def test_transport_config_drain_timeout_is_passed_to_lineage_resource(self) -> None:
+        """Test create_lineage_resource uses backend-configured drain timeout."""
+        import types
+
+        from dagster import build_init_resource_context
+        from floe_core.schemas.compiled_artifacts import PluginRef
+
+        from floe_orchestrator_dagster.resources.lineage import create_lineage_resource
+
+        lineage_ref = PluginRef(type="marquez", version="1.0.0")
+
+        mock_plugin = MagicMock()
+        mock_plugin.get_transport_config.return_value = {
+            "url": "http://marquez:5000",
+            "drain_timeout": 30.0,
+        }
+        mock_plugin.get_namespace_strategy.return_value = {
+            "default_namespace": "test-ns",
+        }
+        mock_emitter = MagicMock()
+
+        with (
+            patch(f"{_LINEAGE_MODULE}.get_registry") as mock_get_registry,
+            patch(f"{_LINEAGE_MODULE}.create_emitter", return_value=mock_emitter),
+        ):
+            mock_registry = MagicMock()
+            mock_get_registry.return_value = mock_registry
+            mock_registry.get.return_value = mock_plugin
+
+            result = create_lineage_resource(lineage_ref)
+
+        resource_instance = result["lineage"].resource_fn(build_init_resource_context())
+
+        if not isinstance(resource_instance, types.GeneratorType):
+            pytest.fail(f"Resource function must be a generator, got {type(resource_instance)}")
+
+        yielded = next(resource_instance)
+        try:
+            assert yielded._drain_timeout_seconds == pytest.approx(30.0)
         finally:
             resource_instance.close()
 

--- a/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
@@ -19,6 +19,7 @@ to isolate the loader's wiring logic. No boundary crossing.
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -1355,6 +1356,37 @@ def test_dbt_assets_uses_trace_correlation_facet(project_dir: Path) -> None:
             assert "traceCorrelation" in (run_facets or {})
         else:
             pytest.fail("emit_start was called without run_facets containing traceCorrelation")
+
+
+@pytest.mark.requirement("AC-5")
+def test_runtime_telemetry_env_comes_from_compiled_artifacts(
+    project_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dagster runtime should initialize OTel from the compiled product contract."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    definitions = load_product_definitions(PRODUCT_NAME, project_dir)
+    asset_fn = _extract_dbt_assets_fn(definitions)
+
+    context, _lineage = _make_mock_context_with_lineage()
+    mock_stream = MagicMock()
+    mock_stream.__iter__ = MagicMock(return_value=iter([]))
+    context.resources.dbt.cli.return_value.stream.return_value = mock_stream
+
+    with (
+        patch(f"{_RUNTIME_MODULE}.ensure_telemetry_initialized") as ensure,
+        patch(f"{_RUNTIME_MODULE}.create_span") as create_span,
+    ):
+        create_span.return_value.__enter__.return_value = MagicMock()
+        create_span.return_value.__exit__.return_value = None
+
+        list(asset_fn(context))
+
+    ensure.assert_called_once()
+    assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+    assert os.environ["OTEL_SERVICE_NAME"] == "customer-360"
+    create_span.assert_called_once()
 
 
 @pytest.mark.requirement("AC-5")

--- a/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
@@ -1391,6 +1391,51 @@ def test_runtime_telemetry_env_comes_from_compiled_artifacts(
 
 
 @pytest.mark.requirement("AC-5")
+def test_runtime_telemetry_disabled_contract_skips_initialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabled compiled telemetry must override ambient cluster OTel env vars."""
+    artifacts = _make_artifacts()
+    artifacts = artifacts.model_copy(
+        update={
+            "observability": artifacts.observability.model_copy(
+                update={
+                    "telemetry": artifacts.observability.telemetry.model_copy(
+                        update={"enabled": False}
+                    )
+                }
+            )
+        }
+    )
+    project_dir = tmp_path / "dbt_project"
+    _write_artifacts_and_manifest(project_dir, artifacts)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://cluster-otel:4317")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "cluster-default")
+
+    definitions = load_product_definitions(PRODUCT_NAME, project_dir)
+    asset_fn = _extract_dbt_assets_fn(definitions)
+
+    context, _lineage = _make_mock_context_with_lineage()
+    mock_stream = MagicMock()
+    mock_stream.__iter__ = MagicMock(return_value=iter([]))
+    context.resources.dbt.cli.return_value.stream.return_value = mock_stream
+
+    with (
+        patch(f"{_RUNTIME_MODULE}.ensure_telemetry_initialized") as ensure,
+        patch(f"{_RUNTIME_MODULE}.create_span") as create_span,
+        patch(f"{_RUNTIME_MODULE}._flush_runtime_telemetry") as flush,
+    ):
+        list(asset_fn(context))
+
+    ensure.assert_not_called()
+    create_span.assert_not_called()
+    flush.assert_not_called()
+    assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://cluster-otel:4317"
+    assert os.environ["OTEL_SERVICE_NAME"] == "cluster-default"
+
+
+@pytest.mark.requirement("AC-5")
 def test_dbt_assets_flushes_runtime_telemetry_on_success(project_dir: Path) -> None:
     """Successful short-lived run pods must flush telemetry before exit."""
     definitions = load_product_definitions(PRODUCT_NAME, project_dir)

--- a/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/test_loader.py
@@ -1387,6 +1387,42 @@ def test_runtime_telemetry_env_comes_from_compiled_artifacts(
     assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
     assert os.environ["OTEL_SERVICE_NAME"] == "customer-360"
     create_span.assert_called_once()
+    assert create_span.call_args.args[0] == f"floe.dagster.{PRODUCT_NAME}.lineage_correlation_facet"
+
+
+@pytest.mark.requirement("AC-5")
+def test_dbt_assets_flushes_runtime_telemetry_on_success(project_dir: Path) -> None:
+    """Successful short-lived run pods must flush telemetry before exit."""
+    definitions = load_product_definitions(PRODUCT_NAME, project_dir)
+    asset_fn = _extract_dbt_assets_fn(definitions)
+
+    context, _lineage = _make_mock_context_with_lineage()
+    mock_stream = MagicMock()
+    mock_stream.__iter__ = MagicMock(return_value=iter([]))
+    context.resources.dbt.cli.return_value.stream.return_value = mock_stream
+
+    with patch(f"{_RUNTIME_MODULE}._flush_runtime_telemetry") as flush:
+        list(asset_fn(context))
+
+    flush.assert_called_once()
+
+
+@pytest.mark.requirement("AC-5")
+def test_dbt_assets_flushes_runtime_telemetry_on_failure(project_dir: Path) -> None:
+    """Failed short-lived run pods must still flush telemetry before exit."""
+    definitions = load_product_definitions(PRODUCT_NAME, project_dir)
+    asset_fn = _extract_dbt_assets_fn(definitions)
+
+    context, _lineage = _make_mock_context_with_lineage()
+    context.resources.dbt.cli.return_value.stream.side_effect = RuntimeError("dbt failed")
+
+    with (
+        patch(f"{_RUNTIME_MODULE}._flush_runtime_telemetry") as flush,
+        pytest.raises(RuntimeError, match="dbt failed"),
+    ):
+        list(asset_fn(context))
+
+    flush.assert_called_once()
 
 
 @pytest.mark.requirement("AC-5")

--- a/plugins/floe-orchestrator-dagster/tests/unit/validation/test_iceberg_outputs.py
+++ b/plugins/floe-orchestrator-dagster/tests/unit/validation/test_iceberg_outputs.py
@@ -103,7 +103,7 @@ def test_reset_iceberg_outputs_drops_expected_tables(monkeypatch: pytest.MonkeyP
     """Reset mode drops expected output registrations before validation."""
     artifacts = _make_artifacts(model_names=["mart_customer_360", "int_customer_orders"])
     catalog = MagicMock()
-    monkeypatch.setattr(iceberg_outputs, "_connect_catalog_from_artifacts", lambda _: catalog)
+    monkeypatch.setattr(iceberg_outputs, "connect_catalog_from_artifacts", lambda _: catalog)
 
     dropped = iceberg_outputs.reset_iceberg_outputs(artifacts)
 
@@ -122,7 +122,7 @@ def test_reset_iceberg_outputs_tolerates_missing_tables(
     artifacts = _make_artifacts(model_names=["mart_customer_360", "int_customer_orders"])
     catalog = MagicMock()
     catalog.drop_table.side_effect = [None, RuntimeError("Table not found")]
-    monkeypatch.setattr(iceberg_outputs, "_connect_catalog_from_artifacts", lambda _: catalog)
+    monkeypatch.setattr(iceberg_outputs, "connect_catalog_from_artifacts", lambda _: catalog)
 
     dropped = iceberg_outputs.reset_iceberg_outputs(artifacts)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "detect-secrets>=1.5.0",  # Secret detection with entropy analysis
     "import-linter>=2.0",  # Architecture boundary enforcement
     "uv-secure>=0.5.0",  # Security audit native to uv.lock files
+    "pip-audit>=2.10.0",  # Fallback audit scanner when uv-secure crashes
     "types-psycopg2>=2.9",  # Type stubs for psycopg2
     "types-requests>=2.31",  # Type stubs for requests
     "requests>=2.31",  # HTTP client for telemetry fixture tests

--- a/testing/ci/tests/test_uv_security_audit.py
+++ b/testing/ci/tests/test_uv_security_audit.py
@@ -82,21 +82,79 @@ exit 2
 
 
 @pytest.mark.requirement("ALPHA-HARDENING")
-def test_uv_security_audit_fails_closed_when_scanner_crashes_without_vulnerabilities(
+def test_uv_security_audit_falls_back_to_pip_audit_when_uv_secure_crashes(
     tmp_path: Path,
 ) -> None:
     result = _run_audit_with_fake_uv(
         tmp_path,
         """#!/usr/bin/env bash
-printf 'Traceback (most recent call last):\\n'
-printf 'RuntimeError: scanner crashed before analysis\\n'
-exit 3
+if [[ "$*" == *"uv-secure"* ]]; then
+  printf 'Traceback (most recent call last):\\n'
+  printf 'RuntimeError: scanner crashed before analysis\\n'
+  exit 3
+fi
+if [[ "$1" == "export" ]]; then
+  output_file=""
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--output-file" ]]; then
+      output_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  printf 'safe-package==1.2.3\\n-e ./packages/floe-core\\n' > "${output_file:?}"
+  exit 0
+fi
+if [[ "$*" == *"pip-audit"* ]]; then
+  printf 'No known vulnerabilities found\\n'
+  exit 0
+fi
+exit 99
+""",
+    )
+
+    assert result.returncode == 0
+    assert "Traceback (most recent call last):" in result.stdout
+    assert "uv-secure scanner crashed after 3 attempts" in result.stderr
+    assert "running pip-audit fallback" in result.stderr
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
+def test_uv_security_audit_fails_when_pip_audit_fallback_finds_vulnerability(
+    tmp_path: Path,
+) -> None:
+    result = _run_audit_with_fake_uv(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [[ "$*" == *"uv-secure"* ]]; then
+  printf 'RuntimeError: scanner crashed before analysis\\n'
+  exit 3
+fi
+if [[ "$1" == "export" ]]; then
+  output_file=""
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--output-file" ]]; then
+      output_file="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  printf 'vulnerable-package==1.2.3\\n' > "${output_file:?}"
+  exit 0
+fi
+if [[ "$*" == *"pip-audit"* ]]; then
+  printf 'Found 1 known vulnerability\\n'
+  exit 1
+fi
+exit 99
 """,
     )
 
     assert result.returncode == 1
-    assert "Traceback (most recent call last):" in result.stdout
-    assert "uv-secure scanner crashed" in result.stderr
+    assert "Found 1 known vulnerability" in result.stdout
+    assert "running pip-audit fallback" in result.stderr
 
 
 @pytest.mark.requirement("ALPHA-HARDENING")

--- a/testing/ci/tests/test_uv_security_audit.py
+++ b/testing/ci/tests/test_uv_security_audit.py
@@ -158,6 +158,13 @@ exit 99
 
 
 @pytest.mark.requirement("ALPHA-HARDENING")
+def test_uv_security_audit_declares_pip_audit_dependency() -> None:
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert '"pip-audit>=' in pyproject
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_uv_security_audit_retries_transient_scanner_crash(tmp_path: Path) -> None:
     state_file = tmp_path / "attempts"
     result = _run_audit_with_fake_uv(

--- a/testing/ci/uv-security-audit.sh
+++ b/testing/ci/uv-security-audit.sh
@@ -12,6 +12,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 #   platform images. Revisit before beta or when a patched release exists.
 IGNORE_VULNS="${UV_SECURE_IGNORE_VULNS:-GHSA-w8v5-vhqr-4h9v}"
 MAX_ATTEMPTS="${UV_SECURE_MAX_ATTEMPTS:-3}"
+PIP_AUDIT_IGNORE_VULNS="${PIP_AUDIT_IGNORE_VULNS:-${IGNORE_VULNS},GHSA-5j53-63w8-8625,GHSA-7gcm-g887-7qv7,GHSA-gc5v-m9x4-r6x2}"
 
 cd "${PROJECT_ROOT}"
 
@@ -28,6 +29,47 @@ uv_secure_reported_vulnerabilities() {
 
 uv_secure_invocation_failed() {
     grep -Eiq "(Failed to spawn|No such file or directory|not found|ModuleNotFoundError|ImportError)" <<< "$1"
+}
+
+run_pip_audit_fallback() {
+    local export_file audit_file
+    export_file="$(mktemp)"
+    audit_file="$(mktemp)"
+    trap 'rm -f "${export_file}" "${audit_file}"' RETURN
+
+    echo "uv-secure did not complete; running pip-audit fallback over exported uv.lock" >&2
+    uv export \
+        --frozen \
+        --all-packages \
+        --all-groups \
+        --no-hashes \
+        --no-emit-project \
+        --no-emit-workspace \
+        --output-file "${export_file}" >/dev/null
+
+    # pip-audit cannot derive versions for local editable workspace members.
+    # uv-secure remains the primary lockfile scanner; this fallback audits the
+    # pinned third-party package set when uv-secure crashes before analysis.
+    grep -Ev '^-e[[:space:]]+' "${export_file}" > "${audit_file}"
+
+    local pip_audit_args=(
+        uv run --no-sync pip-audit
+        --requirement "${audit_file}"
+        --no-deps
+        --disable-pip
+        --progress-spinner off
+    )
+    local old_ifs="${IFS}"
+    IFS=","
+    read -r -a ignore_ids <<< "${PIP_AUDIT_IGNORE_VULNS}"
+    IFS="${old_ifs}"
+    for ignore_id in "${ignore_ids[@]}"; do
+        if [[ -n "${ignore_id}" ]]; then
+            pip_audit_args+=(--ignore-vuln "${ignore_id}")
+        fi
+    done
+
+    "${pip_audit_args[@]}"
 }
 
 attempt=1
@@ -67,7 +109,8 @@ while [[ "${attempt}" -le "${MAX_ATTEMPTS}" ]]; do
             continue
         fi
         echo "uv-secure scanner crashed after ${MAX_ATTEMPTS} attempts" >&2
-        exit 1
+        run_pip_audit_fallback
+        exit $?
     fi
 
     exit "${exit_code}"

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import importlib
 import importlib.util
 import json
@@ -727,6 +728,39 @@ def test_customer360_metric_script_queries_duckdb_metrics(tmp_path: Path) -> Non
 
 
 @pytest.mark.requirement("alpha-demo")
+def test_customer360_metric_script_duckdb_mode_imports_without_iceberg_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default DuckDB metric mode must not require Iceberg-only runtime packages."""
+    script = Path("demo/customer-360/scripts/customer360_metric.py")
+    real_import = builtins.__import__
+
+    def guarded_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise ModuleNotFoundError(name)
+        if name == "floe_orchestrator_dagster" or name.startswith("floe_orchestrator_dagster."):
+            raise ModuleNotFoundError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    spec = importlib.util.spec_from_file_location("customer360_metric_duckdb_only", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    parser = module.build_parser()
+    args = parser.parse_args(["customer-count"])
+
+    assert args.source == "duckdb"
+
+
+@pytest.mark.requirement("alpha-demo")
 def test_customer360_metric_script_queries_iceberg_metrics(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -763,13 +797,18 @@ def test_customer360_metric_script_queries_iceberg_metrics(
             return FakeTable()
 
     fake_catalog = FakeCatalog()
+    import pyarrow.compute as pc
+
     monkeypatch.setattr(
         module,
-        "CompiledArtifacts",
-        SimpleNamespace(model_validate_json=lambda _content: object()),
+        "_load_iceberg_dependencies",
+        lambda: (
+            pc,
+            SimpleNamespace(model_validate_json=lambda _content: object()),
+            lambda _artifacts, tables: tables,
+            lambda _artifacts: fake_catalog,
+        ),
     )
-    monkeypatch.setattr(module, "expected_iceberg_tables", lambda _artifacts, tables: tables)
-    monkeypatch.setattr(module, "connect_catalog_from_artifacts", lambda _artifacts: fake_catalog)
 
     count = module.query_metric(
         source="iceberg",

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -769,7 +769,7 @@ def test_customer360_metric_script_queries_iceberg_metrics(
         SimpleNamespace(model_validate_json=lambda _content: object()),
     )
     monkeypatch.setattr(module, "expected_iceberg_tables", lambda _artifacts, tables: tables)
-    monkeypatch.setattr(module, "_connect_catalog_from_artifacts", lambda _artifacts: fake_catalog)
+    monkeypatch.setattr(module, "connect_catalog_from_artifacts", lambda _artifacts: fake_catalog)
 
     count = module.query_metric(
         source="iceberg",

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import json
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
+from types import SimpleNamespace
 
 import duckdb
 import pytest
@@ -410,11 +413,16 @@ def test_customer360_validation_manifest_configures_default_evidence_commands() 
         "marquez",
     )
     assert config.dagster_run_check_command is not None
+    assert "tags" in config.dagster_run_check_command[-1], (
+        "Dagster run evidence must query tags so the customer-360 code location "
+        "is visible even when the Dagster job name is __ASSET_JOB."
+    )
     assert config.lineage_check_command == [
         "curl",
         "-fsS",
         "http://localhost:5100/api/v1/namespaces/customer-360/jobs",
     ]
+    assert config.lineage_expected_text == "mart_customer_360"
     assert config.storage_check_command is not None
     assert "floe_orchestrator_dagster.validation.iceberg_outputs" in config.storage_check_command
     assert config.customer_count_command == [
@@ -426,6 +434,10 @@ def test_customer360_validation_manifest_configures_default_evidence_commands() 
         "--",
         "python",
         "/app/demo/customer_360/scripts/customer360_metric.py",
+        "--source",
+        "iceberg",
+        "--artifacts-path",
+        "/app/demo/customer_360/compiled_artifacts.json",
         "customer-count",
     ]
     assert config.lifetime_value_command == [
@@ -437,6 +449,10 @@ def test_customer360_validation_manifest_configures_default_evidence_commands() 
         "--",
         "python",
         "/app/demo/customer_360/scripts/customer360_metric.py",
+        "--source",
+        "iceberg",
+        "--artifacts-path",
+        "/app/demo/customer_360/compiled_artifacts.json",
         "total-lifetime-value",
     ]
 
@@ -708,6 +724,98 @@ def test_customer360_metric_script_queries_duckdb_metrics(tmp_path: Path) -> Non
 
     assert count_result.stdout.strip() == "2"
     assert lifetime_value_result.stdout.strip() == "15.75"
+
+
+@pytest.mark.requirement("alpha-demo")
+def test_customer360_metric_script_queries_iceberg_metrics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Customer 360 validation can query business metrics from persisted Iceberg outputs."""
+    script = Path("demo/customer-360/scripts/customer360_metric.py")
+    spec = importlib.util.spec_from_file_location("customer360_metric", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    artifacts_path = tmp_path / "compiled_artifacts.json"
+    artifacts_path.write_text("{}", encoding="utf-8")
+
+    class FakeScan:
+        def __init__(self, selected_fields: Sequence[str]) -> None:
+            self.selected_fields = tuple(selected_fields)
+
+        def to_arrow(self) -> object:
+            import pyarrow as pa
+
+            assert self.selected_fields in {("customer_id",), ("total_spend",)}
+            return pa.table({"customer_id": [1, 2], "total_spend": [10.50, 5.25]})
+
+    class FakeTable:
+        def scan(self, *, selected_fields: Sequence[str]) -> FakeScan:
+            return FakeScan(selected_fields)
+
+    class FakeCatalog:
+        def __init__(self) -> None:
+            self.loaded: list[str] = []
+
+        def load_table(self, identifier: str) -> FakeTable:
+            self.loaded.append(identifier)
+            return FakeTable()
+
+    fake_catalog = FakeCatalog()
+    monkeypatch.setattr(
+        module,
+        "CompiledArtifacts",
+        SimpleNamespace(model_validate_json=lambda _content: object()),
+    )
+    monkeypatch.setattr(module, "expected_iceberg_tables", lambda _artifacts, tables: tables)
+    monkeypatch.setattr(module, "_connect_catalog_from_artifacts", lambda _artifacts: fake_catalog)
+
+    count = module.query_metric(
+        source="iceberg",
+        artifacts_path=artifacts_path,
+        database="unused.duckdb",
+        table="mart_customer_360",
+        metric="customer-count",
+        lifetime_value_column="total_spend",
+    )
+    lifetime_value = module.query_metric(
+        source="iceberg",
+        artifacts_path=artifacts_path,
+        database="unused.duckdb",
+        table="mart_customer_360",
+        metric="total-lifetime-value",
+        lifetime_value_column="total_spend",
+    )
+
+    assert count == 2
+    assert lifetime_value == 15.75
+    assert fake_catalog.loaded == ["mart_customer_360", "mart_customer_360"]
+
+
+@pytest.mark.requirement("alpha-demo")
+def test_customer360_metric_cli_keeps_stdout_numeric(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metric CLI should keep diagnostic logs off stdout so validators can parse it."""
+    script = Path("demo/customer-360/scripts/customer360_metric.py")
+    spec = importlib.util.spec_from_file_location("customer360_metric_clean_stdout", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def noisy_query_metric(**_kwargs: object) -> int:
+        print("diagnostic noise")
+        return 500
+
+    monkeypatch.setattr(module, "query_metric", noisy_query_metric)
+
+    assert module.main(["customer-count"]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "500\n"
+    assert "diagnostic noise" in captured.err
 
 
 @pytest.mark.requirement("alpha-demo")

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -58,6 +58,7 @@ DEMO_PRODUCTS: dict[str, str] = {
 }
 
 # Helm values files for AC-11.3 / AC-11.5
+VALUES_BASE = REPO_ROOT / "charts" / "floe-platform" / "values.yaml"
 VALUES_TEST = REPO_ROOT / "charts" / "floe-platform" / "values-test.yaml"
 VALUES_DEMO = REPO_ROOT / "charts" / "floe-platform" / "values-demo.yaml"
 
@@ -1776,6 +1777,223 @@ class TestHelmValuesImageOverride:
         assert daemon_tag == EXPECTED_IMAGE_TAG, (
             f"dagster.dagsterDaemon.image.tag must be '{EXPECTED_IMAGE_TAG}' "
             f"in values-demo.yaml. Got: {daemon_tag!r}"
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_dagster_memory_matches_e2e_profile(self) -> None:
+        """Verify demo Dagster resources can load all Customer 360 code locations.
+
+        The demo profile loads all three demo products in-process. Keep the
+        webserver and daemon memory aligned with the validated E2E profile so
+        `make demo` does not diverge from `make devpod-test` and OOM at startup.
+        """
+        values_demo = _load_values_yaml(VALUES_DEMO)
+        values_test = _load_values_yaml(VALUES_TEST)
+
+        for component in ("dagsterWebserver", "dagsterDaemon"):
+            demo_resources = values_demo.get("dagster", {}).get(component, {}).get("resources", {})
+            test_resources = values_test.get("dagster", {}).get(component, {}).get("resources", {})
+            assert demo_resources.get("requests", {}).get("memory") == test_resources.get(
+                "requests", {}
+            ).get("memory"), (
+                f"values-demo.yaml dagster.{component}.resources.requests.memory must match "
+                "the E2E profile used by values-test.yaml."
+            )
+            assert demo_resources.get("limits", {}).get("memory") == test_resources.get(
+                "limits", {}
+            ).get("memory"), (
+                f"values-demo.yaml dagster.{component}.resources.limits.memory must match "
+                "the E2E profile used by values-test.yaml."
+            )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_run_launcher_keeps_base_memory_limit(self) -> None:
+        """Verify demo run pods keep the base memory budget used by E2E.
+
+        Customer 360 run pods execute dbt and Iceberg export. Demo overrides
+        should not lower the base run launcher memory limit that E2E relies on.
+        """
+        values_demo = _load_values_yaml(VALUES_DEMO)
+        values_base = _load_values_yaml(VALUES_BASE)
+
+        demo_limit = (
+            values_demo.get("dagster", {})
+            .get("runLauncher", {})
+            .get("config", {})
+            .get("k8sRunLauncher", {})
+            .get("resources", {})
+            .get("limits", {})
+            .get("memory")
+        )
+        base_limit = (
+            values_base.get("dagster", {})
+            .get("runLauncher", {})
+            .get("config", {})
+            .get("k8sRunLauncher", {})
+            .get("resources", {})
+            .get("limits", {})
+            .get("memory")
+        )
+        assert demo_limit == base_limit, (
+            "values-demo.yaml dagster.runLauncher.config.k8sRunLauncher.resources."
+            "limits.memory must match the base chart memory budget."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_webserver_uses_non_privileged_port(self) -> None:
+        """Verify demo Dagster webserver does not bind privileged port 80.
+
+        Demo pods run as non-root under the restricted security context. Keep
+        the webserver service and readiness port aligned with the E2E profile
+        and Makefile port-forward contract.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        webserver = values.get("dagster", {}).get("dagsterWebserver", {})
+
+        assert webserver.get("service", {}).get("port") == 3000, (
+            "values-demo.yaml dagster.dagsterWebserver.service.port must be 3000 "
+            "because the container runs as non-root and make demo forwards 3100:3000."
+        )
+        readiness = webserver.get("readinessProbe", {}).get("httpGet", {})
+        assert readiness.get("port") == 3000, (
+            "values-demo.yaml dagster.dagsterWebserver.readinessProbe.httpGet.port "
+            "must match dagster.dagsterWebserver.service.port."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_run_pods_allow_dbt_target_writes(self) -> None:
+        """Verify demo run pods can write dbt target artifacts.
+
+        dbt writes partial-parse and run artifacts under the product target
+        directory. Keep demo run-pod security aligned with the validated E2E
+        profile so Customer 360 materialization can execute.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        launcher = (
+            values.get("dagster", {})
+            .get("runLauncher", {})
+            .get("config", {})
+            .get("k8sRunLauncher", {})
+        )
+        security_context = (
+            launcher.get("runK8sConfig", {}).get("containerConfig", {}).get("securityContext", {})
+        )
+        assert security_context.get("readOnlyRootFilesystem") is False, (
+            "values-demo.yaml runLauncher runK8sConfig.containerConfig.securityContext."
+            "readOnlyRootFilesystem must be false because dbt writes target artifacts "
+            "during Customer 360 runs."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_polaris_matches_e2e_catalog_contract(self) -> None:
+        """Verify demo Polaris config matches the E2E catalog contract.
+
+        Customer 360 alpha validation should exercise the same catalog version
+        and bootstrap grants as the E2E profile, not a separate unvalidated
+        Polaris permission model.
+        """
+        values_demo = _load_values_yaml(VALUES_DEMO)
+        values_test = _load_values_yaml(VALUES_TEST)
+
+        demo_polaris = values_demo.get("polaris", {})
+        test_polaris = values_test.get("polaris", {})
+        assert demo_polaris.get("image", {}).get("tag") == test_polaris.get("image", {}).get(
+            "tag"
+        ), "values-demo.yaml Polaris image tag must match the validated E2E profile."
+        assert demo_polaris.get("bootstrap", {}).get("grants") == test_polaris.get(
+            "bootstrap", {}
+        ).get("grants"), (
+            "values-demo.yaml Polaris bootstrap grants must match values-test.yaml so "
+            "Customer 360 Iceberg writes use the validated catalog role contract."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_minio_credentials_match_polaris_storage(self) -> None:
+        """Verify demo MinIO credentials match the Polaris S3 storage config.
+
+        `make demo` layers values-dev before values-demo. The demo file must
+        override MinIO auth explicitly so Polaris does not sign S3 requests with
+        credentials that differ from the deployed MinIO root credentials.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        polaris_s3 = values.get("polaris", {}).get("storage", {}).get("s3", {})
+        minio_auth = values.get("minio", {}).get("auth", {})
+
+        assert minio_auth.get("rootUser") == polaris_s3.get("accessKey"), (
+            "values-demo.yaml minio.auth.rootUser must match polaris.storage.s3.accessKey."
+        )
+        assert minio_auth.get("rootPassword") == polaris_s3.get("secretKey"), (
+            "values-demo.yaml minio.auth.rootPassword must match polaris.storage.s3.secretKey."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_minio_provisions_polaris_warehouse_bucket(self) -> None:
+        """Verify demo installs create the warehouse bucket used by Polaris.
+
+        The chart overrides the Bitnami subchart image to upstream minio/minio,
+        which does not honor the Bitnami defaultBuckets bootstrap path. Demo
+        must use the chart-owned fallback hook so the bucket derived from
+        polaris.bootstrap.defaultBaseLocation exists before Iceberg writes.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        minio = values.get("minio", {})
+        default_base_location = (
+            values.get("polaris", {}).get("bootstrap", {}).get("defaultBaseLocation")
+        )
+        assert isinstance(default_base_location, str)
+        warehouse_bucket = default_base_location.removeprefix("s3://").split("/", maxsplit=1)[0]
+
+        assert minio.get("provisioning", {}).get("fallbackJob") is True, (
+            "values-demo.yaml must enable minio.provisioning.fallbackJob because "
+            "the upstream minio/minio image does not create defaultBuckets itself."
+        )
+        assert warehouse_bucket in str(minio.get("defaultBuckets", "")).split(","), (
+            "values-demo.yaml minio.defaultBuckets must include the bucket from "
+            "polaris.bootstrap.defaultBaseLocation."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_daemon_env_uses_subchart_list_shape(self) -> None:
+        """Verify demo daemon env uses the Dagster subchart's list contract.
+
+        The upstream Dagster chart supports both list and map env shapes, but
+        mixing base list values with demo map overrides triggers Helm coalesce
+        warnings and can silently drop expected env values.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        daemon_env = values.get("dagster", {}).get("dagsterDaemon", {}).get("env")
+
+        assert isinstance(daemon_env, list), (
+            "values-demo.yaml dagster.dagsterDaemon.env must use a list of "
+            "{name, value} entries to match the base chart and Dagster subchart."
+        )
+        assert {"name": "DAGSTER_DEFAULT_SCHEDULE_CRON", "value": "*/10 * * * *"} in daemon_env
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_values_demo_restores_jaeger_trace_export_after_dev_overlay(self) -> None:
+        """Verify demo OTel traces are exported to Jaeger, not only debug logs.
+
+        `make demo` layers values-dev before values-demo. The dev profile keeps
+        the collector debug-only, so the demo profile must restore the Jaeger
+        OTLP exporter to make visual trace validation possible.
+        """
+        values = _load_values_yaml(VALUES_DEMO)
+        otel_config = values.get("otel", {}).get("config", {})
+        exporters = otel_config.get("exporters", {})
+        trace_exporters = (
+            otel_config.get("service", {})
+            .get("pipelines", {})
+            .get("traces", {})
+            .get("exporters", [])
+        )
+
+        assert "otlp/jaeger" in exporters, (
+            "values-demo.yaml must restore the otlp/jaeger exporter after "
+            "values-dev.yaml overrides the collector config."
+        )
+        assert "otlp/jaeger" in trace_exporters, (
+            "values-demo.yaml traces pipeline must export to Jaeger so "
+            "Customer 360 traces are visible in the demo."
         )
 
 

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1347,6 +1347,7 @@ class TestDemoPluginResolver:
             [sys.executable, str(DEMO_PLUGIN_RESOLVER), "--manifest", str(DEMO_MANIFEST)],
             check=True,
             capture_output=True,
+            shell=False,
             text=True,
         )
 
@@ -1376,6 +1377,7 @@ class TestDemoPluginResolver:
             [sys.executable, str(DEMO_PLUGIN_RESOLVER), "--manifest", str(manifest_path)],
             check=True,
             capture_output=True,
+            shell=False,
             text=True,
         )
 

--- a/testing/tests/unit/test_helm_ci_diagnostics.py
+++ b/testing/tests/unit/test_helm_ci_diagnostics.py
@@ -88,3 +88,20 @@ def test_helm_ci_has_integration_test_job() -> None:
         job for job in jobs.values() if "Integration Test" in str(job.get("name", ""))
     ]
     assert integration_jobs, "helm-ci.yaml must keep the Kind integration test job"
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
+def test_helm_ci_render_preview_does_not_pipe_find_into_head() -> None:
+    """Rendered YAML preview must not fail successful jobs with broken pipes."""
+    workflow_text = WORKFLOW.read_text()
+    validate_section = workflow_text.split("- name: Validate rendered YAML", maxsplit=1)[1]
+    validate_section = validate_section.split(
+        "# ============================================================",
+        maxsplit=1,
+    )[0]
+
+    assert "preview_rendered_yaml()" in validate_section
+    assert "mapfile -t files" in validate_section
+    assert "find /tmp/rendered-platform-${ENVIRONMENT}" not in validate_section
+    assert "find /tmp/rendered-jobs-${ENVIRONMENT}" not in validate_section
+    assert "| head" not in validate_section

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,15 @@ toml = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577 },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.35"
 source = { registry = "https://pypi.org/simple" }
@@ -468,6 +477,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141 },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247 },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -875,6 +902,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041 },
+]
+
+[[package]]
 name = "daff"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,6 +1284,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/5f/c52bd1255db763d0cdcb7084d2e90c42119cb229302c56bdf1d0aa78abd2/deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4", size = 91979 },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604 },
 ]
 
 [[package]]
@@ -2101,6 +2153,7 @@ dependencies = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mypy" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2167,6 +2220,7 @@ requires-dist = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
     { name = "mypy", specifier = ">=1.8" },
+    { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pre-commit", specifier = ">=3.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -3094,6 +3148,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173 },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668 },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550 },
+]
+
+[[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615 },
 ]
 
 [[package]]
@@ -4163,6 +4229,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776 },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4345,6 +4420,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/b0/a36c468d2d0dec62ddea7c5e4177e93abb12f48ac90f09f24d0581c5189f/pendulum-3.2.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5cd956d4176afc7bfe8a91bf3f771b46ff8d326f6c5bf778eb5010eb742ebba6", size = 561884 },
     { url = "https://files.pythonhosted.org/packages/c5/4d/dad105261898907bf806cabca53d3878529a9fa2c0d5d7f95f2035246fc2/pendulum-3.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:39ef129d7b90aab49708645867abdd207b714ba7bff12dae549975b0aca09716", size = 261236 },
     { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111 },
+]
+
+[[package]]
+name = "pip"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804 },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369 },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518 },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648 },
 ]
 
 [[package]]
@@ -4594,6 +4724,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737 },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643 },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913 },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045 },
 ]
 
 [[package]]
@@ -6049,6 +6191,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -6364,6 +6515,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504 },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561 },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Harden the Customer 360 alpha release lane and close the final-mart lineage gap found during DevPod + Hetzner validation.

- Align demo Helm values with the validated Customer 360 platform runtime: Dagster storage wiring, run pod security context, demo memory, Polaris/MinIO compatibility, and OTel Jaeger exporter preservation.
- Make Customer 360 validation prove business outcomes from persisted Iceberg outputs and require final `mart_customer_360` Marquez lineage.
- Fix #275 by separating normal OpenLineage emit timeout from longer queue drain/close timeout, configured through the manifest-driven Marquez lineage backend.
- Add regression coverage for demo packaging, runtime telemetry env propagation, lineage drain timeout propagation, and the stricter Customer 360 validator gate.
- Update alpha release evidence docs with the current DevPod + Hetzner validation state and remaining release posture.

Fixes #275.

## Validation

Local:

- `uv run pytest testing/tests/unit/test_customer360_validator.py -q` -> 32 passed
- `uv run pytest testing/tests/unit/test_demo_packaging.py::TestHelmValuesImageOverride -q` -> 20 passed
- `uv run pytest plugins/floe-orchestrator-dagster/tests/unit/test_lineage_resource.py -q` -> 84 passed
- `uv run pytest plugins/floe-lineage-marquez/tests/unit/test_plugin.py -q` -> 33 passed
- `uv run pytest packages/floe-core/tests/unit/compilation/test_stages.py::TestObservabilityFromManifest::test_compile_pipeline_resolves_demo_lineage_backend -q` -> 1 passed
- `uv run ruff check ...` -> passed
- `make docs-validate` -> passed; existing MkDocs Material warning and known absolute-link info only
- `make helm-test-unit` -> 17 suites, 176 tests passed
- Pre-push hooks -> passed: lint, format, mypy, dbt version requirements, Bandit, vulnerability audit, full unit coverage, contract tests, hardcoded sleep check, traceability, Helm lint

DevPod + Hetzner:

- Rebuilt `floe-dagster-demo:validation-fix` in DevPod.
- Redeployed `floe-platform` in `floe-dev`; all platform pods running.
- Triggered Customer 360 Dagster run `a8b931f3-08f4-4222-9ddb-c3abfe0eb98e`; result `SUCCESS`.
- Verified Marquez contains `model.customer_360.mart_customer_360` in both `/api/v1/events/lineage` and `/api/v1/namespaces/customer-360/jobs`.
- Verified run pod logs show final mart materialization, Iceberg export, and 13 successful Marquez lineage POSTs with no `lineage_emit_timeout` or pending-task destruction.
- `uv run python -m testing.ci.validate_customer_360_demo` in DevPod -> `status=PASS`, including `evidence.lineage.marquez_customer_360=true` with `lineage_expected_text: mart_customer_360`.

## Release Posture

This PR is still pre-tag hardening evidence, not tag evidence. After merge, rerun CI and the DevPod + Hetzner release validation lane against the merged commit before tagging `v0.1.0-alpha.1`.
