### PR TITLE
docs: validate alpha docs and demo walkthrough

### DIFF
--- a/docs-site/scripts/check-source-docs.mjs
+++ b/docs-site/scripts/check-source-docs.mjs
@@ -280,6 +280,18 @@ export async function collectSourceDocsErrors({
     if (source === 'docs/data-engineers/first-data-product.md' && !/\bhello-orders\b/iu.test(markdown)) {
       errors.push(`${source}: first data product guide must teach hello-orders before Customer 360`);
     }
+    if (
+      source === 'docs/demo/customer-360.md' &&
+      !/Cube\b[^.\n]*(?:disabled by default|not part of the Customer 360 alpha gate)/iu.test(markdown)
+    ) {
+      errors.push(`${source}: must clarify Cube is not required for the Customer 360 alpha query proof`);
+    }
+    if (
+      source === 'docs/demo/customer-360-validation.md' &&
+      !/business\/query proof\b[^.\n]*command-based/iu.test(markdown)
+    ) {
+      errors.push(`${source}: must identify the command-based business/query proof`);
+    }
     for (const rule of disallowedSnippets) {
       if (rule.pattern.test(markdown)) {
         errors.push(`${source}: ${rule.message}`);

--- a/docs-site/scripts/check-source-docs.test.mjs
+++ b/docs-site/scripts/check-source-docs.test.mjs
@@ -114,7 +114,13 @@ test('collectSourceDocsErrors allows links to contributor DevPod docs outside co
     await fs.mkdir(path.join(repoRoot, 'docs/demo'), { recursive: true });
     await fs.writeFile(
       path.join(repoRoot, 'docs/demo/customer-360-validation.md'),
-      '# Validation\n\nSee [DevPod contributor workspace](../contributing/devpod-hetzner.md).\n',
+      [
+        '# Validation',
+        '',
+        'The current alpha business/query proof is command-based against the generated Iceberg mart.',
+        'See [DevPod contributor workspace](../contributing/devpod-hetzner.md).',
+        '',
+      ].join('\n'),
     );
 
     const { errors } = await collectSourceDocsErrors({ repoRoot, manifestPath });
@@ -543,5 +549,64 @@ test('collectSourceDocsErrors rejects broad advanced proof wording as negative c
     assert.deepEqual(errors, [
       "docs/data-engineers/first-data-product.md: presents unsupported root command 'floe compile' as current",
     ]);
+  });
+});
+
+test('collectSourceDocsErrors rejects ambiguous Customer 360 semantic query proof', async () => {
+  await withSourceDocsFixture(async ({ repoRoot, manifestPath }) => {
+    await fs.mkdir(path.join(repoRoot, 'docs/demo'), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, 'docs/demo/customer-360.md'),
+      [
+        '# Customer 360 Golden Demo',
+        '',
+        'You can access Dagster, Polaris, and the semantic/query layer.',
+        '',
+      ].join('\n'),
+    );
+    await fs.writeFile(
+      path.join(repoRoot, 'docs/demo/customer-360-validation.md'),
+      [
+        '# Customer 360 Validation',
+        '',
+        'Business evidence comes from querying Customer 360 metrics.',
+        '',
+      ].join('\n'),
+    );
+
+    const { errors } = await collectSourceDocsErrors({ repoRoot, manifestPath });
+
+    assert.deepEqual(errors, [
+      'docs/demo/customer-360-validation.md: must identify the command-based business/query proof',
+      'docs/demo/customer-360.md: must clarify Cube is not required for the Customer 360 alpha query proof',
+    ]);
+  });
+});
+
+test('collectSourceDocsErrors accepts explicit Customer 360 alpha query boundaries', async () => {
+  await withSourceDocsFixture(async ({ repoRoot, manifestPath }) => {
+    await fs.mkdir(path.join(repoRoot, 'docs/demo'), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, 'docs/demo/customer-360.md'),
+      [
+        '# Customer 360 Golden Demo',
+        '',
+        'Cube is charted but disabled by default and is not part of the Customer 360 alpha gate.',
+        '',
+      ].join('\n'),
+    );
+    await fs.writeFile(
+      path.join(repoRoot, 'docs/demo/customer-360-validation.md'),
+      [
+        '# Customer 360 Validation',
+        '',
+        'The current alpha business/query proof is command-based against the generated Iceberg mart.',
+        '',
+      ].join('\n'),
+    );
+
+    const { errors } = await collectSourceDocsErrors({ repoRoot, manifestPath });
+
+    assert.deepEqual(errors, []);
   });
 });

