### PR TITLE
Upgrade Claude checkout pins to Node 24

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -126,6 +126,21 @@ gh workflow run weekly.yml
 
 ---
 
+## Claude Workflows
+
+The Claude workflows (`claude.yml` and `claude-code-review.yml`) use the same
+Node 24-compatible pinned checkout action as the rest of CI:
+`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`).
+
+Anthropic app-token exchange validates that the workflow file exists on the
+default branch and can fail while a PR is actively changing the Claude workflow
+definition. Treat that as a workflow-identity rollout constraint, not evidence
+that the checkout pin itself is invalid. Merge only after the normal required CI
+checks are green; the Claude workflow identity is restored once the changed
+workflow is on `main`.
+
+---
+
 ## Local Development
 
 ### Install Git Hooks

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/testing/ci/tests/test_github_actions_node24_pins.py
+++ b/testing/ci/tests/test_github_actions_node24_pins.py
@@ -23,12 +23,6 @@ NODE24_ACTION_PINS = {
     "helm/kind-action": "ef37e7f390d99f746eb8b610417061a60e82a6cc",  # pragma: allowlist secret
 }
 
-ANTHROPIC_OIDC_WORKFLOWS = {
-    WORKFLOWS_DIR / "claude-code-review.yml",
-    WORKFLOWS_DIR / "claude.yml",
-}
-ANTHROPIC_OIDC_ROLLOUT_ISSUE = "https://github.com/Obsidian-Owl/floe/issues/274"
-
 USES_RE = re.compile(r"^\s*uses:\s*(?P<action>[^@\s#]+)@(?P<ref>[^\s#]+)")
 
 
@@ -60,8 +54,6 @@ def test_no_known_old_node20_action_pins_remain() -> None:
     old_refs = set(OLD_ACTION_PINS.values())
 
     for workflow, line_number, action, ref in _uses_entries():
-        if workflow in ANTHROPIC_OIDC_WORKFLOWS:
-            continue
         if ref in old_refs:
             stale_pins.append(f"{workflow}:{line_number}: {action}@{ref}")
 
@@ -74,8 +66,6 @@ def test_known_actions_use_exact_node24_compatible_pins() -> None:
     invalid_refs = []
 
     for workflow, line_number, action, ref in _uses_entries():
-        if workflow in ANTHROPIC_OIDC_WORKFLOWS:
-            continue
         expected_ref = NODE24_ACTION_PINS.get(action)
         if expected_ref is not None and ref != expected_ref:
             invalid_refs.append(
@@ -95,13 +85,3 @@ def test_setup_helm_action_owner_uses_canonical_case() -> None:
             lowercase_setup_helm.append(f"{workflow}:{line_number}: {action}@{ref}")
 
     assert lowercase_setup_helm == []
-
-
-@pytest.mark.requirement("github-actions-node24")
-def test_anthropic_oidc_workflows_keep_default_branch_identity() -> None:
-    """Claude workflows keep default-branch content until their OIDC rollout is tracked."""
-    assert ANTHROPIC_OIDC_ROLLOUT_ISSUE.endswith("/274")
-    for workflow in ANTHROPIC_OIDC_WORKFLOWS:
-        workflow_text = workflow.read_text(encoding="utf-8")
-        assert "anthropics/claude-code-action" in workflow_text
-        assert f"actions/checkout@{OLD_ACTION_PINS['actions/checkout']}" in workflow_text


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` in `claude.yml` and `claude-code-review.yml` from the old v4 SHA to the existing repo-wide v6.0.2 SHA.
- Remove the temporary static-test exception for Anthropic OIDC workflows so all workflows are covered by the Node 24 action pin guard.
- Document the rollout decision in `.github/CI.md`: Anthropic app-token exchange can fail while a PR changes the Claude workflow file because workflow identity is validated against the default branch; normal required CI remains the merge gate and identity is restored after the workflow lands on `main`.

Closes #274.

## Validation
- `uv run pytest testing/ci/tests/test_github_actions_node24_pins.py -q`
- `uv run ruff check testing/ci/tests/test_github_actions_node24_pins.py`
- `uv run ruff format --check testing/ci/tests/test_github_actions_node24_pins.py`
- `uv run mypy --strict testing/ci/tests/test_github_actions_node24_pins.py`
- `pre-commit run check-yaml --files .github/workflows/claude-code-review.yml .github/workflows/claude.yml`
- full local pre-push suite

## External validation
- GitHub changelog: Node 24 becomes the default JavaScript action runtime on 2026-06-02 and users should update workflows to action versions that run on Node 24.
- `actions/checkout` releases: v5 moved checkout to Node 24; v6.0.2 resolves to `de0fac2e4500dabe0009e67214ff5f5447ce83dd`.
- Anthropic/Claude Code action issue evidence: app-token exchange can reject workflow files that are not identical to default branch, matching the failure mode tracked in #274.

## Rollout note
The Claude check itself may be skipped or may report the known workflow-identity failure on this PR because this PR edits the Claude workflow files. Treat required CI as authoritative for this migration; the Claude workflow identity becomes default-branch-identical after merge.