### PR TITLE
Apply Dagster GraphQL review hardening

### DIFF
--- a/testing/fixtures/__init__.py
+++ b/testing/fixtures/__init__.py
@@ -64,6 +64,7 @@ from testing.fixtures.dagster import (
     materialize_to_memory,
     wait_for_run_completion,
 )
+from testing.fixtures.dagster_graphql import execute_dagster_graphql_request
 from testing.fixtures.data import (
     create_model_instance,
     generate_random_string,
@@ -272,6 +273,7 @@ __all__ = [
     "ephemeral_instance",
     "execute_job",
     "execute_job_to_memory",
+    "execute_dagster_graphql_request",
     "get_run_status",
     "materialize_asset",
     "materialize_to_memory",

--- a/testing/fixtures/dagster_graphql.py
+++ b/testing/fixtures/dagster_graphql.py
@@ -2,13 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
 from gql import GraphQLRequest, gql
 
 
+class _GqlClient(Protocol):
+    """Subset of ``gql.Client`` required by Dagster GraphQL tests."""
+
+    def execute(self, request: GraphQLRequest) -> dict[str, Any]:
+        """Execute a prepared GraphQL request."""
+
+
+class _DagsterGraphQLClient(Protocol):
+    """Subset of ``DagsterGraphQLClient`` required by this helper."""
+
+    _client: _GqlClient
+
+
 def execute_dagster_graphql_request(
-    dagster_client: Any,
+    dagster_client: _DagsterGraphQLClient,
     query: str,
     variables: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -22,5 +35,7 @@ def execute_dagster_graphql_request(
     """
     request = GraphQLRequest(gql(query), variable_values=variables)
     result = dagster_client._client.execute(request)
-    assert isinstance(result, dict), f"Dagster GraphQL returned non-dict result: {type(result)}"
+    if not isinstance(result, dict):
+        msg = f"Dagster GraphQL returned non-dict result: {type(result)}"
+        raise TypeError(msg)
     return result

--- a/testing/tests/unit/test_dagster_graphql_request.py
+++ b/testing/tests/unit/test_dagster_graphql_request.py
@@ -6,32 +6,37 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+import pytest
 from gql import Client, GraphQLRequest
 from gql.transport.local_schema import LocalSchemaTransport
 from graphql import build_schema
 
-from testing.fixtures.dagster_graphql import execute_dagster_graphql_request
+from testing.fixtures import execute_dagster_graphql_request
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 class _FakeGraphQLClient:
     """Capture raw gql client calls made through the Dagster wrapper."""
 
-    def __init__(self) -> None:
+    def __init__(self, result: Any = None) -> None:
+        self.result = {"ok": True} if result is None else result
         self.calls: list[tuple[GraphQLRequest, dict[str, Any]]] = []
 
-    def execute(self, request: GraphQLRequest, **kwargs: Any) -> dict[str, Any]:
+    def execute(self, request: GraphQLRequest, **kwargs: Any) -> Any:
         self.calls.append((request, kwargs))
-        return {"ok": True}
+        return self.result
 
 
 class _FakeDagsterClient:
     """Minimal shape of DagsterGraphQLClient needed by the helper."""
 
-    def __init__(self) -> None:
+    def __init__(self, result: Any = None) -> None:
         self._client: Any
-        self._client = _FakeGraphQLClient()
+        self._client = _FakeGraphQLClient(result)
 
 
+@pytest.mark.requirement("295")
 def test_execute_dagster_graphql_request_places_variables_on_request() -> None:
     """Avoid gql's deprecated execute(variable_values=...) call shape."""
     dagster_client = _FakeDagsterClient()
@@ -51,6 +56,7 @@ def test_execute_dagster_graphql_request_places_variables_on_request() -> None:
     assert kwargs == {}
 
 
+@pytest.mark.requirement("295")
 def test_execute_dagster_graphql_request_emits_no_gql_deprecation_warning() -> None:
     """Exercise gql.Client.execute with variables using the current request API."""
     dagster_client = _FakeDagsterClient()
@@ -76,9 +82,19 @@ def test_execute_dagster_graphql_request_emits_no_gql_deprecation_warning() -> N
     ]
 
 
+@pytest.mark.requirement("295")
+def test_execute_dagster_graphql_request_rejects_non_dict_results() -> None:
+    """Non-object GraphQL responses should fail under optimized Python too."""
+    dagster_client = _FakeDagsterClient(result=["not", "a", "dict"])
+
+    with pytest.raises(TypeError, match="Dagster GraphQL returned non-dict result"):
+        execute_dagster_graphql_request(dagster_client, "{ __typename }")
+
+
+@pytest.mark.requirement("295")
 def test_data_pipeline_sensor_query_uses_graphql_request_helper() -> None:
     """The E2E sensor query must not call Dagster's deprecated private wrapper."""
-    source = Path("tests/e2e/test_data_pipeline.py").read_text()
+    source = (_REPO_ROOT / "tests/e2e/test_data_pipeline.py").read_text()
 
     assert "execute_dagster_graphql_request(dagster_client, sensor_query, variables)" in source
     assert "dagster_client._execute(sensor_query, variables)" not in source


### PR DESCRIPTION
## Summary

This preserves the Dagster GraphQL review-resolution fixes that missed PR #302's squash merge after #302 was merged before the local follow-up commit reached GitHub.

Changes:
- Add requirement markers to the Dagster GraphQL regression tests.
- Replace assertion-based fixture type narrowing with explicit `TypeError` handling.
- Make the Dagster GraphQL fixture path resolution CWD-safe.
- Type the fake GraphQL client via a protocol and re-export the shared fixture helpers.

## Validation

- `uv run pytest testing/tests/unit/test_dagster_graphql_request.py testing/tests/unit/test_dagster_migration.py -q` -> 19 passed
- `uv run mypy testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py` -> success
- `uv run ruff check testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py testing/fixtures/__init__.py tests/e2e/test_data_pipeline.py` -> passed
- `uv run ruff format --check testing/fixtures/dagster_graphql.py testing/tests/unit/test_dagster_graphql_request.py testing/fixtures/__init__.py tests/e2e/test_data_pipeline.py` -> already formatted
- `git diff --check origin/main..HEAD` -> clean
- `./testing/ci/test-contract.sh tests/contract/test_observability_manifests.py::TestStandardJobReportFlags -q` -> 956 passed, 1 xfailed. Note: this script prepends `tests/contract`, so this exercised the full contract suite.
- Normal `git push` pre-push hook passed: ruff, format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, hardcoded sleep guard, requirement traceability, and Helm lint.

## Validation note

The first push attempt was blocked by a local ignored generated directory, `charts/floe-platform/charts/dagster/`, whose stale unpacked Dagster schema performed remote `$ref` fetches during `helm template` and timed out against GitHub. Removing that ignored generated directory restored the intended packaged dependency path; the full contract hook then passed and the normal push succeeded.