--- a/docs/demo/customer-360-validation.md
+++ b/docs/demo/customer-360-validation.md
@@ -12,6 +12,8 @@ make demo-customer-360-validate
 
 The command loads its default evidence plan from `demo/customer-360/validation.yaml`. The manifest defines service URLs, expected platform pods, and argv-list commands for Dagster, storage, Marquez, Jaeger, and business metric checks.
 
+The current alpha business/query proof is command-based against the generated Iceberg mart. Cube is charted but disabled by default and is not part of the Customer 360 alpha gate unless your platform enables it.
+
 Use `FLOE_DEMO_VALIDATION_MANIFEST=/path/to/validation.yaml` for a different platform shape. Individual command overrides are also available, for example `FLOE_DEMO_LINEAGE_CHECK_COMMAND`, `FLOE_DEMO_STORAGE_CHECK_COMMAND`, `FLOE_DEMO_CUSTOMER_COUNT_COMMAND`, and `FLOE_DEMO_LIFETIME_VALUE_COMMAND`.
 
 Expected evidence keys:

--- a/docs/demo/customer-360.md
+++ b/docs/demo/customer-360.md
@@ -10,7 +10,9 @@ Platform Engineers and Data Engineers should run Customer 360 against a Floe pla
 
 - A Floe platform is deployed and reachable.
 - The Customer 360 data product has been compiled or is available in the demo project.
-- You can access Dagster, object storage, Marquez, Jaeger, Polaris, and the semantic/query layer through your platform access method.
+- You can access Dagster, object storage, Marquez, Jaeger, Polaris, and the current alpha query surface through your platform access method.
+
+The current alpha query proof is the Customer 360 business metric check against generated Iceberg outputs. Cube is charted but disabled by default and is not part of the Customer 360 alpha gate unless your platform enables it.
 
 ## Run
 
@@ -61,6 +63,7 @@ These URLs match the current contributor `make demo` DevPod port-forwards. Produ
 | Marquez | http://localhost:5100 | Customer 360 lineage exists |
 | Jaeger | http://localhost:16686 | Customer 360 traces exist |
 | Polaris | http://localhost:8181 | Customer 360 tables are registered |
+| Business query surface | `make demo-customer-360-validate` | Customer count and total lifetime value checks pass |
 
 ## Business Outcome
 

