### PR TITLE
Fix Polaris bootstrap grants values schema

### DIFF
--- a/charts/floe-platform/values.schema.json
+++ b/charts/floe-platform/values.schema.json
@@ -373,21 +373,18 @@
                 "catalogRole": {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64,
                   "pattern": "^[a-zA-Z0-9_-]+$",
                   "description": "Catalog role name to create and grant privileges to"
                 },
                 "principalRole": {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64,
                   "pattern": "^[a-zA-Z0-9_-]+$",
                   "description": "Principal role name to create and assign the catalog role to"
                 },
                 "bootstrapPrincipal": {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 64,
                   "pattern": "^[a-zA-Z0-9_-]+$",
                   "description": "Bootstrap principal receiving the principal role"
                 },

--- a/charts/floe-platform/values.schema.json
+++ b/charts/floe-platform/values.schema.json
@@ -361,6 +361,85 @@
             "allowedLocations": {
               "type": "array",
               "items": { "type": "string" }
+            },
+            "grants": {
+              "type": "object",
+              "description": "Polaris catalog role, principal role, and privilege grants created by the bootstrap Job",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "catalogRole": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64,
+                  "pattern": "^[a-zA-Z0-9_-]+$",
+                  "description": "Catalog role name to create and grant privileges to"
+                },
+                "principalRole": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64,
+                  "pattern": "^[a-zA-Z0-9_-]+$",
+                  "description": "Principal role name to create and assign the catalog role to"
+                },
+                "bootstrapPrincipal": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 64,
+                  "pattern": "^[a-zA-Z0-9_-]+$",
+                  "description": "Bootstrap principal receiving the principal role"
+                },
+                "privileges": {
+                  "type": "array",
+                  "description": "Apache Polaris 1.3.0 catalog-role privileges to grant",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "CATALOG_ATTACH_POLICY",
+                      "CATALOG_DETACH_POLICY",
+                      "CATALOG_MANAGE_ACCESS",
+                      "CATALOG_MANAGE_CONTENT",
+                      "CATALOG_MANAGE_METADATA",
+                      "CATALOG_READ_PROPERTIES",
+                      "CATALOG_WRITE_PROPERTIES",
+                      "NAMESPACE_ATTACH_POLICY",
+                      "NAMESPACE_CREATE",
+                      "NAMESPACE_DETACH_POLICY",
+                      "NAMESPACE_DROP",
+                      "NAMESPACE_FULL_METADATA",
+                      "NAMESPACE_LIST",
+                      "NAMESPACE_READ_PROPERTIES",
+                      "NAMESPACE_WRITE_PROPERTIES",
+                      "POLICY_ATTACH",
+                      "POLICY_CREATE",
+                      "POLICY_DETACH",
+                      "POLICY_DROP",
+                      "POLICY_FULL_METADATA",
+                      "POLICY_LIST",
+                      "POLICY_READ",
+                      "POLICY_WRITE",
+                      "TABLE_ATTACH_POLICY",
+                      "TABLE_CREATE",
+                      "TABLE_DETACH_POLICY",
+                      "TABLE_DROP",
+                      "TABLE_FULL_METADATA",
+                      "TABLE_LIST",
+                      "TABLE_READ_DATA",
+                      "TABLE_READ_PROPERTIES",
+                      "TABLE_WRITE_DATA",
+                      "TABLE_WRITE_PROPERTIES",
+                      "VIEW_CREATE",
+                      "VIEW_DROP",
+                      "VIEW_FULL_METADATA",
+                      "VIEW_LIST",
+                      "VIEW_READ_PROPERTIES",
+                      "VIEW_WRITE_PROPERTIES"
+                    ]
+                  }
+                }
+              }
             }
           }
         }

--- a/tests/integration/helm/test_schema_validation.py
+++ b/tests/integration/helm/test_schema_validation.py
@@ -686,6 +686,36 @@ class TestPolarisBootstrapGrantsSchema:
             "helm template produced output but it does not contain K8s manifests."
         )
 
