### PR TITLE
ci: deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   docs:
     name: Build docs
@@ -63,3 +67,24 @@ jobs:
         run: uv run python testing/ci/validate-docs-content.py
       - name: Validate Starlight docs site
         run: npm --prefix docs-site run validate
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs-site/dist
+
+  deploy-pages:
+    name: Deploy docs to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -108,6 +108,12 @@ cat > "$HOOKS_DIR/pre-push" << 'HOOK'
 # Installed by: scripts/setup-hooks.sh
 # Re-run 'make setup-hooks' to regenerate
 
+# Git hooks run with repository-local GIT_* variables exported. Clear them
+# before invoking test subprocesses that create their own temporary repos.
+for git_env_var in $(git rev-parse --local-env-vars); do
+    unset "$git_env_var"
+done
+
 if command -v uv >/dev/null 2>&1; then
     exec uv run --no-sync pre-commit run --hook-stage pre-push --all-files
 elif command -v pre-commit >/dev/null 2>&1; then

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -111,7 +111,14 @@ cat > "$HOOKS_DIR/pre-push" << 'HOOK'
 # Git hooks run with repository-local GIT_* variables exported. Clear them
 # before invoking test subprocesses that create their own temporary repos.
 for git_env_var in $(git rev-parse --local-env-vars); do
-    unset "$git_env_var"
+    case "$git_env_var" in
+        GIT_*[!ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]*)
+            continue
+            ;;
+        GIT_*)
+            unset "$git_env_var"
+            ;;
+    esac
 done
 
 if command -v uv >/dev/null 2>&1; then