--- a/docs/releases/v0.1.0-alpha.1-checklist.md
+++ b/docs/releases/v0.1.0-alpha.1-checklist.md
@@ -12,14 +12,16 @@ Release milestone: [`v0.1.0-alpha.1`](https://github.com/Obsidian-Owl/floe/miles
 
 Execution plan: [v0.1.0-alpha.1 Execution Plan](v0.1.0-alpha.1-execution-plan.md)
 
-Open release gates:
+Release gates:
 
-- [#263 Decouple Dagster Iceberg export from floe-iceberg internals](https://github.com/Obsidian-Owl/floe/issues/263)
-- [#278 Release gate: assess contract-layer hard reset before alpha tag](https://github.com/Obsidian-Owl/floe/issues/278)
-- [#284 Release gate: triage open tech-debt backlog for alpha cutline](https://github.com/Obsidian-Owl/floe/issues/284)
-- [#285 Release gate: run final remote validation lane](https://github.com/Obsidian-Owl/floe/issues/285)
-- [#288 Release gate: validate docs and demo walkthrough from Data Engineer and Platform Engineer perspectives](https://github.com/Obsidian-Owl/floe/issues/288)
-- [#289 Release gate: prepare v0.1.0-alpha.1 release notes, tag, and rollback posture](https://github.com/Obsidian-Owl/floe/issues/289)
+| Issue | Status | Notes |
+| --- | --- | --- |
+| [#263 Decouple Dagster Iceberg export from floe-iceberg internals](https://github.com/Obsidian-Owl/floe/issues/263) | Post-alpha / non-blocking for first alpha | Alpha scope requires Iceberg-backed Customer 360; Dagster without `floe-iceberg` remains post-alpha architecture debt. |
+| [#278 Release gate: assess contract-layer hard reset before alpha tag](https://github.com/Obsidian-Owl/floe/issues/278) | Open alpha blocker | Final #285 validation must record whether contract-layer drift remains. |
+| [#284 Release gate: triage open tech-debt backlog for alpha cutline](https://github.com/Obsidian-Owl/floe/issues/284) | Closed | Tech-debt issues were classified; #152 was fixed before this checklist update. |
+| [#285 Release gate: run final remote validation lane](https://github.com/Obsidian-Owl/floe/issues/285) | Open alpha blocker | Requires DevPod remote E2E and Customer 360 evidence on the final merged release-candidate commit. |
+| [#288 Release gate: validate docs and demo walkthrough from Data Engineer and Platform Engineer perspectives](https://github.com/Obsidian-Owl/floe/issues/288) | Evidence recorded | Close only after the walkthrough evidence PR is merged and linked from the issue. |
+| [#289 Release gate: prepare v0.1.0-alpha.1 release notes, tag, and rollback posture](https://github.com/Obsidian-Owl/floe/issues/289) | Open alpha blocker | Final gate after #285 and #288 are closed. |
 
 Release rule: do not tag `v0.1.0-alpha.1` while any `alpha-blocker` issue remains open.
 
@@ -27,9 +29,10 @@ Release rule: do not tag `v0.1.0-alpha.1` while any `alpha-blocker` issue remain
 
 | Gate | Command to Run | Evidence Location | Current Status |
 | --- | --- | --- | --- |
-| Docs site tests | `npm --prefix docs-site test` | `docs/validation/2026-04-30-alpha-docs-quality-review.md` | Not run on final merged release candidate |
-| Docs build | `make docs-build` | GitHub Actions Docs run or local build log linked from validation record | Not run on final merged release candidate |
-| Docs navigation validation | `uv run python testing/ci/validate-docs-navigation.py` | GitHub Actions Docs run or local command output linked from validation record | Not run on final merged release candidate |
+| Docs site tests | `npm --prefix docs-site test` | `docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md` | PASS on current main baseline; rerun if docs change before tag |
+| Docs build | `make docs-build` | `docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md` | PASS on current main baseline; rerun if docs change before tag |
+| Docs navigation validation | `uv run python testing/ci/validate-docs-navigation.py` | `docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md` | PASS on current main baseline; rerun if docs change before tag |
+| Docs and demo persona walkthrough | Public GitHub Pages route review plus source review | `docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md` | PASS with documented alpha limits |
 | Full CI | GitHub Actions CI workflow on the merged release-candidate commit | GitHub Actions CI run URL linked from validation record | Not run on final merged release candidate |
 | Helm CI | GitHub Actions Helm CI workflow on the merged release-candidate commit | GitHub Actions Helm CI run URL linked from validation record | Not run on final merged release candidate |
 | Security scans | GitHub Actions security scan jobs on the merged release-candidate commit | GitHub Actions CI and Helm CI run URLs linked from validation record | Not run on final merged release candidate |
@@ -39,17 +42,19 @@ Release rule: do not tag `v0.1.0-alpha.1` while any `alpha-blocker` issue remain
 | Customer 360 validation | `make demo-customer-360-validate` in the remote DevPod release-validation lane | Final Customer 360 validation record with business, storage, lineage, tracing, and Dagster evidence | Not run on final merged release candidate |
 | Customer 360 cleanup | `make demo-stop` after validation evidence is captured | Final Customer 360 validation record or operator notes | Not run on final merged release candidate |
 | DevPod remote E2E | `make devpod-test` | `test-artifacts/devpod-run-*/output.log` path linked from validation record | Not run on final merged release candidate |
-| #263 release posture | Confirm the GitHub issue records non-blocking alpha scope | Final validation record and issue link | Not run on final merged release candidate |
+| #263 release posture | Confirm the GitHub issue records non-blocking alpha scope | Final validation record and issue link | Recorded as post-alpha / non-blocking; re-confirm during #285 final validation |
 
 ## Validation Records
 
 - [2026-04-29 Alpha Customer 360 Release Validation](../validation/2026-04-29-alpha-customer-360-release-validation.md) is historical evidence only. It predates the Starlight docs migration and final alpha release-candidate validation.
 - [2026-04-30 Alpha Docs Quality Review](../validation/2026-04-30-alpha-docs-quality-review.md) records this docs quality hardening pass and the remaining release validation required before tag.
+- [2026-05-02 Alpha Docs And Demo Walkthrough](../validation/2026-05-02-alpha-docs-demo-walkthrough.md) records the #288 persona walkthrough and docs/demo route validation.
 
 ## Known Alpha Limitations
 
 - The alpha release requires Customer 360 validation with Iceberg enabled.
 - Dagster without `floe-iceberg` installed is not part of the alpha promise.
+- Customer 360's alpha query proof is command-based business metric validation against generated Iceberg outputs. Cube is charted but disabled by default and is not part of the Customer 360 alpha gate unless a platform enables it.
 - #263 remains post-alpha architecture debt only if the release-scope issue posture still classifies it as non-blocking for `v0.1.0-alpha.1`.
 - API validation can satisfy service evidence when recorded with command output, but manual UI screenshots are not required unless the release owner adds that gate.
 

--- a/docs/releases/v0.1.0-alpha.1-execution-plan.md
+++ b/docs/releases/v0.1.0-alpha.1-execution-plan.md
@@ -238,7 +238,7 @@ Expected: all commands pass against current `main`.
 Open and review:
 
 ```text
-https://obsidian-owl.github.io/floe/get-started/first-platform/
+https://obsidian-owl.github.io/floe/platform-engineers/first-platform/
 https://obsidian-owl.github.io/floe/platform-engineers/
 https://obsidian-owl.github.io/floe/guides/deployment/
 https://obsidian-owl.github.io/floe/contributing/
@@ -253,7 +253,7 @@ Open and review:
 ```text
 https://obsidian-owl.github.io/floe/data-engineers/
 https://obsidian-owl.github.io/floe/demo/
-https://obsidian-owl.github.io/floe/guides/first-data-product/
+https://obsidian-owl.github.io/floe/data-engineers/first-data-product/
 ```
 
 Expected: the path explains how a Data Engineer builds a new data product, not only how to inspect the Customer 360 demo.

--- a/docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md
+++ b/docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md
@@ -1,0 +1,67 @@
+# Alpha Docs And Demo Walkthrough - 2026-05-02
+
+## Commit
+
+- Validation baseline commit: `fe526a2f3f3ecc57444e1158064ed82dbb60a04e`
+- Branch: `docs/alpha-docs-demo-walkthrough`
+- Docs site: https://obsidian-owl.github.io/floe/
+- Release gate: https://github.com/Obsidian-Owl/floe/issues/288
+
+## Automated Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| `npm --prefix docs-site test` | PASS | 34 tests passed, 0 failed after adding Customer 360 query-boundary guardrails. |
+| `make docs-build` | PASS | Starlight synced 132 docs pages and built 133 pages; Pagefind and sitemap generation completed. |
+| `uv run python testing/ci/validate-docs-navigation.py` | PASS | Command exited 0 after bytecode compiling 14038 files in the evidence worktree. |
+
+## Published Route Checks
+
+| Page | Result | Evidence |
+| --- | --- | --- |
+| Platform Engineer first platform | PASS | https://obsidian-owl.github.io/floe/platform-engineers/first-platform/ returned HTTP 200 with one H1: `Deploy Your First Platform`. |
+| Platform Engineers | PASS | https://obsidian-owl.github.io/floe/platform-engineers/ returned HTTP 200 with one H1: `Platform Engineers`. |
+| Deployment guide | PASS | https://obsidian-owl.github.io/floe/guides/deployment/ returned HTTP 200 with one H1: `Deployment Guides`. |
+| Contributor workflows | PASS | https://obsidian-owl.github.io/floe/contributing/ returned HTTP 200 with one H1: `Contributing`. |
+| Data Engineers | PASS | https://obsidian-owl.github.io/floe/data-engineers/ returned HTTP 200 with one H1: `Data Engineers`. |
+| Demo | PASS | https://obsidian-owl.github.io/floe/demo/ returned HTTP 200 with one H1: `Demo`. |
+| First data product | PASS | https://obsidian-owl.github.io/floe/data-engineers/first-data-product/ returned HTTP 200 with one H1: `Build Your First Data Product`. |
+| Customer 360 | PASS | https://obsidian-owl.github.io/floe/demo/customer-360/ returned HTTP 200 with one H1: `Customer 360 Golden Demo`. |
+| Customer 360 validation | PASS | https://obsidian-owl.github.io/floe/demo/customer-360-validation/ returned HTTP 200 with one H1: `Customer 360 Validation`. |
+
+The previous execution-plan route `https://obsidian-owl.github.io/floe/guides/first-data-product/` returned HTTP 404. It was not linked from the published docs navigation, but the release execution plan now points at the current persona route: `https://obsidian-owl.github.io/floe/data-engineers/first-data-product/`.
+
+## Platform Engineer Walkthrough
+
+| Page | Result | Notes |
+| --- | --- | --- |
+| First platform | PASS | The guide is provider-neutral: it starts from any Kubernetes cluster, calls out Kind for evaluation, and does not require Hetzner for product deployment. |
+| Platform Engineers | PASS | Ownership is clear: Platform Engineers own cluster access, manifests, service access, secrets, and the Platform Environment Contract. |
+| Deployment guide | PASS | The deployment model is "bring any conformant Kubernetes cluster"; Data Mesh is presented as implemented primitives and planned operations rather than an alpha deployment promise. |
+| Contributor remote validation operations | PASS | Contributor docs keep DevPod + Hetzner scoped to heavyweight validation and release workflows, not product deployment. |
+
+## Data Engineer Walkthrough
+
+| Page | Result | Notes |
+| --- | --- | --- |
+| Data Engineers | PASS | The path starts from a Platform Environment Contract and separates Data Engineer ownership from platform ownership. |
+| First data product | PASS | The guide teaches `hello-orders` before Customer 360 and avoids presenting planned root lifecycle commands as current product commands. |
+| Data product runtime artifacts | PASS | The deployment story is accurately framed as CI artifact packaging and organization-approved deployment handoff for alpha. |
+| Demo | PASS | Customer 360 is positioned as the advanced proof after the first data product path, not as the only onboarding path. |
+| Customer 360 validation | PASS | Validation explains Dagster, storage, Marquez, Jaeger, Polaris, and business metric evidence. The docs now clarify that the current alpha business/query proof is command-based against generated Iceberg outputs, while Cube is optional and disabled by default. |
+
+## Defects Found And Resolved
+
+| Finding | Resolution |
+| --- | --- |
+| Release execution plan pointed the Data Engineer walkthrough at `/floe/guides/first-data-product/`, which returns HTTP 404. | Updated the plan to `/floe/data-engineers/first-data-product/`. |
+| Customer 360 docs used broad `semantic/query layer` wording without clearly stating the current alpha query proof. | Clarified that Customer 360 uses command-based business metric validation against Iceberg outputs; Cube is charted but disabled by default and not part of the Customer 360 alpha gate unless enabled by the platform. |
+| No guardrail existed to prevent future Customer 360 docs from implying Cube is required for the alpha query proof. | Added docs-site source validation tests for the Customer 360 query boundary. |
+
+## Decision
+
+- Release decision: PASS for #288 after this evidence branch is merged.
+- Blocking follow-up issues: none from this walkthrough.
+- Remaining alpha gates: #278, #285, and #289.
+
+This does not replace the final #285 DevPod remote validation lane. The final release-candidate record must still prove the Customer 360 demo, OpenLineage/Marquez, Jaeger, storage, Dagster, and business metric evidence on the merged release-candidate commit.


### PR DESCRIPTION
## Summary

- Records the #288 Platform Engineer and Data Engineer docs/demo walkthrough evidence in `docs/validation/2026-05-02-alpha-docs-demo-walkthrough.md`.
- Clarifies the Customer 360 alpha query proof: command-based business metric validation against generated Iceberg outputs; Cube is charted but disabled by default and not part of the Customer 360 alpha gate unless enabled by a platform.
- Adds docs-site guardrails so future Customer 360 docs cannot imply Cube is required for the alpha query proof.
- Fixes stale release execution-plan walkthrough URLs and updates the alpha checklist with current #288 evidence.

Closes #288 when merged.

## Validation

- `npm --prefix docs-site test` -> 34 passed
- `make docs-build` -> Starlight synced 132 docs pages and built 133 pages
- `uv run python testing/ci/validate-docs-navigation.py` -> passed
- `./testing/ci/uv-security-audit.sh` -> passed after transient DNS recovered
- `./testing/ci/test-contract.sh` -> 956 passed, 1 xfailed
- `./testing/ci/lint-helm.sh` -> passed
- Normal `git push` pre-push hooks -> passed lint, mypy, dbt version, Bandit, uv-secure, unit tests, contract tests, no-hardcoded-sleep, traceability, and Helm lint

## Notes

The first push attempt failed because local DNS could not resolve `pypi.org` and `dagster-io.github.io`, which prevented uv-secure/pip-audit and Helm dependency downloads. After network recovery, `make helm-deps` hydrated subcharts and the failed gates passed without code changes.
