### PR TITLE
Fix destructive E2E readiness sequencing

### DIFF
--- a/plugins/floe-quality-gx/src/floe_quality_gx/plugin.py
+++ b/plugins/floe-quality-gx/src/floe_quality_gx/plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from typing import TYPE_CHECKING, Any
 
 from floe_core.plugin_metadata import HealthState, HealthStatus
@@ -213,22 +214,20 @@ class GreatExpectationsPlugin(QualityPlugin):
             timeout: Maximum time in seconds to wait for response.
                 Not used by this plugin; accepted for base ABC compatibility.
 
-        Returns HEALTHY if Great Expectations can be imported.
+        Returns HEALTHY if Great Expectations is discoverable.
         """
-        try:
-            import great_expectations  # noqa: F401
-
+        if importlib.util.find_spec("great_expectations") is not None:
             return HealthStatus(
                 state=HealthState.HEALTHY,
                 message="Great Expectations is available",
                 details={"gx_available": True},
             )
-        except ImportError:
-            return HealthStatus(
-                state=HealthState.UNHEALTHY,
-                message="Great Expectations is not installed",
-                details={"gx_available": False},
-            )
+
+        return HealthStatus(
+            state=HealthState.UNHEALTHY,
+            message="Great Expectations is not installed",
+            details={"gx_available": False},
+        )
 
     def get_config_schema(self) -> type[BaseModel]:
         """Return QualityConfig as the configuration schema (FR-010)."""

--- a/plugins/floe-quality-gx/tests/unit/test_plugin.py
+++ b/plugins/floe-quality-gx/tests/unit/test_plugin.py
@@ -9,6 +9,8 @@ Tests:
 
 from __future__ import annotations
 
+import builtins
+import importlib.util
 from typing import Any
 
 import pytest
@@ -288,6 +290,46 @@ class TestGreatExpectationsPluginHealthCheck:
         """health_check includes gx_available in details."""
         status = gx_plugin.health_check()
         assert "gx_available" in status.details
+
+    @pytest.mark.requirement("FR-009")
+    def test_health_check_does_not_import_great_expectations(
+        self,
+        gx_plugin,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """health_check uses fast module discovery rather than importing GX."""
+        real_import = builtins.__import__
+
+        def import_without_gx(name: str, *args: object, **kwargs: object) -> object:
+            if name == "great_expectations":
+                raise AssertionError("health_check must not import great_expectations")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(
+            importlib.util,
+            "find_spec",
+            lambda name: object() if name == "great_expectations" else None,
+        )
+        monkeypatch.setattr(builtins, "__import__", import_without_gx)
+
+        status = gx_plugin.health_check()
+
+        assert status.state.value == "healthy"
+        assert status.details["gx_available"] is True
+
+    @pytest.mark.requirement("FR-009")
+    def test_health_check_reports_unavailable_when_gx_module_missing(
+        self,
+        gx_plugin,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """health_check reports unhealthy when Great Expectations is not installed."""
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+        status = gx_plugin.health_check()
+
+        assert status.state.value == "unhealthy"
+        assert status.details["gx_available"] is False
 
 
 class TestGreatExpectationsPluginConfigSchema:

--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -21,6 +21,9 @@
 #                        retained only for debugging DevPod image transport.
 #   DEVPOD_REMOTE_WORKDIR Remote repository root inside the workspace
 #                        (default: /workspace).
+#   DEVPOD_REMOTE_E2E_MAKE_TARGET Make target to run after Kind bootstrap
+#                        (default: test-e2e). Use test-e2e-full for release
+#                        validation with destructive tests.
 #   DEVPOD_REMOTE_E2E_TIMEOUT Remote E2E timeout in seconds (default: 7200).
 #   DEVPOD_REMOTE_POLL_INTERVAL Remote E2E polling interval in seconds
 #                        (default: 20).
@@ -55,6 +58,7 @@ NAMESPACE="${TEST_NAMESPACE:-floe-test}"
 PROVIDER="${DEVPOD_PROVIDER:-hetzner}"
 DEVPOD_E2E_EXECUTION="${DEVPOD_E2E_EXECUTION:-remote}"
 DEVPOD_REMOTE_WORKDIR="${DEVPOD_REMOTE_WORKDIR:-/workspace}"
+DEVPOD_REMOTE_E2E_MAKE_TARGET="${DEVPOD_REMOTE_E2E_MAKE_TARGET:-test-e2e}"
 DEVPOD_REMOTE_RUN_ROOT="${DEVPOD_REMOTE_RUN_ROOT:-/tmp/floe-devpod-e2e}"
 DEVPOD_REMOTE_E2E_TIMEOUT="${DEVPOD_REMOTE_E2E_TIMEOUT:-7200}"
 DEVPOD_REMOTE_POLL_INTERVAL="${DEVPOD_REMOTE_POLL_INTERVAL:-20}"
@@ -174,6 +178,11 @@ if [[ "${DEVPOD_ENABLE_REMOTE_TUNNELS}" != "0" && "${DEVPOD_ENABLE_REMOTE_TUNNEL
     exit 1
 fi
 
+if [[ -z "${DEVPOD_REMOTE_E2E_MAKE_TARGET}" ]]; then
+    error "Invalid DEVPOD_REMOTE_E2E_MAKE_TARGET: value cannot be empty"
+    exit 1
+fi
+
 recover_workspace_after_up_failure() {
     local deadline=$((SECONDS + DEVPOD_UP_RECOVERY_TIMEOUT))
     log "devpod up returned failure; checking whether workspace '${WORKSPACE}' is running before cleanup..."
@@ -209,14 +218,20 @@ provision_workspace() {
 start_remote_e2e_run() {
     local run_dir_q
     local workdir_q
+    local make_target_q
     local remote_script
+    local start_output=""
+    local start_status=0
+    local remote_dir=""
     run_dir_q="$(shell_quote "${REMOTE_RUN_DIR}")"
     workdir_q="$(shell_quote "${DEVPOD_REMOTE_WORKDIR}")"
+    make_target_q="$(shell_quote "${DEVPOD_REMOTE_E2E_MAKE_TARGET}")"
 
     remote_script=$(cat <<REMOTE_SCRIPT
 set -euo pipefail
 run_dir=${run_dir_q}
 workdir=${workdir_q}
+make_target=${make_target_q}
 mkdir -p "\${run_dir}/artifacts"
 rm -f "\${run_dir}/exit-code" "\${run_dir}/output.log" "\${run_dir}/nohup.log"
 cat > "\${run_dir}/run.sh" <<'REMOTE_RUN'
@@ -228,7 +243,7 @@ mkdir -p "\${FLOE_REMOTE_RUN_DIR}/artifacts"
     echo "[remote-e2e] workdir=\${FLOE_REMOTE_WORKDIR}"
     cd "\${FLOE_REMOTE_WORKDIR}"
     SKIP_MONITORING=\${SKIP_MONITORING:-true} make kind-up
-    IMAGE_LOAD_METHOD=kind make test-e2e
+    IMAGE_LOAD_METHOD=kind make "\${FLOE_REMOTE_E2E_MAKE_TARGET}"
 } > "\${FLOE_REMOTE_RUN_DIR}/output.log" 2>&1
 rc=\$?
 cp -a "\${FLOE_REMOTE_WORKDIR}/test-artifacts/." "\${FLOE_REMOTE_RUN_DIR}/artifacts/" 2>/dev/null || true
@@ -237,14 +252,34 @@ echo "\${rc}" > "\${FLOE_REMOTE_RUN_DIR}/exit-code"
 exit 0
 REMOTE_RUN
 chmod +x "\${run_dir}/run.sh"
-FLOE_REMOTE_WORKDIR="\${workdir}" FLOE_REMOTE_RUN_DIR="\${run_dir}" \
+FLOE_REMOTE_WORKDIR="\${workdir}" FLOE_REMOTE_RUN_DIR="\${run_dir}" FLOE_REMOTE_E2E_MAKE_TARGET="\${make_target}" \
     nohup bash "\${run_dir}/run.sh" > "\${run_dir}/nohup.log" 2>&1 < /dev/null &
 echo \$! > "\${run_dir}/pid"
 printf '%s\n' "\${run_dir}"
 REMOTE_SCRIPT
 )
 
-    devpod_remote_bash "${remote_script}"
+    set +e
+    start_output="$(devpod_remote_bash "${remote_script}" 2>&1)"
+    start_status=$?
+    set -e
+
+    remote_dir="$(printf '%s\n' "${start_output}" | grep -Fx "${REMOTE_RUN_DIR}" | tail -1 || true)"
+    if [[ -n "${remote_dir}" ]]; then
+        if [[ "${start_status}" -ne 0 ]]; then
+            error "DevPod SSH reported failure after remote E2E start; continuing with detached run: ${start_output}"
+        fi
+        printf '%s\n' "${remote_dir}"
+        return 0
+    fi
+
+    if [[ "${start_status}" -eq 0 ]]; then
+        printf '%s\n' "${start_output}"
+        return 0
+    fi
+
+    printf '%s\n' "${start_output}" >&2
+    return "${start_status}"
 }
 
 poll_remote_e2e_run() {

--- a/testing/fixtures/polling.py
+++ b/testing/fixtures/polling.py
@@ -27,6 +27,7 @@ import socket
 import time
 from collections.abc import Callable
 
+import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -209,6 +210,75 @@ def wait_for_service(
     )
 
 
+def wait_for_http_status(
+    url: str,
+    expected_status: int = 200,
+    timeout: float = 60.0,
+    interval: float = 3.0,
+    request_timeout: float = 5.0,
+    description: str | None = None,
+    *,
+    raise_on_timeout: bool = True,
+) -> bool:
+    """Wait for an HTTP endpoint to return a specific status code.
+
+    Use this for readiness endpoints where TCP readiness or pod readiness is
+    insufficient, such as Quarkus health checks that return 503 until
+    dependencies have settled.
+
+    Args:
+        url: Full HTTP URL to poll.
+        expected_status: HTTP status code that indicates readiness.
+            Defaults to 200.
+        timeout: Maximum wait time in seconds. Defaults to 60.0.
+        interval: Poll interval in seconds. Defaults to 3.0.
+        request_timeout: Timeout for each HTTP request in seconds. Defaults to 5.0.
+        description: Description for timeout errors. Defaults to the URL.
+        raise_on_timeout: If True, raise on timeout. Defaults to True.
+
+    Returns:
+        True if endpoint returned the expected status within timeout.
+        False if raise_on_timeout=False and timeout occurred.
+
+    Raises:
+        PollingTimeoutError: If endpoint did not return the expected status
+            within timeout and raise_on_timeout=True.
+    """
+    effective_description = description or f"HTTP {expected_status} from {url}"
+    last_status: int | None = None
+    last_error: Exception | None = None
+
+    def check_http_status() -> bool:
+        nonlocal last_status, last_error
+        try:
+            response = httpx.get(url, timeout=request_timeout)
+        except (httpx.HTTPError, OSError) as exc:
+            last_error = exc
+            return False
+
+        last_status = response.status_code
+        last_error = None
+        return response.status_code == expected_status
+
+    ready = wait_for_condition(
+        check_http_status,
+        timeout=timeout,
+        interval=interval,
+        description=effective_description,
+        raise_on_timeout=False,
+    )
+    if ready:
+        return True
+
+    if not raise_on_timeout:
+        return False
+
+    if last_status is not None:
+        effective_description = f"{effective_description} (last HTTP status {last_status})"
+
+    raise PollingTimeoutError(effective_description, timeout, last_error)
+
+
 def _tcp_check(host: str, port: int, timeout: float = 5.0) -> bool:
     """Check if a TCP connection can be established.
 