--- a/testing/ci/tests/test_docs_github_pages_workflow.py
+++ b/testing/ci/tests/test_docs_github_pages_workflow.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+
+UPLOAD_PAGES_ARTIFACT_USES = (
+    "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9"
+)
+DEPLOY_PAGES_USES = "actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128"
+
+
+def _load_docs_workflow() -> dict[object, Any]:
+    workflow = yaml.safe_load(DOCS_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return cast(dict[object, Any], workflow)
+
+
+def _workflow_triggers(workflow: dict[object, Any]) -> dict[str, Any]:
+    triggers = workflow.get("on")
+    if triggers is None and True in workflow:
+        triggers = workflow[True]
+    assert isinstance(triggers, dict)
+    return cast(dict[str, Any], triggers)
+
+
+def _job(workflow: dict[object, Any], name: str) -> dict[str, Any]:
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+    assert name in jobs, f"Expected docs workflow job {name!r}; found {list(jobs)}"
+    return cast(dict[str, Any], jobs[name])
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    return cast(list[dict[str, Any]], steps)
+
+
+@pytest.mark.requirement("alpha-docs")
+def test_docs_workflow_has_pages_permissions_without_broad_token_scope() -> None:
+    """Docs deployment uses the minimum GitHub Pages token permissions."""
+    workflow = _load_docs_workflow()
+
+    assert workflow.get("permissions") == {"contents": "read"}
+
+    deploy_job = _job(workflow, "deploy-pages")
+    assert deploy_job.get("permissions") == {
+        "pages": "write",
+        "id-token": "write",
+    }
+
+
+@pytest.mark.requirement("alpha-docs")
+def test_docs_workflow_uploads_built_starlight_site_on_main_pushes() -> None:
+    """The docs build uploads the generated Starlight dist directory for Pages."""
+    workflow = _load_docs_workflow()
+    docs_job = _job(workflow, "docs")
+    steps = _steps(docs_job)
+
+    assert docs_job.get("if") is None
+    assert any(step.get("run") == "npm --prefix docs-site run validate" for step in steps)
+
+    upload_steps = [step for step in steps if step.get("uses") == UPLOAD_PAGES_ARTIFACT_USES]
+    assert len(upload_steps) == 1
+    assert upload_steps[0].get("if") == "github.event_name == 'push'"
+    assert upload_steps[0].get("with") == {"path": "docs-site/dist"}
+
+
+@pytest.mark.requirement("alpha-docs")
+def test_docs_workflow_deploys_pages_only_after_main_docs_build() -> None:
+    """GitHub Pages deploys from the validated docs artifact, never from PRs."""
+    workflow = _load_docs_workflow()
+    triggers = _workflow_triggers(workflow)
+    deploy_job = _job(workflow, "deploy-pages")
+    steps = _steps(deploy_job)
+
+    assert triggers.get("pull_request") is not None
+    assert triggers.get("push", {}).get("branches") == ["main"]
+    assert deploy_job.get("needs") == "docs"
+    assert deploy_job.get("if") == "github.event_name == 'push' && github.ref == 'refs/heads/main'"
+    assert deploy_job.get("environment") == {
+        "name": "github-pages",
+        "url": "${{ steps.deployment.outputs.page_url }}",
+    }
+    assert any(
+        step.get("id") == "deployment" and step.get("uses") == DEPLOY_PAGES_USES for step in steps
+    )

--- a/testing/ci/tests/test_github_actions_node24_pins.py
+++ b/testing/ci/tests/test_github_actions_node24_pins.py
@@ -17,8 +17,12 @@ OLD_ACTION_PINS = {
 
 NODE24_ACTION_PINS = {
     "actions/checkout": "de0fac2e4500dabe0009e67214ff5f5447ce83dd",  # pragma: allowlist secret
+    "actions/deploy-pages": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",  # pragma: allowlist secret
     "actions/setup-node": "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",  # pragma: allowlist secret
     "actions/setup-python": "a309ff8b426b58ec0e2a45f0f869d46889d02405",  # pragma: allowlist secret
+    "actions/upload-pages-artifact": (
+        "fc324d3547104276b827a68afc52ff2a11cc49c9"  # pragma: allowlist secret
+    ),
     "astral-sh/setup-uv": "08807647e7069bb48b6ef5acd8ec9567f424441b",  # pragma: allowlist secret
     "Azure/setup-helm": "dda3372f752e03dde6b3237bc9431cdc2f7a02a2",  # pragma: allowlist secret
     "helm/kind-action": "ef37e7f390d99f746eb8b610417061a60e82a6cc",  # pragma: allowlist secret

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -325,6 +325,20 @@ class TestLocalHookAlignment:
         assert "git config --local core.hooksPath" in setup_text
         assert "git config --global --get core.hooksPath" in setup_text
 
+    @pytest.mark.requirement("VAL-HOOKS")
+    def test_pre_push_unsets_git_hook_environment_before_running_pytest(self) -> None:
+        """Local pre-push must not leak hook-local Git env into test subprocesses."""
+        setup_text = SETUP_HOOKS.read_text()
+        pre_push_template = setup_text.split("cat > \"$HOOKS_DIR/pre-push\" << 'HOOK'", maxsplit=1)[
+            1
+        ].split("HOOK", maxsplit=1)[0]
+
+        assert "git rev-parse --local-env-vars" in pre_push_template
+        assert 'unset "$git_env_var"' in pre_push_template
+        assert pre_push_template.index('unset "$git_env_var"') < pre_push_template.index(
+            "pre-commit run --hook-stage pre-push",
+        )
+
 
 class TestCubeStoreRollbackPath:
     """Verify Cube Store E2E tests exist and rollback path is documented."""

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -334,7 +334,12 @@ class TestLocalHookAlignment:
         ].split("HOOK", maxsplit=1)[0]
 
         assert "git rev-parse --local-env-vars" in pre_push_template
+        assert 'case "$git_env_var" in' in pre_push_template
+        assert "GIT_*[!ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_]*" in pre_push_template
         assert 'unset "$git_env_var"' in pre_push_template
+        assert pre_push_template.index('case "$git_env_var" in') < pre_push_template.index(
+            'unset "$git_env_var"',
+        )
         assert pre_push_template.index('unset "$git_env_var"') < pre_push_template.index(
             "pre-commit run --hook-stage pre-push",
         )


### PR DESCRIPTION
## Summary
- enable the docs workflow to upload the built Starlight site and deploy it through GitHub Pages on merged main pushes
- keep pull-request docs runs validation-only while restricting Pages/OIDC write permissions to the deploy job
- add regression coverage for the Pages workflow shape and for Node 24-compatible pinned Pages actions
- fix generated pre-push hooks to clear Git hook-local environment variables before running test subprocesses that create temporary Git repositories

## Repository Pages state
- GitHub Pages is enabled for this repo with workflow deployments
- Target URL: https://obsidian-owl.github.io/floe/

## Validation
- RED: uv run pytest testing/ci/tests/test_docs_github_pages_workflow.py -q failed before the workflow had a deploy job/artifact upload
- PASS: uv run pytest testing/ci/tests/test_docs_github_pages_workflow.py testing/ci/tests/test_docs_site_config.py testing/ci/tests/test_github_actions_node24_pins.py -q
- PASS: make docs-validate
- PASS: uv run pytest testing/tests/unit/test_ci_workflows.py::TestLocalHookAlignment testing/ci/tests/test_docs_github_pages_workflow.py testing/ci/tests/test_docs_site_config.py testing/ci/tests/test_github_actions_node24_pins.py tests/unit/test_devpod_source_selection.py::test_source_helper_accepts_tag_refs tests/unit/test_devpod_source_selection.py::test_source_helper_rejects_tail_pattern_ref_matches tests/unit/test_specwright_integration_wrapper.py::test_dispatcher_uses_reachable_branch_history_without_main_refs -q
- PASS: git push pre-push hooks: ruff, format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, no hardcoded sleep, requirement traceability, helm lint