### PR TITLE
Harden demo runtime validation noise handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ DEVPOD_GIT_REF=
 DEVPOD_ALLOW_LOCAL_SOURCE=0
 # Local port for K8s API tunnel
 DEVPOD_K8S_API_PORT=26443
+# K8s API tunnel readiness window. Increase on high-latency or unstable links.
+DEVPOD_TUNNEL_TIMEOUT=120
+DEVPOD_TUNNEL_INTERVAL=2
 # Remote repo root inside the DevPod workspace (matches the default devcontainer)
 DEVPOD_REMOTE_WORKDIR=/workspace
 # Detached remote E2E controls used by make devpod-test

--- a/Makefile
+++ b/Makefile
@@ -461,17 +461,8 @@ demo: ## Run contributor remote release-validation demo via DevPod
 		--env dev --chart ./charts/floe-platform \
 		--values ./charts/floe-platform/values-demo.yaml \
 		$(DEMO_IMAGE_HELM_SET_ARGS)
-	@echo "Starting port-forwards..."
-	@if [ -f .demo-pids ]; then \
-		kill $$(cat .demo-pids) 2>/dev/null || true; \
-		rm -f .demo-pids; \
-	fi
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-dagster-webserver 3100:3000 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-polaris 8181:8181 8182:8182 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-minio 9000:9000 9001:9001 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-jaeger-query 16686:16686 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-marquez 5100:5000 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" kubectl port-forward svc/floe-platform-otel 4317:4317 4318:4318 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
+	@echo "Starting port-forwards and waiting for demo endpoints..."
+	@KUBECONFIG="$(DEVPOD_KUBECONFIG)" scripts/demo-start-port-forwards.sh
 	@echo ""
 	@echo "=== Demo Ready ==="
 	@echo "Dagster UI:    http://localhost:3100"
@@ -503,17 +494,8 @@ demo-local: build-demo-image ## Deploy demo locally (requires local Kind cluster
 	@uv run floe platform deploy --env dev --chart ./charts/floe-platform \
 		--values ./charts/floe-platform/values-demo.yaml \
 		$(DEMO_IMAGE_HELM_SET_ARGS)
-	@echo "Starting port-forwards..."
-	@if [ -f .demo-pids ]; then \
-		kill $$(cat .demo-pids) 2>/dev/null || true; \
-		rm -f .demo-pids; \
-	fi
-	@kubectl port-forward svc/floe-platform-dagster-webserver 3100:3000 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@kubectl port-forward svc/floe-platform-polaris 8181:8181 8182:8182 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@kubectl port-forward svc/floe-platform-minio 9000:9000 9001:9001 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@kubectl port-forward svc/floe-platform-jaeger-query 16686:16686 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@kubectl port-forward svc/floe-platform-marquez 5100:5000 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
-	@kubectl port-forward svc/floe-platform-otel 4317:4317 4318:4318 -n floe-dev >/dev/null 2>&1 & echo $$! >> .demo-pids
+	@echo "Starting port-forwards and waiting for demo endpoints..."
+	@scripts/demo-start-port-forwards.sh
 	@echo ""
 	@echo "=== Demo Ready ==="
 	@echo "Dagster UI:    http://localhost:3100"

--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,10 @@ demo: ## Run contributor remote release-validation demo via DevPod
 	@echo "=== Starting floe Contributor Remote Validation Demo (DevPod) ==="
 	@scripts/devpod-ensure-ready.sh
 	@echo "Building demo image inside DevPod..."
-	@devpod ssh "$(DEVPOD_WORKSPACE)" -- "cd /workspace && FLOE_DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY) FLOE_DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG) make build-demo-image"
+	@devpod ssh "$(DEVPOD_WORKSPACE)" \
+		--start-services=false \
+		--workdir /workspace \
+		--command 'DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY) DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG) FLOE_DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY) FLOE_DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG) make build-demo-image'
 	@echo "Updating Helm chart dependencies..."
 	@helm dependency update charts/floe-platform
 	@echo "Deploying Helm chart via tunneled kubectl..."

--- a/Makefile
+++ b/Makefile
@@ -403,12 +403,14 @@ compile-demo: ## Compile dbt models and generate Dagster definitions for all dem
 		uv run dbt compile --project-dir demo/$$product --profiles-dir demo/$$product || exit 1; \
 	done
 	@echo "Generating Dagster definitions.py for all demo products..."
+	@# This pre-deploy compile runs before Marquez exists; runtime lineage remains enabled in artifacts.
 	@for product in customer-360 iot-telemetry financial-risk; do \
 		echo "Generating definitions for $$product..."; \
 		uv run floe platform compile \
 			--spec demo/$$product/floe.yaml \
 			--manifest $(DEMO_MANIFEST) \
 			--output demo/$$product/compiled_artifacts.json \
+			--no-lineage-emission \
 			--generate-definitions || exit 1; \
 	done
 	@uv run python testing/ci/validate-demo-compiled-artifacts.py \

--- a/demo/customer-360/models/schema.yml
+++ b/demo/customer-360/models/schema.yml
@@ -24,7 +24,8 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['enterprise', 'mid_market', 'smb', 'startup', 'unknown']
+              arguments:
+                values: ['enterprise', 'mid_market', 'smb', 'startup', 'unknown']
       - name: _loaded_at
         description: "Timestamp when record was loaded"
 
@@ -55,7 +56,8 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['completed', 'pending', 'refunded', 'cancelled', 'unknown']
+              arguments:
+                values: ['completed', 'pending', 'refunded', 'cancelled', 'unknown']
       - name: _loaded_at
         description: "Timestamp when record was loaded"
 
@@ -76,13 +78,15 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['billing', 'technical', 'account', 'shipping', 'general', 'unknown']
+              arguments:
+                values: ['billing', 'technical', 'account', 'shipping', 'general', 'unknown']
       - name: priority
         description: "Ticket priority level"
         tests:
           - not_null
           - accepted_values:
-              values: ['low', 'medium', 'high', 'critical']
+              arguments:
+                values: ['low', 'medium', 'high', 'critical']
       - name: created_at
         description: "Timestamp when ticket was created"
         tests:

--- a/demo/financial-risk/models/schema.yml
+++ b/demo/financial-risk/models/schema.yml
@@ -74,7 +74,8 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['AAA', 'AA', 'A', 'BBB', 'BB', 'B', 'CCC']
+              arguments:
+                values: ['AAA', 'AA', 'A', 'BBB', 'BB', 'B', 'CCC']
       - name: country
         description: "Country code"
         tests:

--- a/demo/iot-telemetry/models/schema.yml
+++ b/demo/iot-telemetry/models/schema.yml
@@ -19,13 +19,15 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['temperature', 'pressure', 'vibration', 'humidity', 'flow_rate']
+              arguments:
+                values: ['temperature', 'pressure', 'vibration', 'humidity', 'flow_rate']
       - name: location
         description: Physical location of the sensor
         tests:
           - not_null
           - accepted_values:
-              values: ['line_a', 'line_b', 'line_c', 'warehouse_1', 'warehouse_2']
+              arguments:
+                values: ['line_a', 'line_b', 'line_c', 'warehouse_1', 'warehouse_2']
       - name: installed_at
         description: Date sensor was installed
         tests:
@@ -48,8 +50,9 @@ models:
         tests:
           - not_null
           - relationships:
-              to: ref('stg_sensors')
-              field: sensor_id
+              arguments:
+                to: ref('stg_sensors')
+                field: sensor_id
       - name: timestamp
         description: When the reading was taken
         tests:
@@ -63,7 +66,8 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['celsius', 'bar', 'mm_s', 'percent', 'l_min']
+              arguments:
+                values: ['celsius', 'bar', 'mm_s', 'percent', 'l_min']
       - name: _loaded_at
         description: Timestamp when data was loaded
         tests:
@@ -86,7 +90,8 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ['preventive', 'corrective', 'predictive', 'emergency']
+              arguments:
+                values: ['preventive', 'corrective', 'predictive', 'emergency']
       - name: performed_at
         description: When maintenance was performed
         tests:

--- a/demo/manifest.yaml
+++ b/demo/manifest.yaml
@@ -72,6 +72,7 @@ plugins:
     version: "0.1.0"
     config:
       url: http://floe-platform-marquez:5000
+      environment: demo
       drain_timeout: 30.0
       allow_insecure_http: true
 

--- a/docker/dagster-demo/Dockerfile
+++ b/docker/dagster-demo/Dockerfile
@@ -74,6 +74,9 @@ RUN uv export --frozen --no-dev --no-editable --all-packages --no-emit-workspace
 # =============================================================================
 FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634 AS build
 
+# Build-stage installs run as root by design; runtime drops privileges to dagster.
+ENV PIP_ROOT_USER_ACTION=ignore
+
 # Build dependencies for C extensions (grpcio, greenlet, pyarrow, duckdb)
 # git: required for pip install from git URLs (pyiceberg pinned commit)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/packages/floe-core/src/floe_core/cli/platform/compile.py
+++ b/packages/floe-core/src/floe_core/cli/platform/compile.py
@@ -133,6 +133,16 @@ Examples:
     help="Generate Dagster definitions.py file alongside CompiledArtifacts. "
     "Requires JSON output at a path named compiled_artifacts.json.",
 )