@@ -232,5 +302,6 @@ __all__ = [
     "PollingConfig",
     "PollingTimeoutError",
     "wait_for_condition",
+    "wait_for_http_status",
     "wait_for_service",
 ]

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -565,6 +565,7 @@ validation:
         def validate(self) -> ValidationResult:
             return ValidationResult(status="PASS")
 
+    monkeypatch.delenv("FLOE_DEMO_NAMESPACE", raising=False)
     monkeypatch.setenv("FLOE_DEMO_VALIDATION_MANIFEST", str(manifest))
     monkeypatch.setattr("sys.argv", ["validate_customer_360_demo"])
     monkeypatch.setattr(module, "Customer360Validator", FakeValidator)

--- a/testing/tests/unit/test_polling.py
+++ b/testing/tests/unit/test_polling.py
@@ -15,6 +15,7 @@ from testing.fixtures.polling import (
     PollingConfig,
     PollingTimeoutError,
     wait_for_condition,
+    wait_for_http_status,
     wait_for_service,
 )
 
@@ -178,6 +179,91 @@ class TestWaitForService:
         with patch("testing.fixtures.polling._tcp_check", return_value=False):
             result = wait_for_service("unavailable", 9999, timeout=0.2, raise_on_timeout=False)
             assert result is False
+
+
+class TestWaitForHttpStatus:
+    """Tests for wait_for_http_status() function."""
+
+    @pytest.mark.requirement("9c-FR-016")
+    def test_returns_true_when_expected_status_seen(self) -> None:
+        """Test wait_for_http_status returns True when endpoint returns expected status."""
+        response = MagicMock(status_code=200)
+
+        with patch("testing.fixtures.polling.httpx.get", return_value=response):
+            result = wait_for_http_status(
+                "http://polaris:8182/q/health/ready",
+                timeout=5.0,
+            )
+
+        assert result is True
+
+    @pytest.mark.requirement("9c-FR-016")
+    def test_polls_until_expected_status_seen(self) -> None:
+        """Test wait_for_http_status retries transient non-ready statuses."""
+        responses = [
+            MagicMock(status_code=503),
+            MagicMock(status_code=200),
+        ]
+
+        with patch("testing.fixtures.polling.httpx.get", side_effect=responses) as mock_get:
+            result = wait_for_http_status(
+                "http://polaris:8182/q/health/ready",
+                timeout=5.0,
+                interval=0.1,
+            )
+
+        assert result is True
+        assert mock_get.call_count == 2
+
+    @pytest.mark.requirement("9c-FR-016")
+    def test_raises_timeout_with_last_status(self) -> None:
+        """Test timeout error includes the last HTTP status observed."""
+        response = MagicMock(status_code=503)
+
+        with patch("testing.fixtures.polling.httpx.get", return_value=response):
+            with pytest.raises(PollingTimeoutError) as exc_info:
+                wait_for_http_status(
+                    "http://polaris:8182/q/health/ready",
+                    timeout=0.2,
+                    interval=0.1,
+                    description="Polaris readiness",
+                )
+
+        assert "Polaris readiness" in str(exc_info.value)
+        assert "last HTTP status 503" in str(exc_info.value)
+
+    @pytest.mark.requirement("9c-FR-016")
+    def test_no_raise_on_timeout_returns_false(self) -> None:
+        """Test wait_for_http_status returns False when raise_on_timeout=False."""
+        response = MagicMock(status_code=503)
+
+        with patch("testing.fixtures.polling.httpx.get", return_value=response):
+            result = wait_for_http_status(
+                "http://polaris:8182/q/health/ready",
+                timeout=0.2,
+                interval=0.1,
+                raise_on_timeout=False,
+            )
+
+        assert result is False
+
+    @pytest.mark.requirement("9c-FR-016")
+    def test_raises_timeout_with_last_http_error(self) -> None:
+        """Test timeout error includes the last transport error observed."""
+        with patch(
+            "testing.fixtures.polling.httpx.get",
+            side_effect=OSError("connection refused"),
+        ):
+            with pytest.raises(PollingTimeoutError) as exc_info:
+                wait_for_http_status(
+                    "http://polaris:8182/q/health/ready",
+                    timeout=0.2,
+                    interval=0.1,
+                    description="Polaris readiness",
+                )
+
+        assert "Polaris readiness" in str(exc_info.value)
+        assert "connection refused" in str(exc_info.value)
 
 
 class TestTcpCheck:

