### PR TITLE
Align Dagster GraphQL requirement markers

### DIFF
--- a/testing/tests/unit/test_dagster_graphql_request.py
+++ b/testing/tests/unit/test_dagster_graphql_request.py
@@ -36,7 +36,7 @@ class _FakeDagsterClient:
         self._client = _FakeGraphQLClient(result)
 
 
-@pytest.mark.requirement("295")
+@pytest.mark.requirement("15-FR-007")
 def test_execute_dagster_graphql_request_places_variables_on_request() -> None:
     """Avoid gql's deprecated execute(variable_values=...) call shape."""
     dagster_client = _FakeDagsterClient()
@@ -56,7 +56,7 @@ def test_execute_dagster_graphql_request_places_variables_on_request() -> None:
     assert kwargs == {}
 
 
-@pytest.mark.requirement("295")
+@pytest.mark.requirement("15-FR-007")
 def test_execute_dagster_graphql_request_emits_no_gql_deprecation_warning() -> None:
     """Exercise gql.Client.execute with variables using the current request API."""
     dagster_client = _FakeDagsterClient()
@@ -82,7 +82,7 @@ def test_execute_dagster_graphql_request_emits_no_gql_deprecation_warning() -> N
     ]
 
 
-@pytest.mark.requirement("295")
+@pytest.mark.requirement("15-FR-007")
 def test_execute_dagster_graphql_request_rejects_non_dict_results() -> None:
     """Non-object GraphQL responses should fail under optimized Python too."""
     dagster_client = _FakeDagsterClient(result=["not", "a", "dict"])
@@ -91,7 +91,7 @@ def test_execute_dagster_graphql_request_rejects_non_dict_results() -> None:
         execute_dagster_graphql_request(dagster_client, "{ __typename }")
 
 
-@pytest.mark.requirement("295")
+@pytest.mark.requirement("15-FR-007")
 def test_data_pipeline_sensor_query_uses_graphql_request_helper() -> None:
     """The E2E sensor query must not call Dagster's deprecated private wrapper."""
     source = (_REPO_ROOT / "tests/e2e/test_data_pipeline.py").read_text()


### PR DESCRIPTION
## Summary

Follow-up to PR #303 review feedback. PR #303 merged before the review-resolution marker fix could be pushed, so this preserves the useful consistency fix separately.

Changes:
- Replace issue-number requirement marker `295` with spec-derived `15-FR-007` on the Dagster GraphQL helper regression tests.
- Keep the existing test behavior unchanged.

## Review finding

Closes the non-blocking PR #303 review nit from claude[bot]: requirement markers should use a spec-derived ID when a canonical requirement exists.

## Validation

- `uv run pytest testing/tests/unit/test_dagster_graphql_request.py testing/tests/unit/test_dagster_migration.py -q` -> 19 passed
- `uv run ruff check testing/tests/unit/test_dagster_graphql_request.py` -> passed
- `uv run ruff format --check testing/tests/unit/test_dagster_graphql_request.py` -> already formatted
- `uv run --no-sync python -m testing.traceability --all --threshold 80` -> pass, 100.0% coverage; existing 41 TQR advisory warnings remain unrelated to this one-line marker change class
- `git diff --check origin/main..HEAD` -> clean
- Normal `git push` pre-push hook passed: ruff, format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, hardcoded sleep guard, requirement traceability, and Helm lint.
