### PR TITLE
Remove Dagster gql deprecation warning

### DIFF
--- a/testing/fixtures/dagster_graphql.py
+++ b/testing/fixtures/dagster_graphql.py
@@ -1,0 +1,26 @@
+"""Dagster GraphQL helper utilities for tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gql import GraphQLRequest, gql
+
+
+def execute_dagster_graphql_request(
+    dagster_client: Any,
+    query: str,
+    variables: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute an arbitrary Dagster GraphQL query without deprecated gql kwargs.
+
+    DagsterGraphQLClient exposes arbitrary query execution through its private
+    ``_execute`` helper, but that path passes ``variable_values`` to
+    ``gql.Client.execute`` as deprecated kwargs. Constructing ``GraphQLRequest``
+    directly keeps variable values on the request object, matching gql's current
+    API while preserving the existing Dagster test fixture.
+    """
+    request = GraphQLRequest(gql(query), variable_values=variables)
+    result = dagster_client._client.execute(request)
+    assert isinstance(result, dict), f"Dagster GraphQL returned non-dict result: {type(result)}"
+    return result

--- a/testing/tests/unit/test_dagster_graphql_request.py
+++ b/testing/tests/unit/test_dagster_graphql_request.py
@@ -1,0 +1,84 @@
+"""Tests for non-deprecated Dagster GraphQL request execution helpers."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Any
+
+from gql import Client, GraphQLRequest
+from gql.transport.local_schema import LocalSchemaTransport
+from graphql import build_schema
+
+from testing.fixtures.dagster_graphql import execute_dagster_graphql_request
+
+
+class _FakeGraphQLClient:
+    """Capture raw gql client calls made through the Dagster wrapper."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[GraphQLRequest, dict[str, Any]]] = []
+
+    def execute(self, request: GraphQLRequest, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((request, kwargs))
+        return {"ok": True}
+
+
+class _FakeDagsterClient:
+    """Minimal shape of DagsterGraphQLClient needed by the helper."""
+
+    def __init__(self) -> None:
+        self._client: Any
+        self._client = _FakeGraphQLClient()
+
+
+def test_execute_dagster_graphql_request_places_variables_on_request() -> None:
+    """Avoid gql's deprecated execute(variable_values=...) call shape."""
+    dagster_client = _FakeDagsterClient()
+
+    result = execute_dagster_graphql_request(
+        dagster_client,
+        "query GetSensors($repoSelector: RepositorySelector!) { __typename }",
+        {"repoSelector": {"repositoryName": "repo", "repositoryLocationName": "location"}},
+    )
+
+    assert result == {"ok": True}
+    [(request, kwargs)] = dagster_client._client.calls
+    assert isinstance(request, GraphQLRequest)
+    assert request.variable_values == {
+        "repoSelector": {"repositoryName": "repo", "repositoryLocationName": "location"}
+    }
+    assert kwargs == {}
+
+
+def test_execute_dagster_graphql_request_emits_no_gql_deprecation_warning() -> None:
+    """Exercise gql.Client.execute with variables using the current request API."""
+    dagster_client = _FakeDagsterClient()
+    dagster_client._client = Client(
+        transport=LocalSchemaTransport(build_schema("type Query { ok: Boolean! }")),
+        fetch_schema_from_transport=False,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = execute_dagster_graphql_request(
+            dagster_client,
+            "query Test($includeTypename: Boolean!) { __typename @include(if: $includeTypename) }",
+            {"includeTypename": True},
+        )
+
+    assert result == {"__typename": "Query"}
+    assert not [
+        warning
+        for warning in caught
+        if "GraphQLRequest" in str(warning.message)
+        or "variable_values and operation_name" in str(warning.message)
+    ]
+
+
+def test_data_pipeline_sensor_query_uses_graphql_request_helper() -> None:
+    """The E2E sensor query must not call Dagster's deprecated private wrapper."""
+    source = Path("tests/e2e/test_data_pipeline.py").read_text()
+
+    assert "execute_dagster_graphql_request(dagster_client, sensor_query, variables)" in source
+    assert "dagster_client._execute(sensor_query, variables)" not in source

--- a/tests/e2e/test_data_pipeline.py
+++ b/tests/e2e/test_data_pipeline.py
@@ -46,6 +46,7 @@ import pytest
 from dbt_utils import run_dbt
 
 from testing.base_classes.integration_test_base import IntegrationTestBase
+from testing.fixtures.dagster_graphql import execute_dagster_graphql_request
 from testing.fixtures.polaris import rewrite_table_io_for_host_access
 
 ALL_PRODUCTS = ["customer-360", "iot-telemetry", "financial-risk"]
@@ -853,7 +854,7 @@ class TestDataPipeline(IntegrationTestBase):
                     "repositoryLocationName": repo_location_name,
                 },
             }
-            result = dagster_client._execute(sensor_query, variables)
+            result = execute_dagster_graphql_request(dagster_client, sensor_query, variables)
             assert "sensorsOrError" in result, (
                 f"Dagster sensor query response missing 'sensorsOrError'. Got: {result}"
             )


### PR DESCRIPTION
## Summary
- add a small Dagster GraphQL test helper that constructs `gql.GraphQLRequest` directly
- move the sensor E2E query with variables off DagsterGraphQLClient._execute
- add regression coverage that variables are stored on the request and no gql GraphQLRequest deprecation warning is emitted

Closes #295.

## Validation
- RED first: `uv run pytest testing/tests/unit/test_dagster_graphql_request.py -q` failed because `testing.fixtures.dagster_graphql` did not exist
- `uv run pytest testing/tests/unit/test_dagster_graphql_request.py testing/tests/unit/test_dagster_migration.py -q`
- `uv run ruff check testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py tests/e2e/test_data_pipeline.py`
- `uv run ruff format --check testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py tests/e2e/test_data_pipeline.py`
- `uv run mypy testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py`
- `git diff --check`
- pre-push hook: ruff, mypy, dbt version checks, bandit, uv-secure, unit tests, contract tests, no-hardcoded-sleep, traceability passed; Helm dependency download failed once with a transient Docker Hub socket error, then `./testing/ci/lint-helm.sh` passed fresh before push