--- a/tests/e2e/test_service_failure_resilience_e2e.py
+++ b/tests/e2e/test_service_failure_resilience_e2e.py
@@ -21,10 +21,8 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from pathlib import Path
 
-import httpx
 import pytest
 
 from testing.fixtures.kubernetes import (
@@ -32,7 +30,7 @@ from testing.fixtures.kubernetes import (
     check_pod_ready,
     run_kubectl,
 )
-from testing.fixtures.polling import wait_for_condition
+from testing.fixtures.polling import wait_for_condition, wait_for_http_status
 from testing.fixtures.services import ServiceEndpoint
 
 logger = logging.getLogger(__name__)
@@ -63,11 +61,19 @@ class TestServiceFailureResilience:
         This validates pod replacement detection, NOT downtime observation.
         """
         minio_url = os.environ.get("MINIO_URL", ServiceEndpoint("minio").url)
+        minio_ready_url = f"{minio_url}/minio/health/ready"
+        polaris_health_url = os.environ.get(
+            "POLARIS_HEALTH_URL",
+            ServiceEndpoint("polaris-management").url,
+        )
+        polaris_ready_url = f"{polaris_health_url}/q/health/ready"
 
-        # Verify MinIO is healthy before the test
-        response = httpx.get(f"{minio_url}/minio/health/ready", timeout=5.0)
-        assert response.status_code == 200, (
-            "MinIO not healthy before test — cannot test failure resilience"
+        # Verify MinIO is healthy before the test.
+        wait_for_http_status(
+            minio_ready_url,
+            timeout=60.0,
+            interval=3.0,
+            description="MinIO readiness before pod restart",
         )
 
         # Delete pod and assert recovery via UID change
@@ -83,6 +89,19 @@ class TestServiceFailureResilience:
         # Bound covers delete RPC + recovery polling (30s each worst-case).
         assert recovery_secs < 60.0, f"MinIO recovery took {recovery_secs:.1f}s (limit: 60s)"
 
+        wait_for_http_status(
+            minio_ready_url,
+            timeout=120.0,
+            interval=3.0,
+            description="MinIO readiness after pod restart",
+        )
+        wait_for_http_status(
+            polaris_ready_url,
+            timeout=120.0,
+            interval=3.0,
+            description="Polaris readiness after MinIO pod restart",
+        )
+
     @pytest.mark.requirement("AC-2.7")
     def test_polaris_pod_restart_detected(self) -> None:
         """Verify Polaris pod replacement via UID change after deletion.
@@ -93,13 +112,15 @@ class TestServiceFailureResilience:
             "POLARIS_HEALTH_URL",
             ServiceEndpoint("polaris-management").url,
         )