+@click.option(
+    "--lineage-emission/--no-lineage-emission",
+    default=True,
+    show_default=True,
+    help=(
+        "Emit compile-time OpenLineage events configured by the manifest. "
+        "Disable for offline or pre-deploy artifact generation; compiled "
+        "artifacts still preserve runtime lineage settings."
+    ),
+)
 def compile_command(
     spec: Path | None,
     manifest: Path | None,
@@ -145,6 +155,7 @@ def compile_command(
     skip_contracts: bool,
     drift_detection: bool,
     generate_definitions: bool,
+    lineage_emission: bool,
 ) -> None:
     """Compile FloeSpec and Manifest into CompiledArtifacts.
 
@@ -164,6 +175,7 @@ def compile_command(
         skip_contracts: Skip data contract validation if True.
         drift_detection: Enable schema drift detection if True.
         generate_definitions: Generate Dagster definitions.py if True.
+        lineage_emission: Emit compile-time OpenLineage events if True.
     """
     output_format = output_format.lower()
     resolved_output = output or DEFAULT_OUTPUT_PATHS[output_format]
@@ -199,6 +211,11 @@ def compile_command(
     if generate_definitions:
         _validate_generate_definitions_output(output_format, resolved_output)
 
+    if lineage_emission:
+        info("Compile-time lineage emission: ENABLED")
+    else:
+        info("Compile-time lineage emission: DISABLED (--no-lineage-emission)")
+
     # Log contract-related options (T077)
     if skip_contracts:
         info("Contract validation: SKIPPED (--skip-contracts)")
@@ -222,7 +239,11 @@ def compile_command(
         from floe_core.compilation.stages import compile_pipeline
 
         info("Running compilation pipeline...")
-        artifacts: CompiledArtifacts = compile_pipeline(spec, manifest)
+        artifacts: CompiledArtifacts = compile_pipeline(
+            spec,
+            manifest,
+            emit_lineage=lineage_emission,
+        )
 
         # Step 4: Save CompiledArtifacts to output path (FR-011)
         _write_artifacts_output(

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -340,6 +340,7 @@ def compile_pipeline(
             emitter = create_sync_emitter(None, default_namespace="floe.compilation")
 
         run_id: UUID | None = None
+        lineage_available = True
         try:
             run_facets: dict[str, Any] = {}
             trace_facet = TraceCorrelationFacetBuilder.from_otel_context()
@@ -349,6 +350,7 @@ def compile_pipeline(
         except Exception as _start_err:
             # CWE-532: log type name only — exc_info may contain credential-bearing URLs
             log.warning("lineage_emit_start_failed", error=type(_start_err).__name__)
+            lineage_available = False
 
         try:
             # Stage 2: VALIDATE - Schema validation and quality provider validation
@@ -573,27 +575,28 @@ def compile_pipeline(
             # Records model presence in lineage graph during compilation;
             # execution-time events are emitted by Dagster at runtime.
             dbt_project_name = _dbt_project_name(spec.metadata.name)
-            for model in transforms.models:
-                model_job_name = f"model.{dbt_project_name}.{model.name}"
-                model_run_id: UUID | None = None
-                try:
-                    model_run_id = emitter.emit_start(job_name=model_job_name)
-                    emitter.emit_complete(model_run_id, model_job_name)
-                except Exception as _model_err:
-                    if model_run_id is not None:
-                        try:
-                            emitter.emit_fail(
-                                model_run_id,
-                                model_job_name,
-                                error_message=type(_model_err).__name__,
-                            )
-                        except Exception:
-                            pass  # Best-effort fail event
-                    log.warning(
-                        "lineage_model_emit_failed",
-                        model=model.name,
-                        error=type(_model_err).__name__,
-                    )
+            if lineage_available:
+                for model in transforms.models:
+                    model_job_name = f"model.{dbt_project_name}.{model.name}"
+                    model_run_id: UUID | None = None
+                    try:
+                        model_run_id = emitter.emit_start(job_name=model_job_name)
+                        emitter.emit_complete(model_run_id, model_job_name)
+                    except Exception as _model_err:
+                        if model_run_id is not None:
+                            try:
+                                emitter.emit_fail(
+                                    model_run_id,
+                                    model_job_name,
+                                    error_message=type(_model_err).__name__,
+                                )
+                            except Exception:
+                                pass  # Best-effort fail event
+                        log.warning(
+                            "lineage_model_emit_failed",
+                            model=model.name,
+                            error=type(_model_err).__name__,
+                        )
 
             # Stage 6: GENERATE - Build final CompiledArtifacts
             stage_start = time.perf_counter()

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -255,6 +255,7 @@ def compile_pipeline(
     manifest_path: Path,
     *,
     dry_run: bool = False,
+    emit_lineage: bool = True,
 ) -> CompiledArtifacts:
     """Execute the 6-stage compilation pipeline.
 
@@ -275,6 +276,10 @@ def compile_pipeline(
         spec_path: Path to floe.yaml file.
         manifest_path: Path to manifest.yaml file.
         dry_run: If True, violations are reported but don't block compilation.
+        emit_lineage: If True, emit compile-time OpenLineage events using
+            manifest configuration. If False, use the NoOp transport for
+            offline/pre-deploy artifact generation while preserving runtime
+            lineage settings in compiled artifacts.
 
     Returns:
         CompiledArtifacts ready for serialization.
@@ -332,7 +337,11 @@ def compile_pipeline(
         # Construct lineage emitter from manifest config (after LOAD, inside pipeline span
         # so TraceCorrelationFacetBuilder can capture the active OTel span context)
         try:
-            _lineage_config = _build_lineage_config(manifest)
+            if emit_lineage:
+                _lineage_config = _build_lineage_config(manifest)
+            else:
+                log.info("compile_time_lineage_emission_disabled")
+                _lineage_config = None
             emitter = create_sync_emitter(_lineage_config, default_namespace="floe.compilation")
         except Exception as _build_err:
             # CWE-532: log type name only — exc_info may contain credential-bearing URLs

--- a/packages/floe-core/tests/unit/cli/test_platform_compile.py
+++ b/packages/floe-core/tests/unit/cli/test_platform_compile.py
@@ -32,6 +32,7 @@ class _FakeCompiledArtifacts:
 
     def __init__(self) -> None:
         self.configmap_calls: list[tuple[str, str | None]] = []
+        self.compile_calls: list[dict[str, object]] = []
 
     def to_json_file(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -66,7 +67,16 @@ def fake_compiled_artifacts(monkeypatch: pytest.MonkeyPatch) -> _FakeCompiledArt
     import floe_core.compilation.stages as stages
 
     artifacts = _FakeCompiledArtifacts()
-    monkeypatch.setattr(stages, "compile_pipeline", lambda _spec, _manifest: artifacts)
+
+    def fake_compile_pipeline(
+        _spec: Path,
+        _manifest: Path,
+        **kwargs: object,
+    ) -> _FakeCompiledArtifacts:
+        artifacts.compile_calls.append(kwargs)
+        return artifacts
+
+    monkeypatch.setattr(stages, "compile_pipeline", fake_compile_pipeline)
     return artifacts
 
 
@@ -863,6 +873,77 @@ class TestPlatformCompileCommand:
         # Verify helpful descriptions are present
         assert "contract" in result.output.lower()
         assert "drift" in result.output.lower()
+
+    @pytest.mark.requirement("FR-010")
+    def test_compile_accepts_no_lineage_emission_flag(
+        self,
+        cli_runner: CliRunner,
+        sample_floe_yaml: Path,
+        sample_manifest_yaml: Path,
+        fake_compiled_artifacts: _FakeCompiledArtifacts,
+    ) -> None:
+        """Pre-deploy artifact generation can disable compile-time lineage side effects."""
+        from floe_core.cli.main import cli
+
+        result = cli_runner.invoke(
+            cli,
+            [
+                "platform",
+                "compile",
+                "--spec",
+                str(sample_floe_yaml),
+                "--manifest",
+                str(sample_manifest_yaml),
+                "--no-lineage-emission",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert fake_compiled_artifacts.compile_calls[-1]["emit_lineage"] is False
+        assert "Compile-time lineage emission: DISABLED" in result.output
+
+    @pytest.mark.requirement("FR-010")
+    def test_compile_enables_lineage_emission_by_default(
+        self,
+        cli_runner: CliRunner,
+        sample_floe_yaml: Path,
+        sample_manifest_yaml: Path,
+        fake_compiled_artifacts: _FakeCompiledArtifacts,
+    ) -> None:
+        """Default CLI behavior still follows manifest-configured compile-time lineage."""
+        from floe_core.cli.main import cli
+
+        result = cli_runner.invoke(
+            cli,
+            [
+                "platform",
+                "compile",
+                "--spec",
+                str(sample_floe_yaml),
+                "--manifest",
+                str(sample_manifest_yaml),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert fake_compiled_artifacts.compile_calls[-1]["emit_lineage"] is True
+
+    @pytest.mark.requirement("FR-010")
+    def test_compile_help_shows_lineage_emission_flag(
+        self,
+        cli_runner: CliRunner,
+    ) -> None:
+        """Help documents offline compile-time lineage control."""
+        from floe_core.cli.main import cli
+
+        result = cli_runner.invoke(
+            cli,
+            ["platform", "compile", "--help"],
+        )
+
+        assert result.exit_code == 0
+        assert "--lineage-emission / --no-lineage-emission" in result.output
+        assert "compile-time OpenLineage" in result.output
 
 
 class TestPlatformGroup:

--- a/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
+++ b/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
@@ -417,6 +417,33 @@ class TestCompilePipelineLineageStart:
         ]
         assert model_start_calls == []
 
+    @pytest.mark.requirement("AC-OLC-5")
+    def test_emit_lineage_false_uses_noop_transport_config(
+        self,
+        spec_path: Path,
+        lineage_manifest_path: Path,
+        mock_emitter: MagicMock,
+    ) -> None:
+        """Offline compilation can preserve manifest lineage without HTTP emission.
+
+        Pre-deploy packaging generates artifacts before Marquez exists. It must
+        not attempt the manifest HTTP endpoint, but artifacts still need lineage
+        enabled so runtime Dagster/OpenLineage behavior remains configured.
+        """
+        from floe_core.compilation.stages import compile_pipeline
+
+        with patch(CREATE_SYNC_EMITTER_PATH, return_value=mock_emitter) as mock_factory:
+            artifacts = compile_pipeline(
+                spec_path,
+                lineage_manifest_path,
+                emit_lineage=False,
+            )
+
+        mock_factory.assert_called_once()
+        config_arg = _get_arg(mock_factory.call_args, 0, "transport_config")
+        assert config_arg is None
+        assert artifacts.observability.lineage is True
+
 
 class TestCompilePipelineLineageComplete:
     """AC-OLC-6: compile_pipeline() emits COMPLETE event at pipeline close."""

--- a/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
+++ b/packages/floe-core/tests/unit/compilation/test_compile_pipeline_lineage.py
@@ -389,6 +389,34 @@ class TestCompilePipelineLineageStart:
         assert isinstance(result, CompiledArtifacts)
         assert result.metadata.product_name == PRODUCT_NAME
 
+    @pytest.mark.requirement("AC-OLC-5")
+    def test_emit_start_failure_skips_per_model_lineage_noise(
+        self,
+        spec_path: Path,
+        lineage_manifest_path: Path,
+        mock_emitter: MagicMock,
+    ) -> None:
+        """A failed pipeline START marks compile-time lineage unavailable.
+
+        If the backend is not reachable before deployment, every per-model
+        event would fail for the same reason. Compilation should emit one
+        pipeline-level warning and skip per-model lineage instead of producing
+        repeated model warnings.
+        """
+        from floe_core.compilation.stages import compile_pipeline
+
+        mock_emitter.emit_start.side_effect = ConnectionError("Marquez unavailable")
+
+        with patch(CREATE_SYNC_EMITTER_PATH, return_value=mock_emitter):
+            compile_pipeline(spec_path, lineage_manifest_path)
+
+        model_start_calls = [
+            c
+            for c in mock_emitter.emit_start.call_args_list
+            if str(_get_arg(c, 0, "job_name")).startswith("model.")
+        ]
+        assert model_start_calls == []
+
 
 class TestCompilePipelineLineageComplete:
     """AC-OLC-6: compile_pipeline() emits COMPLETE event at pipeline close."""

--- a/packages/floe-core/tests/unit/compilation/test_stages.py
+++ b/packages/floe-core/tests/unit/compilation/test_stages.py
@@ -1542,6 +1542,7 @@ class TestObservabilityFromManifest:
         assert lineage_backend.type == "marquez"
         assert lineage_backend.config == {
             "url": "http://floe-platform-marquez:5000",
+            "environment": "demo",
             "drain_timeout": 30.0,
             "allow_insecure_http": True,
         }

--- a/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
+++ b/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
@@ -33,14 +33,55 @@ _LOCALHOST_HOSTNAMES: frozenset[str] = frozenset(
         "localhost.localdomain",
     }
 )
-_WARNED_INSECURE_HTTP_HOSTS: set[str] = set()
+_NON_PRODUCTION_ENVIRONMENTS: frozenset[str] = frozenset(
+    {
+        "ci",
+        "demo",
+        "dev",
+        "development",
+        "kind",
+        "local",
+        "test",
+        "testing",
+    }
+)
+_WARNED_INSECURE_HTTP_HOSTS: set[tuple[str, int]] = set()
 
 
-def _warn_insecure_http_once(hostname: str) -> None:
-    """Warn once when explicit non-localhost HTTP is enabled for Marquez."""
-    if hostname in _WARNED_INSECURE_HTTP_HOSTS:
+def _is_non_production_environment(environment: str) -> bool:
+    """Return True for explicitly non-production deployment environments."""
+    return environment.strip().lower() in _NON_PRODUCTION_ENVIRONMENTS
+
+
+def _insecure_http_log_level(
+    *,
+    environment: str,
+    manifest_override: bool,
+    environment_override: bool,
+) -> int:
+    """Choose a log level for explicit non-localhost HTTP Marquez config."""
+    if environment_override:
+        return logging.WARNING
+    if manifest_override and _is_non_production_environment(environment):
+        return logging.INFO
+    return logging.WARNING
+
+
+def _log_insecure_http_once(hostname: str, *, level: int, environment: str) -> None:
+    """Log once when explicit non-localhost HTTP is enabled for Marquez."""
+    key = (hostname, level)
+    if key in _WARNED_INSECURE_HTTP_HOSTS:
         return
-    _WARNED_INSECURE_HTTP_HOSTS.add(hostname)
+    _WARNED_INSECURE_HTTP_HOSTS.add(key)
+    if level <= logging.INFO:
+        logger.info(
+            "Non-production HTTP enabled for Marquez URL '%s' "
+            "(environment=%s) via explicit manifest config.",
+            hostname,
+            environment,
+        )
+        return
+
     logger.warning(
         "INSECURE HTTP enabled for Marquez URL '%s' - development/test use only! "
         "Use HTTPS before deploying to production.",
@@ -162,11 +203,17 @@ class MarquezConfig(BaseModel):
                 return self
 
             # Allow HTTP with explicit manifest config or environment override.
-            if (
-                self.allow_insecure_http
-                or os.environ.get("FLOE_ALLOW_INSECURE_HTTP", "").lower() == "true"
-            ):
-                _warn_insecure_http_once(hostname)
+            env_override = os.environ.get("FLOE_ALLOW_INSECURE_HTTP", "").lower() == "true"
+            if self.allow_insecure_http or env_override:
+                _log_insecure_http_once(
+                    hostname,
+                    level=_insecure_http_log_level(
+                        environment=self.environment,
+                        manifest_override=self.allow_insecure_http,
+                        environment_override=env_override,
+                    ),
+                    environment=self.environment,
+                )
                 self.url = v
                 return self
 

--- a/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
+++ b/plugins/floe-lineage-marquez/src/floe_lineage_marquez/__init__.py
@@ -33,6 +33,19 @@ _LOCALHOST_HOSTNAMES: frozenset[str] = frozenset(
         "localhost.localdomain",
     }
 )
+_WARNED_INSECURE_HTTP_HOSTS: set[str] = set()
+
+
+def _warn_insecure_http_once(hostname: str) -> None:
+    """Warn once when explicit non-localhost HTTP is enabled for Marquez."""
+    if hostname in _WARNED_INSECURE_HTTP_HOSTS:
+        return
+    _WARNED_INSECURE_HTTP_HOSTS.add(hostname)
+    logger.warning(
+        "INSECURE HTTP enabled for Marquez URL '%s' - development/test use only! "
+        "Use HTTPS before deploying to production.",
+        hostname,
+    )
 
 
 def _is_localhost(hostname: str) -> bool:
@@ -153,12 +166,7 @@ class MarquezConfig(BaseModel):
                 self.allow_insecure_http
                 or os.environ.get("FLOE_ALLOW_INSECURE_HTTP", "").lower() == "true"
             ):
-                logger.critical(
-                    "INSECURE HTTP enabled for Marquez URL '%s' - "
-                    "development/test use only! Use HTTPS before deploying "
-                    "to production.",
-                    hostname,
-                )
+                _warn_insecure_http_once(hostname)
                 self.url = v
                 return self
 

--- a/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
+++ b/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
@@ -7,6 +7,7 @@ for Marquez deployments.
 
 from __future__ import annotations
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
 
@@ -337,6 +338,32 @@ def test_config_allows_manifest_explicit_internal_http() -> None:
 
     assert config.url == "http://floe-platform-marquez:5000"
     assert config.allow_insecure_http is True
+
+
+@pytest.mark.requirement("REQ-527")
+def test_insecure_http_override_logs_once_at_warning_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Explicit in-cluster HTTP should warn once without repeated critical noise."""
+    import floe_lineage_marquez as marquez_module
+
+    marquez_module._WARNED_INSECURE_HTTP_HOSTS.clear()
+    caplog.set_level(logging.WARNING, logger="floe_lineage_marquez")
+
+    for _ in range(2):
+        MarquezConfig(
+            url="http://floe-platform-marquez:5000",
+            allow_insecure_http=True,
+        )
+
+    insecure_records = [
+        record
+        for record in caplog.records
+        if "INSECURE HTTP enabled for Marquez URL" in record.getMessage()
+    ]
+    assert len(insecure_records) == 1
+    assert insecure_records[0].levelno == logging.WARNING
+    assert all(record.levelno < logging.CRITICAL for record in insecure_records)
 
 
 @pytest.mark.requirement("REQ-527")

--- a/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
+++ b/plugins/floe-lineage-marquez/tests/unit/test_plugin.py
@@ -344,7 +344,7 @@ def test_config_allows_manifest_explicit_internal_http() -> None:
 def test_insecure_http_override_logs_once_at_warning_level(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Explicit in-cluster HTTP should warn once without repeated critical noise."""
+    """Production/default in-cluster HTTP should warn once without critical noise."""
     import floe_lineage_marquez as marquez_module
 
     marquez_module._WARNED_INSECURE_HTTP_HOSTS.clear()
@@ -364,6 +364,37 @@ def test_insecure_http_override_logs_once_at_warning_level(
     assert len(insecure_records) == 1
     assert insecure_records[0].levelno == logging.WARNING
     assert all(record.levelno < logging.CRITICAL for record in insecure_records)
+
+
+@pytest.mark.requirement("REQ-527")
+def test_manifest_nonprod_insecure_http_logs_once_at_info_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Manifest-declared demo/test HTTP should be visible without warning noise."""
+    import floe_lineage_marquez as marquez_module
+
+    marquez_module._WARNED_INSECURE_HTTP_HOSTS.clear()
+    caplog.set_level(logging.INFO, logger="floe_lineage_marquez")
+
+    for _ in range(2):
+        MarquezConfig(
+            url="http://floe-platform-marquez:5000",
+            environment="demo",
+            allow_insecure_http=True,
+        )
+
+    insecure_records = [
+        record
+        for record in caplog.records
+        if "Non-production HTTP enabled for Marquez URL" in record.getMessage()
+    ]
+    assert len(insecure_records) == 1
+    assert insecure_records[0].levelno == logging.INFO
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and "Marquez URL" in record.getMessage()
+    ]
 
 
 @pytest.mark.requirement("REQ-527")

--- a/scripts/demo-start-port-forwards.sh
+++ b/scripts/demo-start-port-forwards.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${FLOE_DEMO_NAMESPACE:-floe-dev}"
+RELEASE="${FLOE_DEMO_RELEASE:-floe-platform}"
+PIDS_FILE="${FLOE_DEMO_PIDS_FILE:-.demo-pids}"
+LOG_FILE="${FLOE_DEMO_PORT_FORWARD_LOG:-.demo-port-forwards.log}"
+
+DAGSTER_HOST_PORT="${FLOE_DEMO_DAGSTER_PORT:-3100}"
+POLARIS_API_PORT="${FLOE_DEMO_POLARIS_API_PORT:-8181}"
+POLARIS_MGMT_PORT="${FLOE_DEMO_POLARIS_MGMT_PORT:-8182}"
+MINIO_API_PORT="${FLOE_DEMO_MINIO_API_PORT:-9000}"
+MINIO_CONSOLE_PORT="${FLOE_DEMO_MINIO_CONSOLE_PORT:-9001}"
+JAEGER_PORT="${FLOE_DEMO_JAEGER_PORT:-16686}"
+MARQUEZ_PORT="${FLOE_DEMO_MARQUEZ_PORT:-5100}"
+OTEL_GRPC_PORT="${FLOE_DEMO_OTEL_GRPC_PORT:-4317}"
+OTEL_HTTP_PORT="${FLOE_DEMO_OTEL_HTTP_PORT:-4318}"
+
+KUBECTL=(kubectl)
+if [[ -n "${KUBECONFIG:-}" ]]; then
+    KUBECTL+=(--kubeconfig "${KUBECONFIG}")
+fi
+
+stop_existing() {
+    if [[ -f "${PIDS_FILE}" ]]; then
+        kill $(cat "${PIDS_FILE}") 2>/dev/null || true
+        rm -f "${PIDS_FILE}"
+    fi
+}
+
+cleanup_on_error() {
+    local rc=$?
+    if [[ ${rc} -ne 0 ]]; then
+        stop_existing
+        echo "Port-forward startup failed. See ${LOG_FILE} for kubectl output." >&2
+    fi
+    exit "${rc}"
+}
+trap cleanup_on_error EXIT
+
+start_port_forward() {
+    local service=$1
+    shift
+    "${KUBECTL[@]}" port-forward "svc/${service}" "$@" -n "${NAMESPACE}" >>"${LOG_FILE}" 2>&1 &
+    echo $! >>"${PIDS_FILE}"
+}
+
+wait_for_tcp() {
+    local host=$1 port=$2 label=$3 timeout=${4:-30}
+    for _ in $(seq 1 "${timeout}"); do
+        if (echo >/dev/tcp/"${host}"/"${port}") 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: ${label} did not accept TCP connections on ${host}:${port} after ${timeout}s" >&2
+    return 1
+}
+
+wait_for_http() {
+    local url=$1 label=$2 timeout=${3:-60}
+    for _ in $(seq 1 "${timeout}"); do
+        if curl -fsS --connect-timeout 2 --max-time 5 "${url}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: ${label} did not become healthy at ${url} after ${timeout}s" >&2
+    return 1
+}
+
+stop_existing
+: >"${LOG_FILE}"
+
+"${KUBECTL[@]}" wait --for=condition=ready pod \
+    -l "app.kubernetes.io/instance=${RELEASE}" \
+    -n "${NAMESPACE}" \
+    --timeout=180s >/dev/null
+
+start_port_forward "${RELEASE}-dagster-webserver" "${DAGSTER_HOST_PORT}:3000"
+start_port_forward "${RELEASE}-polaris" "${POLARIS_API_PORT}:8181" "${POLARIS_MGMT_PORT}:8182"
+start_port_forward "${RELEASE}-minio" "${MINIO_API_PORT}:9000" "${MINIO_CONSOLE_PORT}:9001"
+start_port_forward "${RELEASE}-jaeger-query" "${JAEGER_PORT}:16686"
+start_port_forward "${RELEASE}-marquez" "${MARQUEZ_PORT}:5000"
+start_port_forward "${RELEASE}-otel" "${OTEL_GRPC_PORT}:4317" "${OTEL_HTTP_PORT}:4318"
+
+wait_for_http "http://localhost:${DAGSTER_HOST_PORT}/server_info" "Dagster"
+wait_for_tcp localhost "${POLARIS_API_PORT}" "Polaris"
+wait_for_tcp localhost "${POLARIS_MGMT_PORT}" "Polaris management"
+wait_for_tcp localhost "${MINIO_API_PORT}" "MinIO API"
+wait_for_tcp localhost "${MINIO_CONSOLE_PORT}" "MinIO console"
+wait_for_http "http://localhost:${JAEGER_PORT}/api/services" "Jaeger" 30
+wait_for_tcp localhost "${MARQUEZ_PORT}" "Marquez"
+wait_for_tcp localhost "${OTEL_GRPC_PORT}" "OTel gRPC"
+wait_for_tcp localhost "${OTEL_HTTP_PORT}" "OTel HTTP"

--- a/scripts/demo-start-port-forwards.sh
+++ b/scripts/demo-start-port-forwards.sh
@@ -69,13 +69,20 @@ wait_for_http() {
     return 1
 }
 
+wait_for_deployment() {
+    local deployment=$1 timeout=${2:-180s}
+    "${KUBECTL[@]}" rollout status "deployment/${deployment}" -n "${NAMESPACE}" --timeout="${timeout}" >/dev/null
+}
+
 stop_existing
 : >"${LOG_FILE}"
 
-"${KUBECTL[@]}" wait --for=condition=ready pod \
-    -l "app.kubernetes.io/instance=${RELEASE}" \
-    -n "${NAMESPACE}" \
-    --timeout=180s >/dev/null
+wait_for_deployment "${RELEASE}-dagster-webserver"
+wait_for_deployment "${RELEASE}-polaris"
+wait_for_deployment "${RELEASE}-minio"
+wait_for_deployment "${RELEASE}-jaeger"
+wait_for_deployment "${RELEASE}-marquez"
+wait_for_deployment "${RELEASE}-otel"
 
 start_port_forward "${RELEASE}-dagster-webserver" "${DAGSTER_HOST_PORT}:3000"
 start_port_forward "${RELEASE}-polaris" "${POLARIS_API_PORT}:8181" "${POLARIS_MGMT_PORT}:8182"

--- a/scripts/devpod-sync-kubeconfig.sh
+++ b/scripts/devpod-sync-kubeconfig.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 WORKSPACE="${1:-floe}"
 LOCAL_KUBECONFIG="${DEVPOD_KUBECONFIG:-${HOME}/.kube/devpod-${WORKSPACE}.config}"
 LOCAL_API_PORT="${DEVPOD_K8S_API_PORT:-26443}"
+TUNNEL_TIMEOUT="${DEVPOD_TUNNEL_TIMEOUT:-120}"
+TUNNEL_INTERVAL="${DEVPOD_TUNNEL_INTERVAL:-2}"
 
 # Validate inputs contain only safe characters
 if [[ ! "${WORKSPACE}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
@@ -26,6 +28,14 @@ if [[ ! "${WORKSPACE}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
 fi
 if [[ ! "${LOCAL_API_PORT}" =~ ^[0-9]+$ ]]; then
     echo "[devpod-sync] ERROR: Invalid port: ${LOCAL_API_PORT}" >&2
+    exit 1
+fi
+if [[ ! "${TUNNEL_TIMEOUT}" =~ ^[0-9]+$ || "${TUNNEL_TIMEOUT}" -lt 1 ]]; then
+    echo "[devpod-sync] ERROR: Invalid DEVPOD_TUNNEL_TIMEOUT: ${TUNNEL_TIMEOUT}" >&2
+    exit 1
+fi
+if [[ ! "${TUNNEL_INTERVAL}" =~ ^[0-9]+$ || "${TUNNEL_INTERVAL}" -lt 1 ]]; then
+    echo "[devpod-sync] ERROR: Invalid DEVPOD_TUNNEL_INTERVAL: ${TUNNEL_INTERVAL}" >&2
     exit 1
 fi
 if [[ -z "${LOCAL_KUBECONFIG}" ]]; then
@@ -168,23 +178,29 @@ nohup devpod ssh "${WORKSPACE}" \
 
 TUNNEL_PID=$!
 
-# Wait briefly for tunnel to establish
-sleep 3
-
-if ! kill -0 "${TUNNEL_PID}" 2>/dev/null; then
-    error "SSH tunnel process exited immediately. Check ${HOME}/.kube/devpod-ssh.log"
-fi
-
 # ─── Validate ────────────────────────────────────────────────────────────────
 
 log "Validating connection..."
-if kubectl --kubeconfig "${LOCAL_KUBECONFIG}" cluster-info >/dev/null 2>&1; then
-    log "SUCCESS: K8s cluster accessible at localhost:${LOCAL_API_PORT}"
-    log ""
-    log "Usage:"
-    log "  export KUBECONFIG=${LOCAL_KUBECONFIG}"
-    log "  kubectl get pods -n floe-test"
-else
-    log "WARNING: cluster-info check failed. The tunnel may need a moment to establish."
-    log "Retry: kubectl --kubeconfig ${LOCAL_KUBECONFIG} cluster-info"
-fi
+tunnel_deadline=$((SECONDS + TUNNEL_TIMEOUT))
+while (( SECONDS < tunnel_deadline )); do
+    if kubectl --kubeconfig "${LOCAL_KUBECONFIG}" cluster-info >/dev/null 2>&1; then
+        log "SUCCESS: K8s cluster accessible at localhost:${LOCAL_API_PORT}"
+        log ""
+        log "Usage:"
+        log "  export KUBECONFIG=${LOCAL_KUBECONFIG}"
+        log "  kubectl get pods -n floe-test"
+        exit 0
+    fi
+
+    if ! kill -0 "${TUNNEL_PID}" 2>/dev/null; then
+        error "SSH tunnel process exited before Kubernetes became reachable. Check ${HOME}/.kube/devpod-ssh.log"
+    fi
+
+    elapsed=$((TUNNEL_TIMEOUT - (tunnel_deadline - SECONDS)))
+    log "Waiting for SSH tunnel... (${elapsed}/${TUNNEL_TIMEOUT}s)"
+    sleep "${TUNNEL_INTERVAL}"
+done
+
+error "K8s cluster not reachable via ${LOCAL_KUBECONFIG} after ${TUNNEL_TIMEOUT}s.
+  Check ${HOME}/.kube/devpod-ssh.log and retry:
+  kubectl --kubeconfig ${LOCAL_KUBECONFIG} cluster-info"

--- a/testing/ci/test-unit-c-boundary.sh
+++ b/testing/ci/test-unit-c-boundary.sh
@@ -95,7 +95,7 @@ ensure_remote_demo_image_loaded() {
     sync_devpod_checkout
     info "Remote demo image '${demo_image}' is missing. Rebuilding it in the DevPod workspace..."
     devpod_remote_command \
-        "FLOE_DEMO_IMAGE_REPOSITORY=${image_repository_q} FLOE_DEMO_IMAGE_TAG=${image_tag_q} KIND_CLUSTER_NAME=${kind_cluster_q} make build-demo-image"
+        "DEMO_IMAGE_REPOSITORY=${image_repository_q} DEMO_IMAGE_TAG=${image_tag_q} FLOE_DEMO_IMAGE_REPOSITORY=${image_repository_q} FLOE_DEMO_IMAGE_TAG=${image_tag_q} KIND_CLUSTER_NAME=${kind_cluster_q} make build-demo-image"
 }
 
 ensure_remote_test_runner_image_loaded() {

--- a/testing/fixtures/credentials.py
+++ b/testing/fixtures/credentials.py
@@ -29,6 +29,7 @@ MANIFEST_PATH_ENV_VARS = ("FLOE_MANIFEST_PATH", "POLARIS_MANIFEST_PATH")
 _DEFAULT_POLARIS_CLIENT_ID = "demo-admin"
 _DEFAULT_POLARIS_CLIENT_SECRET = "demo-secret"  # pragma: allowlist secret  # noqa: S105
 _DEFAULT_POLARIS_ENDPOINT = "http://floe-platform-polaris:8181/api/catalog"
+_DEFAULT_POLARIS_OAUTH2_SERVER_URI = "http://floe-platform-polaris:8181/api/catalog/v1/oauth/tokens"
 _DEFAULT_POLARIS_SCOPE = "PRINCIPAL_ROLE:ALL"
 _DEFAULT_POLARIS_WAREHOUSE = "floe-demo"
 _DEFAULT_MINIO_ACCESS_KEY = "minioadmin"
@@ -248,3 +249,51 @@ def get_polaris_endpoint(manifest_path: Path | None = None) -> str:
         return str(uri)
 
     return _DEFAULT_POLARIS_ENDPOINT
+
+
+def get_polaris_oauth2_server_uri(
+    manifest_path: Path | None = None,
+    *,
+    catalog_endpoint: str | None = None,
+) -> str:
+    """Return the Polaris OAuth2 token endpoint for PyIceberg.
+
+    PyIceberg 0.11 warns when ``oauth2-server-uri`` is omitted and will remove
+    fallback inference in 1.0. Prefer explicit runtime configuration, then
+    derive from the active catalog endpoint so host, in-cluster, and manifest
+    paths stay aligned.
+
+    Args:
+        manifest_path: Optional path to manifest.yaml.
+        catalog_endpoint: Active Polaris REST catalog endpoint. When provided,
+            it is used to derive the token endpoint before manifest fallback.
+
+    Returns:
+        Polaris OAuth2 token endpoint URI string.
+    """
+    for env_var in ("POLARIS_OAUTH2_SERVER_URI", "FLOE_E2E_POLARIS_OAUTH2_URI"):
+        env_uri = _env_or_none(env_var)
+        if env_uri is not None:
+            return env_uri
+
+    if catalog_endpoint is not None and catalog_endpoint.strip():
+        return _derive_oauth2_server_uri(catalog_endpoint)
+
+    raw = _read_manifest(manifest_path)
+    token_url = _catalog_oauth2(raw).get("token_url")
+    if token_url is not None and str(token_url).strip():
+        return str(token_url)
+
+    endpoint = get_polaris_endpoint(manifest_path)
+    if endpoint:
+        return _derive_oauth2_server_uri(endpoint)
+
+    return _DEFAULT_POLARIS_OAUTH2_SERVER_URI
+
+
+def _derive_oauth2_server_uri(catalog_endpoint: str) -> str:
+    """Derive Polaris token endpoint from a catalog endpoint or service base URL."""
+    endpoint = catalog_endpoint.rstrip("/")
+    if endpoint.endswith("/api/catalog"):
+        return f"{endpoint}/v1/oauth/tokens"
+    return f"{endpoint}/api/catalog/v1/oauth/tokens"

--- a/testing/fixtures/credentials.py
+++ b/testing/fixtures/credentials.py
@@ -47,14 +47,19 @@ DEFAULT_POLARIS_CONFIG = {
 def resolve_manifest_path(manifest_path: Path | None = None) -> Path:
     """Resolve the manifest path from an explicit argument, env, or repo default."""
     if manifest_path is not None:
-        return manifest_path
+        return _normalize_manifest_path(manifest_path)
 
     for env_var in MANIFEST_PATH_ENV_VARS:
         env_path = _env_or_none(env_var)
         if env_path is not None:
-            return Path(env_path).expanduser()
+            return _normalize_manifest_path(Path(env_path))
 
     return _default_manifest_path()
+
+
+def _normalize_manifest_path(manifest_path: Path) -> Path:
+    """Return an absolute, user-expanded manifest path without requiring it to exist."""
+    return manifest_path.expanduser().resolve(strict=False)
 
 
 def _default_manifest_path() -> Path:

--- a/testing/fixtures/polaris.py
+++ b/testing/fixtures/polaris.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 from testing.fixtures.credentials import (
     get_minio_credentials,
     get_polaris_credentials,
+    get_polaris_oauth2_server_uri,
     get_polaris_scope,
     get_polaris_warehouse,
 )
@@ -125,6 +126,7 @@ def create_polaris_catalog(config: PolarisConfig) -> Catalog:
             "polaris",
             type="rest",
             uri=config.uri,
+            **{"oauth2-server-uri": get_polaris_oauth2_server_uri(catalog_endpoint=config.uri)},
             warehouse=config.warehouse,
             credential=config.credential.get_secret_value(),
             scope=config.scope,

--- a/testing/k8s/setup-cluster.sh
+++ b/testing/k8s/setup-cluster.sh
@@ -406,7 +406,12 @@ deploy_monitoring_stack() {
 build_demo_image() {
     if [[ -f "${PROJECT_ROOT}/docker/dagster-demo/Dockerfile" ]]; then
         log_info "Building Dagster demo image (${FLOE_DEMO_IMAGE})..."
-        KIND_CLUSTER_NAME="${CLUSTER_NAME}" make -C "${PROJECT_ROOT}" build-demo-image 2>&1 || {
+        KIND_CLUSTER_NAME="${CLUSTER_NAME}" \
+            DEMO_IMAGE_REPOSITORY="${FLOE_DEMO_IMAGE_REPOSITORY}" \
+            DEMO_IMAGE_TAG="${FLOE_DEMO_IMAGE_TAG}" \
+            FLOE_DEMO_IMAGE_REPOSITORY="${FLOE_DEMO_IMAGE_REPOSITORY}" \
+            FLOE_DEMO_IMAGE_TAG="${FLOE_DEMO_IMAGE_TAG}" \
+            make -C "${PROJECT_ROOT}" build-demo-image 2>&1 || {
             log_warn "Dagster demo image build failed — Dagster pods will be in ErrImageNeverPull"
         }
     fi

--- a/testing/tests/unit/test_credentials.py
+++ b/testing/tests/unit/test_credentials.py
@@ -20,6 +20,7 @@ from testing.fixtures.credentials import (
     get_minio_credentials,
     get_polaris_credentials,
     get_polaris_endpoint,
+    get_polaris_oauth2_server_uri,
 )
 
 # ---------------------------------------------------------------------------
@@ -28,6 +29,7 @@ from testing.fixtures.credentials import (
 MANIFEST_POLARIS_CLIENT_ID = "demo-admin"
 MANIFEST_POLARIS_CLIENT_SECRET = "demo-secret"  # pragma: allowlist secret
 MANIFEST_POLARIS_URI = "http://floe-platform-polaris:8181/api/catalog"
+MANIFEST_POLARIS_OAUTH2_URI = "http://floe-platform-polaris:8181/api/catalog/v1/oauth/tokens"
 MINIO_DEFAULT_ACCESS_KEY = "minioadmin"
 MINIO_DEFAULT_SECRET_KEY = "minioadmin123"  # pragma: allowlist secret
 
@@ -55,6 +57,7 @@ def _make_valid_manifest(tmp_path: Path) -> Path:
                     "oauth2": {
                         "client_id": MANIFEST_POLARIS_CLIENT_ID,
                         "client_secret": MANIFEST_POLARIS_CLIENT_SECRET,
+                        "token_url": MANIFEST_POLARIS_OAUTH2_URI,
                     },
                 },
             },
@@ -106,7 +109,7 @@ class TestGetMinioCredentials:
         access_key, secret_key = get_minio_credentials(manifest_path=manifest)
 
         assert access_key == "custom-key"
-        assert secret_key == "custom-secret"
+        assert secret_key == "custom-secret"  # pragma: allowlist secret
 
     @pytest.mark.requirement("AC-2")
     def test_returns_defaults_when_manifest_missing(
@@ -165,7 +168,7 @@ class TestGetMinioCredentials:
         access_key, secret_key = get_minio_credentials(manifest_path=manifest)
 
         assert access_key == MINIO_DEFAULT_ACCESS_KEY
-        assert secret_key == "only-secret"
+        assert secret_key == "only-secret"  # pragma: allowlist secret
 
     @pytest.mark.requirement("AC-2")
     def test_empty_env_vars_treated_as_unset(
@@ -216,7 +219,7 @@ class TestGetPolarisCredentials:
         client_id, client_secret = get_polaris_credentials(manifest_path=manifest)
 
         assert client_id == "env-client"
-        assert client_secret == "env-secret"
+        assert client_secret == "env-secret"  # pragma: allowlist secret
 
     @pytest.mark.requirement("AC-2")
     def test_returns_defaults_when_manifest_missing(
@@ -347,7 +350,7 @@ class TestGetPolarisCredentials:
         client_id, client_secret = get_polaris_credentials(manifest_path=manifest)
 
         assert client_id == MANIFEST_POLARIS_CLIENT_ID
-        assert client_secret == "env-secret-only"
+        assert client_secret == "env-secret-only"  # pragma: allowlist secret
 
     @pytest.mark.requirement("AC-2")
     def test_empty_env_vars_treated_as_unset(
@@ -378,7 +381,7 @@ class TestGetPolarisCredentials:
                         "config": {
                             "oauth2": {
                                 "client_id": "production-admin",
-                                "client_secret": "production-secret",
+                                "client_secret": "production-secret",  # pragma: allowlist secret
                             }
                         }
                     }
@@ -389,7 +392,7 @@ class TestGetPolarisCredentials:
         client_id, client_secret = get_polaris_credentials(manifest_path=custom_manifest)
 
         assert client_id == "production-admin"
-        assert client_secret == "production-secret"
+        assert client_secret == "production-secret"  # pragma: allowlist secret
 
     @pytest.mark.requirement("AC-2")
     def test_manifest_yaml_is_empty_file(
@@ -560,6 +563,84 @@ class TestGetPolarisEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# get_polaris_oauth2_server_uri
+# ---------------------------------------------------------------------------
+
+
+class TestGetPolarisOAuth2ServerUri:
+    """Tests for get_polaris_oauth2_server_uri()."""
+
+    @pytest.mark.requirement("AC-2")
+    def test_env_var_overrides_manifest(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Explicit token endpoint env vars take priority."""
+        monkeypatch.setenv("POLARIS_OAUTH2_SERVER_URI", "http://auth.example/token")
+        manifest = _make_valid_manifest(tmp_path)
+
+        uri = get_polaris_oauth2_server_uri(manifest_path=manifest)
+
+        assert uri == "http://auth.example/token"
+
+    @pytest.mark.requirement("AC-2")
+    def test_derives_from_runtime_catalog_endpoint_before_manifest(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Runtime catalog endpoints should keep host and in-cluster paths aligned."""
+        monkeypatch.delenv("POLARIS_OAUTH2_SERVER_URI", raising=False)
+        monkeypatch.delenv("FLOE_E2E_POLARIS_OAUTH2_URI", raising=False)
+        manifest = _make_valid_manifest(tmp_path)
+
+        uri = get_polaris_oauth2_server_uri(
+            manifest_path=manifest,
+            catalog_endpoint="http://localhost:18181/api/catalog",
+        )
+
+        assert uri == "http://localhost:18181/api/catalog/v1/oauth/tokens"
+
+    @pytest.mark.requirement("AC-2")
+    def test_reads_token_url_from_manifest_when_no_runtime_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Manifest token_url is used when there is no explicit runtime endpoint."""
+        monkeypatch.delenv("POLARIS_OAUTH2_SERVER_URI", raising=False)
+        monkeypatch.delenv("FLOE_E2E_POLARIS_OAUTH2_URI", raising=False)
+        manifest = _make_valid_manifest(tmp_path)
+
+        uri = get_polaris_oauth2_server_uri(manifest_path=manifest)
+
+        assert uri == MANIFEST_POLARIS_OAUTH2_URI
+
+    @pytest.mark.requirement("AC-2")
+    def test_derives_from_manifest_endpoint_when_token_url_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Missing token_url falls back to the manifest catalog endpoint."""
+        monkeypatch.delenv("POLARIS_OAUTH2_SERVER_URI", raising=False)
+        monkeypatch.delenv("FLOE_E2E_POLARIS_OAUTH2_URI", raising=False)
+        manifest = _write_manifest(
+            tmp_path / "manifest.yaml",
+            {
+                "plugins": {
+                    "catalog": {
+                        "config": {
+                            "uri": "http://polaris.example/api/catalog",
+                            "oauth2": {
+                                "client_id": "id",
+                                "client_secret": "secret",  # pragma: allowlist secret
+                            },
+                        }
+                    }
+                }
+            },
+        )
+
+        uri = get_polaris_oauth2_server_uri(manifest_path=manifest)
+
+        assert uri == "http://polaris.example/api/catalog/v1/oauth/tokens"
+
+
+# ---------------------------------------------------------------------------
 # Cross-cutting: API contract tests
 # ---------------------------------------------------------------------------
 
@@ -608,9 +689,9 @@ class TestCredentialsAPIContract:
         second_id, second_secret = get_polaris_credentials(manifest_path=manifest)
 
         assert first_id == "first-call-id"
-        assert first_secret == "first-call-secret"
+        assert first_secret == "first-call-secret"  # pragma: allowlist secret
         assert second_id == "second-call-id"
-        assert second_secret == "second-call-secret"
+        assert second_secret == "second-call-secret"  # pragma: allowlist secret
         # Prove they are different (not cached/stale)
         assert first_id != second_id
         assert first_secret != second_secret
@@ -633,7 +714,7 @@ class TestCredentialsAPIContract:
                         "config": {
                             "oauth2": {
                                 "client_id": "first-id",
-                                "client_secret": "first-secret",
+                                "client_secret": "first-secret",  # pragma: allowlist secret
                             }
                         }
                     }
@@ -651,7 +732,7 @@ class TestCredentialsAPIContract:
                         "config": {
                             "oauth2": {
                                 "client_id": "second-id",
-                                "client_secret": "second-secret",
+                                "client_secret": "second-secret",  # pragma: allowlist secret
                             }
                         }
                     }

--- a/testing/tests/unit/test_credentials.py
+++ b/testing/tests/unit/test_credentials.py
@@ -21,6 +21,7 @@ from testing.fixtures.credentials import (
     get_polaris_credentials,
     get_polaris_endpoint,
     get_polaris_oauth2_server_uri,
+    resolve_manifest_path,
 )
 
 # ---------------------------------------------------------------------------
@@ -695,6 +696,33 @@ class TestCredentialsAPIContract:
         # Prove they are different (not cached/stale)
         assert first_id != second_id
         assert first_secret != second_secret
+
+    @pytest.mark.requirement("AC-2")
+    def test_resolve_manifest_path_normalizes_explicit_relative_paths(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Explicit manifest paths are normalized to absolute paths before use."""
+        monkeypatch.chdir(tmp_path)
+        manifest = Path("config") / ".." / "manifest.yaml"
+
+        resolved = resolve_manifest_path(manifest)
+
+        assert resolved == (tmp_path / "manifest.yaml").resolve(strict=False)
+        assert resolved.is_absolute()
+
+    @pytest.mark.requirement("AC-2")
+    def test_resolve_manifest_path_normalizes_environment_paths(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Manifest path env vars are normalized to absolute paths before use."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("FLOE_MANIFEST_PATH", "config/../manifest.yaml")
+        monkeypatch.delenv("POLARIS_MANIFEST_PATH", raising=False)
+
+        resolved = resolve_manifest_path()
+
+        assert resolved == (tmp_path / "manifest.yaml").resolve(strict=False)
+        assert resolved.is_absolute()
 
     @pytest.mark.requirement("AC-2")
     def test_no_caching_of_manifest_values(

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -536,6 +536,16 @@ def test_cli_loads_customer360_validation_manifest_by_default(
     tmp_path: Path,
 ) -> None:
     """The release validation CLI gets runnable evidence checks from a manifest by default."""
+    for name in (
+        "FLOE_DEMO_NAMESPACE",
+        "FLOE_DEMO_DAGSTER_URL",
+        "FLOE_DEMO_MARQUEZ_URL",
+        "FLOE_DEMO_JAEGER_URL",
+        "FLOE_DEMO_PLATFORM_EXPECTED_SERVICES",
+        "FLOE_DEMO_COMMAND_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
     module = importlib.import_module("testing.ci.validate_customer_360_demo")
     manifest = tmp_path / "validation.yaml"
     manifest.write_text(

--- a/testing/tests/unit/test_demo_makefile_kubeconfig.py
+++ b/testing/tests/unit/test_demo_makefile_kubeconfig.py
@@ -51,3 +51,18 @@ def test_devpod_sync_parses_kubeconfig_with_kubectl_not_yaml_regex() -> None:
     assert "urlparse" in sync_script
     assert "sed -nE" not in sync_script
     assert "config set-cluster" in sync_script
+
+
+@pytest.mark.requirement("197")
+def test_devpod_sync_waits_for_tunnel_readiness_before_returning() -> None:
+    """DevPod kubeconfig sync must not return while the SSH tunnel is still starting."""
+    sync_script = Path("scripts/devpod-sync-kubeconfig.sh").read_text()
+    env_example = Path(".env.example").read_text()
+
+    assert 'TUNNEL_TIMEOUT="${DEVPOD_TUNNEL_TIMEOUT:-120}"' in sync_script
+    assert 'TUNNEL_INTERVAL="${DEVPOD_TUNNEL_INTERVAL:-2}"' in sync_script
+    assert "while (( SECONDS < tunnel_deadline )); do" in sync_script
+    assert 'kubectl --kubeconfig "${LOCAL_KUBECONFIG}" cluster-info' in sync_script
+    assert 'kill -0 "${TUNNEL_PID}"' in sync_script
+    assert "SSH tunnel process exited before Kubernetes became reachable" in sync_script
+    assert "DEVPOD_TUNNEL_TIMEOUT=120" in env_example

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1513,6 +1513,24 @@ class TestMakefileDemoChain:
             )
 
     @pytest.mark.requirement("WU11-AC6")
+    def test_remote_demo_build_passes_same_image_ref_as_deploy(self) -> None:
+        """The DevPod demo build must use the same image ref Helm deploys.
+
+        Without command-line ``DEMO_IMAGE_*`` overrides, the remote build can
+        recompute a dirty tag from generated artifacts while Helm deploys the
+        local clean SHA tag, leaving Dagster pods in ``ErrImageNeverPull``.
+        """
+        content = _read_makefile_content()
+        body = _extract_target_body(content, "demo")
+
+        assert "--command" in body, "demo must use DevPod's explicit command flag."
+        assert "DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY)" in body
+        assert "DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG)" in body
+        assert "FLOE_DEMO_IMAGE_REPOSITORY=$(DEMO_IMAGE_REPOSITORY)" in body
+        assert "FLOE_DEMO_IMAGE_TAG=$(DEMO_IMAGE_TAG)" in body
+        assert "$(DEMO_IMAGE_HELM_SET_ARGS)" in body
+
+    @pytest.mark.requirement("WU11-AC6")
     def test_demo_local_starts_local_port_forwards(self) -> None:
         """Verify demo-local starts localhost port-forwards after deploying.
 

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -49,6 +49,7 @@ DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 MAKEFILE = REPO_ROOT / "Makefile"
 DEMO_PLUGIN_RESOLVER = REPO_ROOT / "scripts" / "resolve-demo-plugins.py"
 DEMO_MANIFEST = REPO_ROOT / "demo" / "manifest.yaml"
+DEMO_PORT_FORWARD_SCRIPT = REPO_ROOT / "scripts" / "demo-start-port-forwards.sh"
 
 # The three demo products: disk name (hyphenated) -> container name (underscore)
 DEMO_PRODUCTS: dict[str, str] = {
@@ -1539,18 +1540,21 @@ class TestMakefileDemoChain:
         """
         content = _read_makefile_content()
         body = _extract_target_body(content, "demo-local")
+        script = DEMO_PORT_FORWARD_SCRIPT.read_text()
 
         assert "KUBECONFIG" not in body, "demo-local port-forwards must use local kube context."
-        assert ".demo-pids" in body, "demo-local must write pids for make demo-stop."
-        for command in (
-            "kubectl port-forward svc/floe-platform-dagster-webserver 3100:3000 -n floe-dev",
-            "kubectl port-forward svc/floe-platform-polaris 8181:8181 8182:8182 -n floe-dev",
-            "kubectl port-forward svc/floe-platform-minio 9000:9000 9001:9001 -n floe-dev",
-            "kubectl port-forward svc/floe-platform-jaeger-query 16686:16686 -n floe-dev",
-            "kubectl port-forward svc/floe-platform-marquez 5100:5000 -n floe-dev",
-            "kubectl port-forward svc/floe-platform-otel 4317:4317 4318:4318 -n floe-dev",
+        assert "scripts/demo-start-port-forwards.sh" in body
+        assert ".demo-pids" in script, "helper must write pids for make demo-stop."
+        for service_suffix, port_mapping in (
+            ("dagster-webserver", "DAGSTER_HOST_PORT}:3000"),
+            ("polaris", "POLARIS_API_PORT}:8181"),
+            ("minio", "MINIO_API_PORT}:9000"),
+            ("jaeger-query", "JAEGER_PORT}:16686"),
+            ("marquez", "MARQUEZ_PORT}:5000"),
+            ("otel", "OTEL_GRPC_PORT}:4317"),
         ):
-            assert command in body, f"demo-local must start port-forward: {command}"
+            assert service_suffix in script
+            assert port_mapping in script
 
     @pytest.mark.requirement("WU11-AC6")
     def test_demo_local_prints_reachable_urls(self) -> None:
@@ -1565,6 +1569,57 @@ class TestMakefileDemoChain:
         assert "OTel HTTP:     http://localhost:4318" in body
         assert "Stop with: make demo-stop" in body
         assert "http://localhost:3000" not in body
+
+    @pytest.mark.requirement("WU11-AC6")
+    def test_demo_targets_use_ready_checked_port_forward_helper(self) -> None:
+        """Demo targets must not print ready before forwarded services respond."""
+        content = _read_makefile_content()
+        remote_body = _extract_target_body(content, "demo")
+        local_body = _extract_target_body(content, "demo-local")
+
+        assert (
+            'KUBECONFIG="$(DEVPOD_KUBECONFIG)" scripts/demo-start-port-forwards.sh' in remote_body
+        )
+        assert "scripts/demo-start-port-forwards.sh" in local_body
+
+    @pytest.mark.requirement("WU11-AC6")
+    def test_demo_port_forward_helper_waits_for_dagster_http_health(self) -> None:
+        """The shared helper must verify Dagster HTTP readiness before returning."""
+        assert DEMO_PORT_FORWARD_SCRIPT.exists(), "demo port-forward helper is missing"
+        script = DEMO_PORT_FORWARD_SCRIPT.read_text()
+
+        assert "/server_info" in script
+        assert "curl" in script
+        assert "wait_for_http" in script
+        assert '"${RELEASE}-dagster-webserver" "${DAGSTER_HOST_PORT}:3000"' in script
+        assert 'RELEASE="${FLOE_DEMO_RELEASE:-floe-platform}"' in script
+        assert 'DAGSTER_HOST_PORT="${FLOE_DEMO_DAGSTER_PORT:-3100}"' in script
+
+    @pytest.mark.requirement("WU11-AC6")
+    def test_demo_dbt_accepted_values_use_dbt_1_11_arguments_property(self) -> None:
+        """Demo dbt tests should not emit dbt 1.11 generic-test deprecations."""
+        for product in DEMO_PRODUCTS:
+            schema_path = REPO_ROOT / "demo" / product / "models" / "schema.yml"
+            schema = _load_values_yaml(schema_path)
+            for model in schema.get("models", []):
+                for column in model.get("columns", []):
+                    for test in column.get("tests", []):
+                        if not isinstance(test, dict):
+                            continue
+                        for test_name, config in test.items():
+                            if test_name not in {"accepted_values", "relationships"}:
+                                continue
+                            assert isinstance(config, dict)
+                            assert "arguments" in config, (
+                                f"{schema_path}:{model['name']}.{column['name']} "
+                                f"must nest {test_name} config under arguments"
+                            )
+                            deprecated_argument_keys = {"field", "to", "values"} & set(config)
+                            assert not deprecated_argument_keys, (
+                                f"{schema_path}:{model['name']}.{column['name']} "
+                                f"uses deprecated top-level {test_name} arguments: "
+                                f"{sorted(deprecated_argument_keys)}"
+                            )
 
 
 # ============================================================

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -370,6 +370,19 @@ class TestDockerfileMacrosAndManifest:
         )
 
     @pytest.mark.requirement("WU11-AC1")
+    def test_demo_manifest_marks_insecure_marquez_http_as_demo_environment(self) -> None:
+        """Demo HTTP lineage config must declare a non-production environment."""
+        manifest = yaml.safe_load(DEMO_MANIFEST.read_text())
+        lineage_backend = manifest["plugins"]["lineage_backend"]
+        config = lineage_backend["config"]
+
+        assert config["allow_insecure_http"] is True
+        assert config["environment"] == "demo", (
+            "demo/manifest.yaml allows in-cluster HTTP for Marquez and must "
+            "explicitly mark that plugin config as demo/non-production."
+        )
+
+    @pytest.mark.requirement("WU11-AC1")
     def test_dockerfile_copies_macros_directory(self) -> None:
         """Verify Dockerfile has a COPY instruction for the macros/ directory.
 

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -471,6 +471,17 @@ class TestDockerfilePipOperations:
                 f"pip install for requirements.txt must use --require-hashes. Line: {pip_line}"
             )
 
+    @pytest.mark.requirement("WU12-AC5")
+    def test_build_stage_suppresses_pip_root_warning(self) -> None:
+        """Build-stage pip runs as root, while the runtime image remains non-root."""
+        content = _read_dockerfile_raw()
+
+        assert "PIP_ROOT_USER_ACTION=ignore" in content, (
+            "Dockerfile build stage must explicitly suppress pip's root-user warning. "
+            "The runtime image still needs to switch to the dagster user."
+        )
+        assert "USER dagster" in content, "Runtime stage must continue to run as non-root user."
+
     @pytest.mark.requirement("WU12-AC2")
     def test_workspace_packages_use_no_deps(self) -> None:
         """Verify workspace package pip install uses --no-deps.

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -2651,6 +2651,25 @@ class TestGeneratedDefinitions:
             f"to generate definitions.py files. Recipe body:\n{body}"
         )
 
+    @pytest.mark.requirement("WU11-AC8")
+    def test_compile_demo_disables_predeploy_lineage_emission(self) -> None:
+        """compile-demo must not POST OpenLineage before Marquez is deployed.
+
+        The demo manifest keeps runtime lineage enabled. The pre-deploy
+        artifact-generation step runs before the platform services exist, so it
+        must explicitly disable compile-time lineage side effects.
+        """
+        content = _read_makefile_content()
+        body = _extract_target_body(content, "compile-demo")
+        assert body.strip(), (
+            "compile-demo target has no recipe body. Cannot verify lineage emission flag."
+        )
+        assert "--no-lineage-emission" in body, (
+            "compile-demo target must pass '--no-lineage-emission' so "
+            "pre-deploy artifact generation does not attempt Marquez before "
+            f"the platform exists. Recipe body:\n{body}"
+        )
+
 
 # ============================================================
 # WU-12: Docker Packaging Strategy — Structural Tests

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1620,6 +1620,20 @@ class TestMakefileDemoChain:
         assert 'DAGSTER_HOST_PORT="${FLOE_DEMO_DAGSTER_PORT:-3100}"' in script
 
     @pytest.mark.requirement("WU11-AC6")
+    def test_demo_port_forward_helper_waits_only_for_service_deployments(self) -> None:
+        """The helper must not wait on Helm hook/job pods that can complete."""
+        script = DEMO_PORT_FORWARD_SCRIPT.read_text()
+
+        assert 'rollout status "deployment/${deployment}"' in script
+        assert 'wait_for_deployment "${RELEASE}-dagster-webserver"' in script
+        assert 'wait_for_deployment "${RELEASE}-polaris"' in script
+        assert 'wait_for_deployment "${RELEASE}-minio"' in script
+        assert 'wait_for_deployment "${RELEASE}-jaeger"' in script
+        assert 'wait_for_deployment "${RELEASE}-marquez"' in script
+        assert 'wait_for_deployment "${RELEASE}-otel"' in script
+        assert "app.kubernetes.io/instance=${RELEASE}" not in script
+
+    @pytest.mark.requirement("WU11-AC6")
     def test_demo_dbt_accepted_values_use_dbt_1_11_arguments_property(self) -> None:
         """Demo dbt tests should not emit dbt 1.11 generic-test deprecations."""
         for product in DEMO_PRODUCTS:

--- a/testing/tests/unit/test_polaris_fixture.py
+++ b/testing/tests/unit/test_polaris_fixture.py
@@ -169,6 +169,7 @@ class TestCreatePolarisCatalog:
                 "polaris",
                 type="rest",
                 uri="http://test:8181/api/catalog",
+                **{"oauth2-server-uri": "http://test:8181/api/catalog/v1/oauth/tokens"},
                 warehouse="test_warehouse",
                 credential="test_client:test_secret",
                 scope="TEST_SCOPE",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ import subprocess
 import uuid
 import warnings
 from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -137,6 +138,19 @@ def _is_duplicate_polaris_grant_response(response: httpx.Response) -> bool:
         and "grant_records_pkey" in response.text
         and "sql-state '23505'" in response.text
     )
+
+
+@contextmanager
+def _suppress_httpx_info_logs() -> Generator[None, None, None]:
+    """Suppress expected httpx request summaries while preserving warnings."""
+    httpx_logger = logging.getLogger("httpx")
+    previous_level = httpx_logger.level
+    if httpx_logger.getEffectiveLevel() <= logging.INFO:
+        httpx_logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        httpx_logger.setLevel(previous_level)
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -817,15 +831,16 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         )
 
     # Step 2: Assign principal role to root principal (idempotent)
-    pr_assign_response = httpx.put(
-        f"{polaris_url}/api/management/v1/principals/root/principal-roles",
-        headers=headers,
-        json={"principalRole": {"name": principal_role}},
-        timeout=10.0,
-    )
+    with _suppress_httpx_info_logs():
+        pr_assign_response = httpx.put(
+            f"{polaris_url}/api/management/v1/principals/root/principal-roles",
+            headers=headers,
+            json={"principalRole": {"name": principal_role}},
+            timeout=10.0,
+        )
     if _is_duplicate_polaris_grant_response(pr_assign_response):
         logger.info(
-            "Principal role %s already assigned to root (duplicate grant record, HTTP 500)",
+            "Principal role %s already assigned to root (duplicate grant record)",
             principal_role,
         )
     elif pr_assign_response.status_code not in (200, 201, 204, 409):
@@ -849,15 +864,16 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         )
 
     # Step 4: Grant CATALOG_MANAGE_CONTENT privilege
-    grant_response = httpx.put(
-        f"{polaris_url}/api/management/v1/catalogs/{catalog_name}"
-        "/catalog-roles/catalog_admin/grants",
-        headers=headers,
-        json={"grant": {"type": "catalog", "privilege": "CATALOG_MANAGE_CONTENT"}},
-        timeout=10.0,
-    )
+    with _suppress_httpx_info_logs():
+        grant_response = httpx.put(
+            f"{polaris_url}/api/management/v1/catalogs/{catalog_name}"
+            "/catalog-roles/catalog_admin/grants",
+            headers=headers,
+            json={"grant": {"type": "catalog", "privilege": "CATALOG_MANAGE_CONTENT"}},
+            timeout=10.0,
+        )
     if _is_duplicate_polaris_grant_response(grant_response):
-        logger.info("CATALOG_MANAGE_CONTENT already granted (duplicate grant record, HTTP 500)")
+        logger.info("CATALOG_MANAGE_CONTENT already granted (duplicate grant record)")
     elif grant_response.status_code not in (200, 201, 204, 409):
         logger.warning(
             "Failed to grant CATALOG_MANAGE_CONTENT: HTTP %s",
@@ -865,15 +881,16 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         )
 
     # Step 5: Assign catalog role to principal role (idempotent — 200/204 ok, 409 exists)
-    assign_response = httpx.put(
-        f"{polaris_url}/api/management/v1/principal-roles/{principal_role}/catalog-roles/{catalog_name}",
-        headers=headers,
-        json={"catalogRole": {"name": "catalog_admin"}},
-        timeout=10.0,
-    )
+    with _suppress_httpx_info_logs():
+        assign_response = httpx.put(
+            f"{polaris_url}/api/management/v1/principal-roles/{principal_role}/catalog-roles/{catalog_name}",
+            headers=headers,
+            json={"catalogRole": {"name": "catalog_admin"}},
+            timeout=10.0,
+        )
     if _is_duplicate_polaris_grant_response(assign_response):
         logger.info(
-            "catalog_admin already assigned to %s (duplicate grant record, HTTP 500)",
+            "catalog_admin already assigned to %s (duplicate grant record)",
             principal_role,
         )
     elif assign_response.status_code not in (200, 204, 409):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -29,6 +29,7 @@ import yaml
 from testing.fixtures.credentials import (
     get_minio_credentials,
     get_polaris_credentials,
+    get_polaris_oauth2_server_uri,
     get_polaris_scope,
     get_polaris_warehouse,
     resolve_manifest_path,
@@ -226,6 +227,7 @@ def pytest_collection_modifyitems(
 
         test_func = item.function
         test_name = item.nodeid
+        item_markers = {mark.name for mark in item.iter_markers()}
 
         try:
             source = inspect.getsource(test_func)
@@ -253,7 +255,7 @@ def pytest_collection_modifyitems(
                 )
 
         # TQR-010: dry_run=True in E2E tests
-        if re.search(r"dry_run\s*=\s*True", source):
+        if "developer_workflow" not in item_markers and re.search(r"dry_run\s*=\s*True", source):
             violations.append(
                 f"TQR WARNING: {test_name} - TQR-010 violation: "
                 "dry_run=True found in E2E test (E2E should execute real operations)"
@@ -734,6 +736,10 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         **{
             "type": "rest",
             "uri": f"{polaris_url}/api/catalog",
+            "oauth2-server-uri": get_polaris_oauth2_server_uri(
+                _MANIFEST_PATH,
+                catalog_endpoint=f"{polaris_url}/api/catalog",
+            ),
             "credential": polaris_credential,
             "scope": _manifest_scope,
             "warehouse": os.environ.get("POLARIS_WAREHOUSE", _manifest_warehouse),

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -130,6 +130,15 @@ def _resolve_polaris_credential(
     return credential, client_id, client_secret
 
 
+def _is_duplicate_polaris_grant_response(response: httpx.Response) -> bool:
+    """Return True when Polaris reports an idempotent duplicate grant as HTTP 500."""
+    return (
+        response.status_code == 500
+        and "grant_records_pkey" in response.text
+        and "sql-state '23505'" in response.text
+    )
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Register custom markers and E2E-scoped rerun config."""
     config.addinivalue_line(
@@ -814,7 +823,12 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         json={"principalRole": {"name": principal_role}},
         timeout=10.0,
     )
-    if pr_assign_response.status_code not in (200, 201, 204, 409):
+    if _is_duplicate_polaris_grant_response(pr_assign_response):
+        logger.info(
+            "Principal role %s already assigned to root (duplicate grant record, HTTP 500)",
+            principal_role,
+        )
+    elif pr_assign_response.status_code not in (200, 201, 204, 409):
         logger.warning(
             "Failed to assign principal role %s to root: HTTP %s",
             principal_role,
@@ -842,7 +856,9 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         json={"grant": {"type": "catalog", "privilege": "CATALOG_MANAGE_CONTENT"}},
         timeout=10.0,
     )
-    if grant_response.status_code not in (200, 201, 204, 409):
+    if _is_duplicate_polaris_grant_response(grant_response):
+        logger.info("CATALOG_MANAGE_CONTENT already granted (duplicate grant record, HTTP 500)")
+    elif grant_response.status_code not in (200, 201, 204, 409):
         logger.warning(
             "Failed to grant CATALOG_MANAGE_CONTENT: HTTP %s",
             grant_response.status_code,
@@ -855,7 +871,12 @@ def polaris_client(wait_for_service: Callable[..., None]) -> Any:
         json={"catalogRole": {"name": "catalog_admin"}},
         timeout=10.0,
     )
-    if assign_response.status_code not in (200, 204, 409):
+    if _is_duplicate_polaris_grant_response(assign_response):
+        logger.info(
+            "catalog_admin already assigned to %s (duplicate grant record, HTTP 500)",
+            principal_role,
+        )
+    elif assign_response.status_code not in (200, 204, 409):
         logger.warning(
             "Failed to assign catalog_admin to %s: HTTP %s",
             principal_role,

--- a/tests/e2e/dbt_utils.py
+++ b/tests/e2e/dbt_utils.py
@@ -20,6 +20,7 @@ import boto3
 from testing.fixtures.credentials import (
     get_minio_credentials,
     get_polaris_credentials,
+    get_polaris_oauth2_server_uri,
     get_polaris_scope,
     get_polaris_warehouse,
 )
@@ -79,6 +80,9 @@ def _get_polaris_catalog(*, fresh: bool = False) -> Any:
             **{
                 "type": "rest",
                 "uri": polaris_url,
+                "oauth2-server-uri": get_polaris_oauth2_server_uri(
+                    catalog_endpoint=polaris_url,
+                ),
                 "credential": os.environ.get("POLARIS_CREDENTIAL", default_cred),
                 "scope": os.environ.get("POLARIS_SCOPE", get_polaris_scope()),
                 "warehouse": os.environ.get("POLARIS_WAREHOUSE", get_polaris_warehouse()),

--- a/tests/e2e/test_platform_deployment_e2e.py
+++ b/tests/e2e/test_platform_deployment_e2e.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -479,10 +478,6 @@ class TestPlatformDeployment:
         successfully pulled and the pod is running.
         """
         if not _cube_store_enabled_in_test_values():
-            warnings.warn(
-                "Cube Store disabled in values-test.yaml; verifying rollback state instead.",
-                stacklevel=2,
-            )
             _assert_cube_store_rollback_state()
             return
 
@@ -507,10 +502,6 @@ class TestPlatformDeployment:
         is passing, meaning Cube Store is accepting connections.
         """
         if not _cube_store_enabled_in_test_values():
-            warnings.warn(
-                "Cube Store disabled in values-test.yaml; verifying rollback state instead.",
-                stacklevel=2,
-            )
             _assert_cube_store_rollback_state()
             return
 

--- a/tests/e2e/test_promotion.py
+++ b/tests/e2e/test_promotion.py
@@ -443,7 +443,9 @@ class TestPromotion(IntegrationTestBase):
             )
 
             # Assert trace_id is populated (OTel correlation)
-            assert len(record.trace_id) > 0, "trace_id must be populated for OTel correlation"
+            assert record.trace_id and record.trace_id.strip(), (
+                "trace_id must be populated for OTel correlation"
+            )
 
             # Assert timestamps
             assert record.promoted_at is not None, "promoted_at must be set"
@@ -510,6 +512,7 @@ class TestPromotion(IntegrationTestBase):
             )
 
     @pytest.mark.e2e
+    @pytest.mark.developer_workflow
     @pytest.mark.requirement("FR-070")
     def test_dry_run_gates_execute(self) -> None:
         """Test that dry_run=True executes gates but makes no state changes.
@@ -554,7 +557,7 @@ class TestPromotion(IntegrationTestBase):
             assert record.promotion_id is not None, "promotion_id must be set"
 
             # Assert trace_id exists
-            assert len(record.trace_id) > 0, "trace_id must be populated"
+            assert record.trace_id and record.trace_id.strip(), "trace_id must be populated"
 
         except (ConnectionError, OSError, Exception) as e:
             # Infrastructure error is expected when OCI registry unavailable
@@ -645,7 +648,7 @@ class TestPromotion(IntegrationTestBase):
 
             # Validate trace_id is a valid hex string (OTel format)
             assert record.trace_id is not None, "trace_id must be present"
-            assert len(record.trace_id) > 0, "trace_id must not be empty"
+            assert record.trace_id.strip(), "trace_id must not be empty"
 
             # OTel trace IDs are 32 hex characters
             # The promote() method formats as: format(span_context.trace_id, "032x")
@@ -702,7 +705,7 @@ class TestPromotion(IntegrationTestBase):
 
             # If we get a record, check for failed gates
             failed_gates = [gr for gr in record.gate_results if gr.status == GateStatus.FAILED]
-            assert len(failed_gates) > 0, (
+            assert failed_gates, (
                 "At least one gate should have FAILED status with invalid scanner command"
             )
 

--- a/tests/e2e/tests/test_polaris_jdbc_durability.py
+++ b/tests/e2e/tests/test_polaris_jdbc_durability.py
@@ -36,6 +36,7 @@ from testing.fixtures.credentials import (
 from testing.fixtures.polaris import (
     PolarisConfig,
     create_polaris_catalog,
+    drop_test_namespace,
     rewrite_table_io_for_host_access,
 )
 from testing.fixtures.polling import wait_for_condition
@@ -362,8 +363,7 @@ class TestPolarisJdbcDurability(IntegrationTestBase):
 
         # Cleanup (best-effort)
         try:
-            fresh_catalog.purge_table(fqn)
-            fresh_catalog.drop_namespace(ns_name)
+            drop_test_namespace(fresh_catalog, ns_name)
         except Exception as exc:
             # Non-fatal — test already passed; cleanup is courtesy
             import logging

--- a/tests/unit/test_dbt_namespace_reset.py
+++ b/tests/unit/test_dbt_namespace_reset.py
@@ -60,6 +60,7 @@ def test_get_polaris_catalog_uses_env_endpoints_without_eager_service_resolution
         {
             "type": "rest",
             "uri": "http://example.test/api/catalog",
+            "oauth2-server-uri": "http://example.test/api/catalog/v1/oauth/tokens",
             "credential": "id:secret",
             "scope": get_polaris_scope(),
             "warehouse": get_polaris_warehouse(),

--- a/tests/unit/test_flux_source_selection.py
+++ b/tests/unit/test_flux_source_selection.py
@@ -277,3 +277,43 @@ def test_render_flux_manifests_merges_demo_image_into_inline_values(
     assert "existingConfig: {enabled: true}" in rendered_content
     assert 'repository: "floe-dagster-demo"' in rendered_content
     assert 'tag: "local"' in rendered_content
+
+
+@pytest.mark.requirement("AC-2")
+def test_build_demo_image_passes_resolved_image_ref_to_make(tmp_path: Path) -> None:
+    """Kind bootstrap must build the same demo image ref it deploys.
+
+    ``build-demo-image`` can derive a dirty tag from generated artifacts if
+    the resolved image ref is not passed as Make variables. The bootstrap
+    path must therefore forward both the shell ``FLOE_*`` contract and the
+    Make ``DEMO_IMAGE_*`` contract.
+    """
+    result = _run_setup_function(
+        textwrap.dedent(
+            """\
+            mkdir -p "${PROJECT_ROOT}/docker/dagster-demo"
+            touch "${PROJECT_ROOT}/docker/dagster-demo/Dockerfile"
+
+            make() {
+                printf 'make_args=%s\\n' "$*"
+                printf 'DEMO_IMAGE_REPOSITORY=%s\\n' "${DEMO_IMAGE_REPOSITORY:-}"
+                printf 'DEMO_IMAGE_TAG=%s\\n' "${DEMO_IMAGE_TAG:-}"
+                printf 'FLOE_DEMO_IMAGE_REPOSITORY=%s\\n' "${FLOE_DEMO_IMAGE_REPOSITORY:-}"
+                printf 'FLOE_DEMO_IMAGE_TAG=%s\\n' "${FLOE_DEMO_IMAGE_TAG:-}"
+            }
+
+            build_demo_image
+            """
+        ),
+        tmp_path,
+    )
+
+    demo_repo = "floe-dagster-demo"  # pragma: allowlist secret
+
+    assert result.returncode == 0, result.stderr
+    assert "make_args=-C " in result.stdout
+    assert " build-demo-image" in result.stdout
+    assert f"DEMO_IMAGE_REPOSITORY={demo_repo}" in result.stdout
+    assert "DEMO_IMAGE_TAG=local" in result.stdout
+    assert f"FLOE_DEMO_IMAGE_REPOSITORY={demo_repo}" in result.stdout
+    assert "FLOE_DEMO_IMAGE_TAG=local" in result.stdout

--- a/tests/unit/test_polaris_duplicate_grant_response.py
+++ b/tests/unit/test_polaris_duplicate_grant_response.py
@@ -1,0 +1,26 @@
+"""Unit tests for Polaris duplicate grant response handling in E2E fixtures."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def test_duplicate_polaris_grant_500_matches_helm_bootstrap_signature() -> None:
+    """The E2E fixture should treat duplicate grant records like Helm bootstrap."""
+    from tests.e2e.conftest import _is_duplicate_polaris_grant_response
+
+    response = httpx.Response(
+        500,
+        text="duplicate key value violates unique constraint grant_records_pkey; sql-state '23505'",
+    )
+
+    assert _is_duplicate_polaris_grant_response(response) is True
+
+
+def test_duplicate_polaris_grant_helper_rejects_unexpected_500() -> None:
+    """Unexpected Polaris HTTP 500 responses must remain visible."""
+    from tests.e2e.conftest import _is_duplicate_polaris_grant_response
+
+    response = httpx.Response(500, text="database unavailable")
+
+    assert _is_duplicate_polaris_grant_response(response) is False

--- a/tests/unit/test_polaris_duplicate_grant_response.py
+++ b/tests/unit/test_polaris_duplicate_grant_response.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import httpx
 
 
@@ -24,3 +26,27 @@ def test_duplicate_polaris_grant_helper_rejects_unexpected_500() -> None:
     response = httpx.Response(500, text="database unavailable")
 
     assert _is_duplicate_polaris_grant_response(response) is False
+
+
+def test_duplicate_grant_context_suppresses_expected_httpx_info_noise() -> None:
+    """Expected duplicate-grant retries should not print scary httpx 500 lines."""
+    from tests.e2e.conftest import _suppress_httpx_info_logs
+
+    httpx_logger = logging.getLogger("httpx")
+    original_level = httpx_logger.level
+    try:
+        httpx_logger.setLevel(logging.INFO)
+        with _suppress_httpx_info_logs():
+            assert httpx_logger.level == logging.WARNING
+        assert httpx_logger.level == logging.INFO
+    finally:
+        httpx_logger.setLevel(original_level)
+
+
+def test_duplicate_grant_fixture_log_messages_avoid_http_500_text() -> None:
+    """Known duplicate-grant info messages should not contain literal HTTP 500."""
+    from pathlib import Path
+
+    source = Path("tests/e2e/conftest.py").read_text(encoding="utf-8")
+
+    assert "duplicate grant record, HTTP 500" not in source

--- a/tests/unit/test_polaris_jdbc_durability_cleanup.py
+++ b/tests/unit/test_polaris_jdbc_durability_cleanup.py
@@ -1,0 +1,13 @@
+"""Regression tests for Polaris JDBC durability cleanup behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_polaris_jdbc_durability_cleanup_does_not_require_purge_enabled() -> None:
+    """The restart durability test must clean up without requiring Polaris purge."""
+    source = Path("tests/e2e/tests/test_polaris_jdbc_durability.py").read_text(encoding="utf-8")
+
+    assert ".purge_table(" not in source
+    assert "drop_test_namespace(fresh_catalog, ns_name)" in source

--- a/tests/unit/test_unit_c_boundary_wrapper.py
+++ b/tests/unit/test_unit_c_boundary_wrapper.py
@@ -34,6 +34,8 @@ def test_boundary_wrapper_restores_demo_image_before_waiting_for_flux() -> None:
     assert "ensure_remote_demo_image_loaded()" in script
     assert "sync_devpod_checkout" in script
     assert 'local demo_image="${FLOE_DEMO_IMAGE}"' in script
+    assert "DEMO_IMAGE_REPOSITORY=${image_repository_q}" in script
+    assert "DEMO_IMAGE_TAG=${image_tag_q}" in script
     assert "FLOE_DEMO_IMAGE_REPOSITORY=${image_repository_q}" in script
     assert "FLOE_DEMO_IMAGE_TAG=${image_tag_q}" in script
     assert "KIND_CLUSTER_NAME=${kind_cluster_q} make build-demo-image" in script


### PR DESCRIPTION
## Summary

- Keeps compile-time lineage emission opt-in so demo/package build steps no longer emit misleading pre-deploy Marquez connection failures before Marquez exists.
- Makes in-cluster Marquez HTTP explicit and manifest-driven for the demo environment, while preserving warnings for production/default insecure HTTP paths.
- Quiets expected Polaris duplicate-grant HTTP 500 fixture noise without masking unexpected 500s, and fixes the Polaris JDBC durability cleanup path to avoid requiring destructive purge to be enabled.
- Adds regression coverage for lineage emission defaults, manifest-driven Marquez HTTP config, duplicate-grant log suppression, and non-purge Polaris durability cleanup.

## Validation

- `make lint`
- `make typecheck`
- `make test-unit`
- pre-push hooks: ruff, format, mypy, dbt version requirements, bandit, uv-secure, unit+coverage, contract tests, no hardcoded sleep, traceability, Helm lint
- DevPod + Hetzner standard E2E on settled cluster: `249 passed, 83 deselected, 1 warning in 702.30s (0:11:42)`
- Final runtime-noise scan found no matches for: lineage `ConnectError`, pip root warnings, Polaris duplicate-grant HTTP 500 text, insecure Marquez HTTP warnings, `FLOE_ALLOW_INSECURE_HTTP`, or Polaris durability `Best-effort cleanup failed`.

## Notes

- `83 deselected` is expected for the standard E2E lane because destructive tests are excluded.
- The remaining pytest warning is the tracked third-party `gql` deprecation in #295.
- During validation, an immediate post-push rerun exposed a Flux settlement race where the platform upgraded during E2E and restarted PostgreSQL. The settled rerun passed; the validation-harness fix is tracked in #297.
- The existing detached DevPod wrapper hang remains tracked in #296.

Refs #285
Refs #295
Refs #296
Refs #297