+    @pytest.mark.requirement("AC-28.6")
+    @pytest.mark.usefixtures("helm_available", "update_helm_dependencies")
+    def test_valid_long_grants_identity_names_succeed(
+        self,
+        platform_chart_path: Path,
+    ) -> None:
+        """Helm template MUST not reject role names the bootstrap Job can render."""
+        long_role_name = "platform_data_engineering_catalog_admin_role_for_customer_360_alpha"
+        result = _helm_template(
+            platform_chart_path,
+            set_values=[
+                "polaris.bootstrap.enabled=true",
+                "polaris.auth.bootstrapCredentials.clientSecret=SCHEMA-TEST-SENTINEL",
+                "polaris.bootstrap.grants.enabled=true",
+                f"polaris.bootstrap.grants.catalogRole={long_role_name}",
+                f"polaris.bootstrap.grants.principalRole={long_role_name}",
+                f"polaris.bootstrap.grants.bootstrapPrincipal={long_role_name}",
+                "polaris.bootstrap.grants.privileges[0]=CATALOG_MANAGE_CONTENT",
+            ],
+        )
+
+        stderr = _stderr_text(result)
+
+        assert result.returncode == 0, (
+            "helm template FAILED with long but shell-safe Polaris grants identity "
+            "names. The schema should not add a stricter maxLength cap than the "
+            "bootstrap Job runtime validation.\n"
+            f"STDERR: {stderr[:1000]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # AC-28.4: Custom overlays not blocked (additionalProperties: true)

--- a/tests/integration/helm/test_schema_validation.py
+++ b/tests/integration/helm/test_schema_validation.py
@@ -37,6 +37,8 @@ SCHEMA_VALIDATION_FAILED = "validation failed"
 BOOTSTRAP_CLIENT_SECRET_FIELD = "clientSecret"
 S3_ENDPOINT_FIELD = "endpoint"
 ENVIRONMENT_FIELD = "environment"
+GRANTS_FIELD = "grants"
+PRIVILEGES_FIELD = "privileges"
 
 # The exact set of valid environment values per the schema enum.
 # Tests MUST verify ALL of these are accepted; a partial enum is a bug.
@@ -539,6 +541,149 @@ class TestS3EndpointRequired:
             "helm template FAILED when S3 is disabled. The endpoint "
             "constraint should only apply when S3 is enabled.\n"
             f"STDERR: {stderr[:1000]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-28.6: Polaris bootstrap grants schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestPolarisBootstrapGrantsSchema:
+    """Tests that polaris.bootstrap.grants is validated by values.schema.json.
+
+    AC-28.6: Polaris grant settings MUST be rejected by Helm schema validation
+    when booleans, role names, or privilege lists are malformed. This catches
+    operator mistakes before the bootstrap Job runs.
+    """
+
+    @pytest.mark.requirement("AC-28.6")
+    @pytest.mark.usefixtures("helm_available", "update_helm_dependencies")
+    def test_grants_enabled_string_rejected(
+        self,
+        platform_chart_path: Path,
+    ) -> None:
+        """Helm template MUST fail when grants.enabled is a string."""
+        result = _helm_template(
+            platform_chart_path,
+            set_values=[
+                "polaris.bootstrap.grants.enabled=not-a-bool",
+            ],
+        )
+
+        stderr = _stderr_text(result)
+
+        assert result.returncode != 0, (
+            "helm template should have FAILED when polaris.bootstrap.grants.enabled "
+            "is a string, but it succeeded. This means the schema does not enforce "
+            "the grants.enabled boolean contract.\n"
+            f"STDOUT (first 500 chars): {_stdout_text(result)[:500]}"
+        )
+
+        stderr_lower = stderr.lower()
+        assert SCHEMA_ERROR_INDICATOR in stderr_lower or SCHEMA_VALIDATION_FAILED in stderr_lower, (
+            f"helm template failed, but not due to schema validation.\nSTDERR: {stderr[:1000]}"
+        )
+        assert GRANTS_FIELD in stderr_lower or "boolean" in stderr_lower, (
+            "Schema validation failed, but the error does not reference the grants "
+            f"boolean constraint.\nSTDERR: {stderr[:1000]}"
+        )
+
+    @pytest.mark.requirement("AC-28.6")
+    @pytest.mark.usefixtures("helm_available", "update_helm_dependencies")
+    def test_grants_privileges_scalar_rejected(
+        self,
+        platform_chart_path: Path,
+    ) -> None:
+        """Helm template MUST fail when grants.privileges is not an array."""
+        result = _helm_template(
+            platform_chart_path,
+            set_values=[
+                "polaris.bootstrap.grants.privileges=CATALOG_MANAGE_CONTENT",
+            ],
+        )
+
+        stderr = _stderr_text(result)
+
+        assert result.returncode != 0, (
+            "helm template should have FAILED when polaris.bootstrap.grants.privileges "
+            "is a scalar string, but it succeeded. The schema must require a list "
+            "of privilege strings.\n"
+            f"STDOUT (first 500 chars): {_stdout_text(result)[:500]}"
+        )
+
+        stderr_lower = stderr.lower()
+        assert SCHEMA_ERROR_INDICATOR in stderr_lower or SCHEMA_VALIDATION_FAILED in stderr_lower, (
+            f"helm template failed, but not due to schema validation.\nSTDERR: {stderr[:1000]}"
+        )
+        assert PRIVILEGES_FIELD in stderr_lower or "array" in stderr_lower, (
+            "Schema validation failed, but the error does not reference the privileges "
+            f"array constraint.\nSTDERR: {stderr[:1000]}"
+        )
+
+    @pytest.mark.requirement("AC-28.6")
+    @pytest.mark.usefixtures("helm_available", "update_helm_dependencies")
+    def test_grants_invalid_privilege_rejected(
+        self,
+        platform_chart_path: Path,
+    ) -> None:
+        """Helm template MUST fail when a grants privilege is unsupported."""
+        result = _helm_template(
+            platform_chart_path,
+            set_values=[
+                "polaris.bootstrap.grants.privileges[0]=NOT_A_POLARIS_PRIVILEGE",
+            ],
+        )
+
+        stderr = _stderr_text(result)
+
+        assert result.returncode != 0, (
+            "helm template should have FAILED when polaris.bootstrap.grants.privileges "
+            "contains an unsupported privilege, but it succeeded. The schema must "
+            "restrict privileges to known Polaris privilege names.\n"
+            f"STDOUT (first 500 chars): {_stdout_text(result)[:500]}"
+        )
+
+        stderr_lower = stderr.lower()
+        assert SCHEMA_ERROR_INDICATOR in stderr_lower or SCHEMA_VALIDATION_FAILED in stderr_lower, (
+            f"helm template failed, but not due to schema validation.\nSTDERR: {stderr[:1000]}"
+        )
+        assert PRIVILEGES_FIELD in stderr_lower or "enum" in stderr_lower, (
+            "Schema validation failed, but the error does not reference the privileges "
+            f"enum constraint.\nSTDERR: {stderr[:1000]}"
+        )
+
+    @pytest.mark.requirement("AC-28.6")
+    @pytest.mark.usefixtures("helm_available", "update_helm_dependencies")
+    def test_valid_grants_configuration_succeeds(
+        self,
+        platform_chart_path: Path,
+    ) -> None:
+        """Helm template MUST succeed with valid bootstrap grant settings."""
+        result = _helm_template(
+            platform_chart_path,
+            set_values=[
+                "polaris.bootstrap.enabled=true",
+                "polaris.auth.bootstrapCredentials.clientSecret=SCHEMA-TEST-SENTINEL",
+                "polaris.bootstrap.grants.enabled=true",
+                "polaris.bootstrap.grants.catalogRole=catalog_admin",
+                "polaris.bootstrap.grants.principalRole=floe-pipeline",
+                "polaris.bootstrap.grants.bootstrapPrincipal=root",
+                "polaris.bootstrap.grants.privileges[0]=CATALOG_MANAGE_CONTENT",
+            ],
+        )
+
+        stderr = _stderr_text(result)
+
+        assert result.returncode == 0, (
+            "helm template FAILED with a valid Polaris bootstrap grants configuration. "
+            "The schema should allow this configuration.\n"
+            f"STDERR: {stderr[:1000]}"
+        )
+
+        stdout = _stdout_text(result)
+        assert "apiVersion:" in stdout or "kind:" in stdout, (
+            "helm template produced output but it does not contain K8s manifests."
         )
 
 

--- a/tests/integration/helm/test_values_schema.py
+++ b/tests/integration/helm/test_values_schema.py
@@ -175,6 +175,29 @@ class TestFloePlatformSchema:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(invalid_values, floe_platform_schema)
 
+    @pytest.mark.requirement("9b-FR-004")
+    def test_polaris_bootstrap_grants_identity_fields_do_not_add_length_cap(
+        self,
+        floe_platform_schema: dict[str, Any],
+    ) -> None:
+        """Test that schema does not add a stricter role-name cap than runtime validation."""
+        long_role_name = "platform_data_engineering_catalog_admin_role_for_customer_360_alpha"
+        values = {
+            "polaris": {
+                "bootstrap": {
+                    "grants": {
+                        "enabled": True,
+                        "catalogRole": long_role_name,
+                        "principalRole": long_role_name,
+                        "bootstrapPrincipal": long_role_name,
+                        "privileges": ["CATALOG_MANAGE_CONTENT"],
+                    },
+                },
+            },
+        }
+
+        jsonschema.validate(values, floe_platform_schema)
+
 
 @pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema not installed")
 class TestFloeJobsSchema:

--- a/tests/integration/helm/test_values_schema.py
+++ b/tests/integration/helm/test_values_schema.py
@@ -120,6 +120,61 @@ class TestFloePlatformSchema:
         for section in expected:
             assert section in properties, f"Missing schema section: {section}"
 
+    @pytest.mark.requirement("9b-FR-004")
+    def test_polaris_bootstrap_grants_schema_has_expected_fields(
+        self,
+        floe_platform_schema: dict[str, Any],
+    ) -> None:
+        """Test that Polaris bootstrap grants are covered by values.schema.json."""
+        grants_schema = floe_platform_schema["properties"]["polaris"]["properties"]["bootstrap"][
+            "properties"
+        ]["grants"]
+
+        properties = grants_schema.get("properties", {})
+        assert properties["enabled"]["type"] == "boolean"
+        assert properties["catalogRole"]["type"] == "string"
+        assert properties["principalRole"]["type"] == "string"
+        assert properties["bootstrapPrincipal"]["type"] == "string"
+        assert properties["privileges"]["type"] == "array"
+        assert properties["privileges"]["items"]["type"] == "string"
+        assert "enum" in properties["privileges"]["items"]
+
+    @pytest.mark.requirement("9b-FR-004")
+    def test_polaris_bootstrap_grants_enabled_must_be_boolean(
+        self,
+        floe_platform_schema: dict[str, Any],
+    ) -> None:
+        """Test that grants.enabled rejects string values."""
+        invalid_values = {
+            "polaris": {
+                "bootstrap": {
+                    "grants": {
+                        "enabled": "true",
+                    },
+                },
+            },
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(invalid_values, floe_platform_schema)
+
+    @pytest.mark.requirement("9b-FR-004")
+    def test_polaris_bootstrap_grants_privileges_must_be_valid_enum_values(
+        self,
+        floe_platform_schema: dict[str, Any],
+    ) -> None:
+        """Test that grants.privileges rejects unsupported Polaris privilege names."""
+        invalid_values = {
+            "polaris": {
+                "bootstrap": {
+                    "grants": {
+                        "privileges": ["NOT_A_POLARIS_PRIVILEGE"],
+                    },
+                },
+            },
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(invalid_values, floe_platform_schema)
+
 
 @pytest.mark.skipif(not HAS_JSONSCHEMA, reason="jsonschema not installed")
 class TestFloeJobsSchema:


### PR DESCRIPTION
## Summary
- Add `polaris.bootstrap.grants` to the floe-platform Helm `values.schema.json`.
- Validate grant booleans, role/principal names, and Apache Polaris 1.3.0 privilege enum values.
- Add static JSON Schema tests and Helm CLI schema tests for invalid and valid grants configuration.

Fixes #152.

## Validation
- `uv run pytest tests/integration/helm/test_values_schema.py -q`
- `uv run pytest tests/integration/helm/test_schema_validation.py -q`
- `uv run ruff check tests/integration/helm/test_values_schema.py tests/integration/helm/test_schema_validation.py`
- `uv run ruff format --check tests/integration/helm/test_values_schema.py tests/integration/helm/test_schema_validation.py`
- `make helm-lint`
- `helm lint charts/floe-platform --values charts/floe-platform/values-test.yaml`
- `helm lint charts/floe-platform --values charts/floe-platform/values-demo.yaml`
- `git diff --check`
- Pre-push hook suite passed on retry: ruff, mypy, dbt version requirements, bandit, uv-secure, full unit tests + coverage, contract tests, no-hardcoded-sleep, requirement traceability, helm lint.

Note: the first pre-push attempt hit a cold-start timing flake in `TestPluginSystem.test_plugin_health_checks` where the Great Expectations health check took 25s against a 10s budget. The exact test passed in isolation immediately after, and the full pre-push suite passed on retry.