+        polaris_ready_url = f"{polaris_health_url}/q/health/ready"
 
-        # Verify Polaris is healthy (management endpoint, no OAuth needed)
-        response = httpx.get(
-            f"{polaris_health_url}/q/health/ready",
-            timeout=5.0,
+        # Verify Polaris is healthy (management endpoint, no OAuth needed).
+        wait_for_http_status(
+            polaris_ready_url,
+            timeout=120.0,
+            interval=3.0,
+            description="Polaris readiness before pod restart",
         )
-        assert response.status_code == 200, "Polaris not healthy before test"
 
         # Delete pod and assert recovery via UID change
         result = assert_pod_recovery(
@@ -114,21 +135,12 @@ class TestServiceFailureResilience:
         # Bound covers delete RPC + recovery polling (30s each worst-case).
         assert recovery_secs < 60.0, f"Polaris recovery took {recovery_secs:.1f}s (limit: 60s)"
 
-        # Wait for port-forward to reconnect (port 8182 management health)
-        polaris_health_ready = wait_for_condition(
-            lambda: _check_port_forward_health(f"{polaris_health_url}/q/health/ready"),
-            timeout=60.0,
+        wait_for_http_status(
+            polaris_ready_url,
+            timeout=120.0,
             interval=3.0,
-            description="Polaris port-forward health (8182) to recover",
-            raise_on_timeout=False,
+            description="Polaris readiness after pod restart",
         )
-        if not polaris_health_ready:
-            warnings.warn(
-                "Polaris port-forward (8182) did not recover within 60s after pod restart. "
-                "Subsequent tests using port 8182 may fail.",
-                UserWarning,
-                stacklevel=2,
-            )
 
     @pytest.mark.requirement("AC-2.7")
     def test_compilation_during_service_outage(
@@ -197,19 +209,13 @@ class TestServiceFailureResilience:
             f"Polaris pod did not recover within 120s.\n"
             f"Check: kubectl get pods -n {NAMESPACE} -l app.kubernetes.io/component=polaris"
         )
-
-
-def _check_port_forward_health(url: str) -> bool:
-    """Check if a port-forwarded health endpoint is reachable.
-
-    Args:
-        url: Full URL to health endpoint (e.g. http://localhost:8182/q/health/ready).
-
-    Returns:
-        True if endpoint returns HTTP 200.
-    """
-    try:
-        response = httpx.get(url, timeout=3.0)
-        return response.status_code == 200
-    except (httpx.HTTPError, OSError):
-        return False
+        polaris_health_url = os.environ.get(
+            "POLARIS_HEALTH_URL",
+            ServiceEndpoint("polaris-management").url,
+        )
+        wait_for_http_status(
+            f"{polaris_health_url}/q/health/ready",
+            timeout=120.0,
+            interval=3.0,
+            description="Polaris readiness after compilation outage test",
+        )

--- a/tests/unit/test_destructive_readiness_wiring.py
+++ b/tests/unit/test_destructive_readiness_wiring.py
@@ -1,0 +1,53 @@
+"""Regression tests for destructive E2E service readiness sequencing."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESTRUCTIVE_E2E = REPO_ROOT / "tests" / "e2e" / "test_service_failure_resilience_e2e.py"
+
+
+def _function_source(function_name: str) -> str:
+    source = DESTRUCTIVE_E2E.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return ast.get_source_segment(source, node) or ""
+    raise AssertionError(f"Function {function_name} not found in {DESTRUCTIVE_E2E}")
+
+
+def test_destructive_tests_use_shared_http_status_waiter() -> None:
+    """Destructive tests should use strict HTTP readiness, not ad hoc one-shot GETs."""
+    source = DESTRUCTIVE_E2E.read_text()
+
+    assert "wait_for_http_status" in source
+
+
+def test_minio_restart_waits_for_polaris_readiness_after_recovery() -> None:
+    """MinIO restarts must wait for dependent Polaris readiness before next test."""
+    source = _function_source("test_minio_pod_restart_detected")
+
+    assert "wait_for_http_status" in source
+    assert "Polaris readiness after MinIO pod restart" in source
+    assert source.index("assert_pod_recovery(") < source.index(
+        "Polaris readiness after MinIO pod restart"
+    )
+
+
+def test_polaris_restart_preflight_uses_polled_readiness() -> None:
+    """Polaris preflight should tolerate transient 503s from previous destructive tests."""
+    source = _function_source("test_polaris_pod_restart_detected")
+
+    assert "wait_for_http_status" in source
+    assert "Polaris readiness before pod restart" in source
+    assert "response = httpx.get" not in source
+
+
+def test_compilation_outage_cleanup_waits_for_polaris_http_readiness() -> None:
+    """Compilation outage cleanup should restore Polaris endpoint readiness, not only pod Ready."""
+    source = _function_source("test_compilation_during_service_outage")
+
+    assert "wait_for_http_status" in source
+    assert "Polaris readiness after compilation outage test" in source

--- a/tests/unit/test_devpod_source_selection.py
+++ b/tests/unit/test_devpod_source_selection.py
@@ -230,6 +230,7 @@ def test_full_lifecycle_runs_e2e_inside_devpod_by_default() -> None:
     script = _read(_DEVPOD_TEST)
 
     assert 'DEVPOD_E2E_EXECUTION="${DEVPOD_E2E_EXECUTION:-remote}"' in script
+    assert 'DEVPOD_REMOTE_E2E_MAKE_TARGET="${DEVPOD_REMOTE_E2E_MAKE_TARGET:-test-e2e}"' in script
     assert 'case "${DEVPOD_E2E_EXECUTION}" in' in script
     assert "remote)" in script
     assert "run_remote_e2e_detached" in script
@@ -237,7 +238,7 @@ def test_full_lifecycle_runs_e2e_inside_devpod_by_default() -> None:
     assert "poll_remote_e2e_run" in script
     assert "fetch_remote_e2e_artifacts" in script
     assert '--workdir "${DEVPOD_REMOTE_WORKDIR}"' in script
-    assert "IMAGE_LOAD_METHOD=kind make test-e2e" in script
+    assert 'IMAGE_LOAD_METHOD=kind make "\\${FLOE_REMOTE_E2E_MAKE_TARGET}"' in script
     assert '--command "bash -lc ${escaped_script}"' in script
 
 
@@ -250,7 +251,21 @@ def test_remote_e2e_bootstraps_kind_before_running_tests() -> None:
         "The detached remote E2E script must create/deploy the Kind stack "
         "before running the in-cluster E2E Job."
     )
-    assert script.index("make kind-up") < script.index("IMAGE_LOAD_METHOD=kind make test-e2e")
+    assert script.index("make kind-up") < script.index(
+        'IMAGE_LOAD_METHOD=kind make "\\${FLOE_REMOTE_E2E_MAKE_TARGET}"'
+    )
+
+
+@pytest.mark.requirement("AC-DevPod-Remote-E2E")
+def test_remote_e2e_make_target_is_configurable_without_shell_command_injection() -> None:
+    """Release validation must be able to select test-e2e-full remotely."""
+    script = _read(_DEVPOD_TEST)
+
+    assert "DEVPOD_REMOTE_E2E_MAKE_TARGET" in script
+    assert "FLOE_REMOTE_E2E_MAKE_TARGET=" in script
+    assert 'make "\\${FLOE_REMOTE_E2E_MAKE_TARGET}"' in script
+    assert "DEVPOD_REMOTE_E2E_COMMAND" not in script
+    assert "eval " not in script
 
 
 @pytest.mark.requirement("AC-DevPod-Remote-E2E")
@@ -273,6 +288,21 @@ def test_full_lifecycle_remote_e2e_is_detached_and_resumable() -> None:
     assert "DEVPOD_REMOTE_POLL_FAILURE_LIMIT" in script
     assert "DEVPOD_REMOTE_E2E_TIMEOUT" in script
     assert "test-artifacts/devpod-${REMOTE_RUN_ID}" in script
+
+
+@pytest.mark.requirement("AC-DevPod-Remote-E2E")
+def test_remote_e2e_start_accepts_run_dir_when_devpod_tunnel_exits_nonzero() -> None:
+    """A DevPod tunnel error after nohup start must not kill the detached run."""
+    script = _read(_DEVPOD_TEST)
+    start_start = script.index("start_remote_e2e_run() {")
+    poll_start = script.index("poll_remote_e2e_run() {", start_start)
+    start_function = script[start_start:poll_start]
+
+    assert "start_output=" in start_function
+    assert "start_status=$?" in start_function
+    assert 'grep -Fx "${REMOTE_RUN_DIR}"' in start_function
+    assert "DevPod SSH reported failure after remote E2E start" in start_function
+    assert "printf '%s\\n' \"${remote_dir}\"" in start_function
 
 
 @pytest.mark.requirement("AC-DevPod-Remote-E2E")


### PR DESCRIPTION
## Summary
- Adds shared HTTP readiness polling for destructive E2E service checks so dependent-service recovery is waited on explicitly instead of relying on one-shot health probes.
- Makes the MinIO, Polaris, and compilation-outage destructive tests wait for the affected HTTP readiness boundaries before moving to the next disruptive scenario.
- Hardens the DevPod remote E2E helper so release validation can run `test-e2e-full` and survive DevPod tunnel errors after a detached run has started.
- Keeps Great Expectations plugin health checks lightweight by checking discoverability without importing the heavy framework.

Closes #294.

## Validation
- `uv run --extra dev pytest testing/tests/unit/test_polling.py -q` -> `22 passed`
- `uv run --extra dev pytest tests/unit/test_destructive_readiness_wiring.py testing/tests/unit/test_polling.py -q` -> `26 passed`
- `uv run --extra dev pytest plugins/floe-quality-gx/tests/unit/test_plugin.py::TestGreatExpectationsPluginHealthCheck testing/tests/unit/test_customer360_validator.py::test_cli_loads_customer360_validation_manifest_by_default -q` -> `5 passed`
- `uv run --extra dev pytest tests/unit/test_devpod_source_selection.py -q` -> `26 passed`
- `make lint` -> passed
- `make typecheck` -> passed before latest DevPod-helper-only commit
- `make test-unit` -> `10139 passed, 1 skipped, 1 xfailed, 2 warnings`
- `git push` pre-push hook -> passed lint, format, strict mypy, dbt version checks, Bandit, uv-secure, unit tests, contract tests, no-hardcoded-sleep, traceability, and Helm lint

## DevPod + Hetzner Release Lane
Command:

```bash
DEVPOD_WORKSPACE=floe-destructive-readiness \
DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full \
DEVPOD_REMOTE_RUN_ROOT=/tmp/floe-devpod-e2e-full \
DEVPOD_REMOTE_E2E_TIMEOUT=10800 \
DEVPOD_REMOTE_POLL_FAILURE_LIMIT=45 \
./scripts/devpod-test.sh
```

Result:
- Bootstrap: `8 passed, 324 deselected, 3 warnings`
- Platform: `250 passed, 82 deselected, 107 warnings`
- Developer workflow: `67 passed, 265 deselected, 3 warnings`
- Destructive: `7 passed, 325 deselected`
- Summary: Bootstrap, Platform, Developer, Destructive all `PASSED`; remote exit `0`
- Workspace cleanup: `Successfully deleted workspace 'floe-destructive-readiness'`

Artifacts:
- `test-artifacts/devpod-helper-full-20260503T081141Z/output.log`
- `test-artifacts/devpod-run-20260503T081142Z-91563/output.log`