### PR TITLE
Fix architecture drift guard branch checks

### DIFF
--- a/scripts/check-architecture-drift
+++ b/scripts/check-architecture-drift
@@ -30,6 +30,8 @@ log_ok() { echo -e "${GREEN}[arch-drift]${NC} $1"; }
 
 warnings=0
 violations=0
+readonly PLATFORM_SERVICE_NAMES="dagster|polaris|polaris-management|minio|minio-console|postgres|postgresql|jaeger-query|otel-collector-grpc|otel-collector-http|marquez|oci-registry|oci-registry-auth"
+readonly PLATFORM_SERVICE_MAP_REGEX="(^|[[:space:],{])['\"]?(${PLATFORM_SERVICE_NAMES})['\"]?[[:space:]]*:[[:space:]]*['\"]?[0-9]+['\"]?([[:space:]]*[,}]|[[:space:]]*$)"
 
 # Technology Ownership Rules
 # dbt owns SQL - Python must not parse/validate/transform SQL
@@ -162,7 +164,7 @@ check_platform_contract_literals() {
             ;;
     esac
 
-    if grep -qE "['\"](dagster|polaris|polaris-management|minio|minio-console|postgres|postgresql|jaeger-query|otel-collector-grpc|otel-collector-http|marquez|oci-registry|oci-registry-auth)['\"][[:space:]]*:[[:space:]]*['\"]?[0-9]+['\"]?([[:space:]]*[,}]|[[:space:]]*$)" "$file" 2>/dev/null; then
+    if grep -qE "${PLATFORM_SERVICE_MAP_REGEX}" "$file" 2>/dev/null; then
         log_error "$file: duplicated platform service map detected - use floe_core.contracts.topology"
         violations=$((violations + 1))
     fi

--- a/scripts/check-architecture-drift
+++ b/scripts/check-architecture-drift
@@ -224,6 +224,16 @@ validate_file_path() {
     resolved_dir="$(cd "$candidate_dir" 2>/dev/null && pwd -P)" || return 1
     resolved_path="${resolved_dir}/${candidate_name}"
 
+    # Resolve the final component too. A tracked symlink inside the repo can
+    # otherwise point outside PROJECT_ROOT while still passing the prefix check.
+    if [[ -L "$resolved_path" ]]; then
+        if ! command -v python3 >/dev/null 2>&1; then
+            log_warn "Unable to safely resolve symlink without python3: $file"
+            return 1
+        fi
+        resolved_path=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$resolved_path") || return 1
+    fi
+
     # Ensure path starts with PROJECT_ROOT (no traversal)
     if [[ "$resolved_path" != "${PROJECT_ROOT}"/* ]]; then
         log_warn "Path traversal attempt blocked: $file"

--- a/scripts/check-architecture-drift
+++ b/scripts/check-architecture-drift
@@ -44,13 +44,13 @@ check_dbt_ownership() {
     # Check for SQL parsing in Python
     if grep -qE "(sqlparse|sql.*parse|parse.*sql|ast.*sql)" "$file" 2>/dev/null; then
         log_error "$file: SQL parsing detected - dbt owns SQL compilation"
-        ((violations++))
+        violations=$((violations + 1))
     fi
 
     # Check for SQL validation
     if grep -qE "(validate.*sql|sql.*valid)" "$file" 2>/dev/null; then
         log_warn "$file: SQL validation detected - consider delegating to dbt"
-        ((warnings++))
+        warnings=$((warnings + 1))
     fi
 }
 
@@ -64,7 +64,7 @@ check_layer_boundaries() {
         # Check for manifest.yaml modifications
         if grep -qE "(manifest\.yaml|write.*manifest|save.*manifest)" "$file" 2>/dev/null; then
             log_error "$file: Layer 4 (Data) modifying Layer 2 (Configuration) - FORBIDDEN"
-            ((violations++))
+            violations=$((violations + 1))
         fi
     fi
 }
@@ -86,7 +86,7 @@ check_contract_boundaries() {
             return 0
         fi
         log_warn "$file: Direct FloeSpec usage - use CompiledArtifacts for cross-package contracts"
-        ((warnings++))
+        warnings=$((warnings + 1))
     fi
 }
 
@@ -99,7 +99,7 @@ check_plugin_rules() {
         # Check for hardcoded secrets
         if grep -qE "(password|secret|api_key|token)\s*=\s*['\"][^'\"]+['\"]" "$file" 2>/dev/null; then
             log_error "$file: Hardcoded secret in plugin - use SecretReference"
-            ((violations++))
+            violations=$((violations + 1))
         fi
 
         # Check for missing entry point registration (in setup.py or pyproject.toml)
@@ -108,7 +108,7 @@ check_plugin_rules() {
             package_dir=$(dirname "$file")
             if [[ ! -f "${package_dir}/pyproject.toml" ]]; then
                 log_warn "$file: Plugin may be missing entry point registration"
-                ((warnings++))
+                warnings=$((warnings + 1))
             fi
         fi
     fi
@@ -132,30 +132,40 @@ check_test_organization() {
 
         if [[ "$package_imports" -lt 2 ]]; then
             log_warn "$file: Root-level test imports from <2 packages - should be in package tests/"
-            ((warnings++))
+            warnings=$((warnings + 1))
         fi
     fi
 
     # Check for time.sleep in tests
     if grep -qE "time\.sleep\(" "$file" 2>/dev/null; then
         log_warn "$file: time.sleep() in test - use polling utilities instead"
-        ((warnings++))
+        warnings=$((warnings + 1))
     fi
 
     # Check for pytest.skip
     if grep -qE "@pytest\.mark\.skip|pytest\.skip\(" "$file" 2>/dev/null; then
         log_error "$file: pytest.skip detected - tests must FAIL not skip"
-        ((violations++))
+        violations=$((violations + 1))
+    fi
+}
+
+check_platform_contract_literals() {
+    local file="$1"
+
+    case "$file" in
+        *"packages/floe-core/src/floe_core/contracts/"*|*"charts/floe-platform/templates/tests/_contract-env.generated.tpl")
+            return 0
+            ;;
+    esac
+
+    if grep -qE "['\"](dagster|polaris|polaris-management|minio|minio-console|postgres|postgresql|jaeger-query|otel-collector-grpc|otel-collector-http|marquez|oci-registry|oci-registry-auth)['\"][[:space:]]*:[[:space:]]*['\"]?[0-9]+['\"]?([[:space:]]*[,}]|[[:space:]]*$)" "$file" 2>/dev/null; then
+        log_error "$file: duplicated platform service map detected - use floe_core.contracts.topology"
+        violations=$((violations + 1))
     fi
 }
 
 check_file() {
     local file="$1"
-
-    # Only check Python files
-    if [[ ! "$file" == *.py ]]; then
-        return 0
-    fi
 
     # Skip non-existent files (deleted)
     if [[ ! -f "$file" ]]; then
@@ -163,6 +173,19 @@ check_file() {
     fi
 
     log_info "Checking $file..."
+
+    # Platform service literal checks apply to source-controlled text files.
+    # Other checks below remain Python-only.
+    case "$file" in
+        *.py|*.sh|*.yaml|*.yml|*.toml|*.tpl|*.md|*/Makefile|Makefile)
+            check_platform_contract_literals "$file"
+            ;;
+    esac
+
+    # Only check Python files for Python-specific rules.
+    if [[ ! "$file" == *.py ]]; then
+        return 0
+    fi
 
     check_dbt_ownership "$file"
     check_layer_boundaries "$file"
@@ -174,10 +197,26 @@ check_file() {
 validate_file_path() {
     # Prevent path traversal - ensure file is within PROJECT_ROOT
     local file="$1"
+    local candidate_path
+    local candidate_dir
+    local candidate_name
+    local resolved_dir
     local resolved_path
 
     # Resolve to absolute path and check it's within project
-    resolved_path=$(realpath -m "${PROJECT_ROOT}/${file}" 2>/dev/null) || return 1
+    case "$file" in
+        /*)
+            candidate_path="$file"
+            ;;
+        *)
+            candidate_path="${PROJECT_ROOT}/${file}"
+            ;;
+    esac
+
+    candidate_dir="$(dirname "$candidate_path")"
+    candidate_name="$(basename "$candidate_path")"
+    resolved_dir="$(cd "$candidate_dir" 2>/dev/null && pwd -P)" || return 1
+    resolved_path="${resolved_dir}/${candidate_name}"
 
     # Ensure path starts with PROJECT_ROOT (no traversal)
     if [[ "$resolved_path" != "${PROJECT_ROOT}"/* ]]; then
@@ -201,7 +240,7 @@ main() {
         check_file "$target"
     else
         # Check all changed files
-        log_info "Checking all changed Python files..."
+        log_info "Checking all changed files..."
 
         # Validate git refs exist before using them
         local base_ref="main"
@@ -217,7 +256,7 @@ main() {
 
         # Get changed files using validated refs with -- separator
         local changed_files
-        changed_files=$(git diff --name-only "${base_ref}...${head_ref}" -- "*.py" 2>/dev/null || true)
+        changed_files=$(git diff --name-only "${base_ref}...${head_ref}" 2>/dev/null || true)
 
         if [[ -z "$changed_files" ]]; then
             log_info "No changed files to check"
@@ -229,9 +268,7 @@ main() {
             local safe_path
             safe_path=$(validate_file_path "$file") || continue
 
-            if [[ "$safe_path" == *.py ]]; then
-                check_file "$safe_path"
-            fi
+            check_file "$safe_path"
         done <<< "$changed_files"
     fi
 

--- a/scripts/check-architecture-drift
+++ b/scripts/check-architecture-drift
@@ -127,7 +127,11 @@ check_test_organization() {
     if [[ "$file" == "${PROJECT_ROOT}/tests/"* ]]; then
         # Check if it imports from multiple packages
         local package_imports
-        package_imports=$(grep -E "from (floe_core|floe_dagster|floe_dbt|floe_polaris)" "$file" 2>/dev/null | wc -l | tr -d ' ')
+        package_imports=$(
+            { grep -E "from (floe_core|floe_dagster|floe_dbt|floe_polaris)" "$file" 2>/dev/null || true; } \
+                | wc -l \
+                | tr -d ' '
+        )
         package_imports=${package_imports:-0}
 
         if [[ "$package_imports" -lt 2 ]]; then

--- a/testing/ci/tests/test_architecture_drift_guard.py
+++ b/testing/ci/tests/test_architecture_drift_guard.py
@@ -6,7 +6,11 @@ import subprocess
 import uuid
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+ROOT_UNIT_TESTS_DIR = PROJECT_ROOT / "tests" / "unit"
+CONTRACTS_DIR = PROJECT_ROOT / "packages" / "floe-core" / "src" / "floe_core" / "contracts"
 
 
 def run_architecture_drift(target: Path) -> subprocess.CompletedProcess[str]:
@@ -23,6 +27,13 @@ def run_architecture_drift(target: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _cleanup_architecture_drift_scratch_files(directory: Path) -> None:
+    """Remove scratch files left by interrupted subprocess-boundary tests."""
+    for path in directory.glob("_arch_drift_*.py"):
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_reaches_summary_under_set_e(tmp_path: Path) -> None:
     """Counter increments must not exit before the summary under set -e."""
     parser_module = ("s" + "ql") + ("pa" + "rse")
@@ -42,14 +53,17 @@ def test_architecture_drift_reaches_summary_under_set_e(tmp_path: Path) -> None:
     assert "Violations: 1, Warnings: 1" in result.stderr
 
 
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_import_count_reaches_warning_summary() -> None:
     """Root test import counting must not exit before the warning summary."""
-    drift_file = PROJECT_ROOT / "tests" / "unit" / f"test_arch_drift_{uuid.uuid4().hex}.py"
+    _cleanup_architecture_drift_scratch_files(ROOT_UNIT_TESTS_DIR)
+    drift_file = ROOT_UNIT_TESTS_DIR / f"_arch_drift_{uuid.uuid4().hex}.py"
     drift_file.write_text("def test_placeholder() -> None:\n    pass\n")
     try:
         result = run_architecture_drift(drift_file)
     finally:
         drift_file.unlink(missing_ok=True)
+        _cleanup_architecture_drift_scratch_files(ROOT_UNIT_TESTS_DIR)
 
     assert result.returncode == 1
     assert "Root-level test imports from <2 packages" in result.stderr
@@ -57,6 +71,7 @@ def test_architecture_drift_import_count_reaches_warning_summary() -> None:
     assert "Warnings: 1" in result.stderr
 
 
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_rejects_single_quoted_platform_service_map(
     tmp_path: Path,
 ) -> None:
@@ -71,6 +86,7 @@ def test_architecture_drift_rejects_single_quoted_platform_service_map(
     assert "duplicated platform service map detected" in result.stderr
 
 
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_rejects_non_python_platform_service_map(
     tmp_path: Path,
 ) -> None:
@@ -85,6 +101,22 @@ def test_architecture_drift_rejects_non_python_platform_service_map(
     assert "duplicated platform service map detected" in result.stderr
 
 
+@pytest.mark.requirement("ALPHA-HARDENING")
+def test_architecture_drift_rejects_unquoted_yaml_platform_service_map(
+    tmp_path: Path,
+) -> None:
+    """Duplicated platform service maps in YAML do not require quoted keys."""
+    component_name = "pola" + "ris"
+    duplicated_map = tmp_path / "duplicated_service_map.yaml"
+    duplicated_map.write_text(f"ports:\n  {component_name}: 8181\n")
+
+    result = run_architecture_drift(duplicated_map)
+
+    assert result.returncode == 2
+    assert "duplicated platform service map detected" in result.stderr
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_allows_nested_platform_service_config_map(
     tmp_path: Path,
 ) -> None:
@@ -96,5 +128,21 @@ def test_architecture_drift_allows_nested_platform_service_config_map(
     )
 
     result = run_architecture_drift(nested_config)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
+def test_architecture_drift_allows_contract_owned_platform_service_map() -> None:
+    """Contract-owned files may define canonical service maps."""
+    component_name = "pola" + "ris"
+    _cleanup_architecture_drift_scratch_files(CONTRACTS_DIR)
+    contract_file = CONTRACTS_DIR / f"_arch_drift_{uuid.uuid4().hex}.py"
+    contract_file.write_text(f"SERVICE_DEFAULT_PORTS = {{{component_name!r}: 8181}}\n")
+    try:
+        result = run_architecture_drift(contract_file)
+    finally:
+        contract_file.unlink(missing_ok=True)
+        _cleanup_architecture_drift_scratch_files(CONTRACTS_DIR)
 
     assert result.returncode == 0, result.stderr

--- a/testing/ci/tests/test_architecture_drift_guard.py
+++ b/testing/ci/tests/test_architecture_drift_guard.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import subprocess
+import uuid
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 def run_architecture_drift(target: Path) -> subprocess.CompletedProcess[str]:
@@ -39,6 +40,21 @@ def test_architecture_drift_reaches_summary_under_set_e(tmp_path: Path) -> None:
     assert result.returncode == 2
     assert "ARCHITECTURE DRIFT DETECTED" in result.stderr
     assert "Violations: 1, Warnings: 1" in result.stderr
+
+
+def test_architecture_drift_import_count_reaches_warning_summary() -> None:
+    """Root test import counting must not exit before the warning summary."""
+    drift_file = PROJECT_ROOT / "tests" / "unit" / f"test_arch_drift_{uuid.uuid4().hex}.py"
+    drift_file.write_text("def test_placeholder() -> None:\n    pass\n")
+    try:
+        result = run_architecture_drift(drift_file)
+    finally:
+        drift_file.unlink(missing_ok=True)
+
+    assert result.returncode == 1
+    assert "Root-level test imports from <2 packages" in result.stderr
+    assert "ARCHITECTURE DRIFT WARNINGS" in result.stderr
+    assert "Warnings: 1" in result.stderr
 
 
 def test_architecture_drift_rejects_single_quoted_platform_service_map(

--- a/testing/ci/tests/test_architecture_drift_guard.py
+++ b/testing/ci/tests/test_architecture_drift_guard.py
@@ -72,6 +72,79 @@ def test_architecture_drift_import_count_reaches_warning_summary() -> None:
 
 
 @pytest.mark.requirement("ALPHA-HARDENING")
+def test_architecture_drift_rejects_changed_symlink_to_external_file(tmp_path: Path) -> None:
+    """Changed symlinks must resolve the final path before project-prefix checks."""
+    parser_module = ("s" + "ql") + ("pa" + "rse")
+    outside_file = tmp_path / "external_drift.py"
+    outside_file.write_text(f"import {parser_module}\n")
+
+    repo = tmp_path / "repo"
+    script_path = repo / "scripts" / "check-architecture-drift"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text((PROJECT_ROOT / "scripts" / "check-architecture-drift").read_text())
+    script_path.chmod(0o755)
+
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "floe@example.invalid"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Floe Test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (repo / "baseline.py").write_text("print('baseline')\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-b", "feature"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (repo / "external_link.py").symlink_to(outside_file)
+    subprocess.run(
+        ["git", "add", "external_link.py"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add external symlink"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(script_path)],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "SQL parsing detected" not in result.stderr
+
+
+@pytest.mark.requirement("ALPHA-HARDENING")
 def test_architecture_drift_rejects_single_quoted_platform_service_map(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_architecture_drift_guard.py
+++ b/tests/unit/test_architecture_drift_guard.py
@@ -1,0 +1,84 @@
+"""Regression tests for architecture drift guard scripts."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_architecture_drift(target: Path) -> subprocess.CompletedProcess[str]:
+    """Run the architecture drift script against a target file."""
+    return subprocess.run(
+        [
+            str(PROJECT_ROOT / "scripts/check-architecture-drift"),
+            str(target),
+        ],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_architecture_drift_reaches_summary_under_set_e(tmp_path: Path) -> None:
+    """Counter increments must not exit before the summary under set -e."""
+    parser_module = ("s" + "ql") + ("pa" + "rse")
+    validation_suffix = "s" + "ql"
+    drift_file = tmp_path / "sql_drift.py"
+    drift_file.write_text(
+        f"import {parser_module}\n"
+        "\n"
+        f"def validate_{validation_suffix}(text: str) -> bool:\n"
+        "    return True\n"
+    )
+
+    result = run_architecture_drift(drift_file)
+
+    assert result.returncode == 2
+    assert "ARCHITECTURE DRIFT DETECTED" in result.stderr
+    assert "Violations: 1, Warnings: 1" in result.stderr
+
+
+def test_architecture_drift_rejects_single_quoted_platform_service_map(
+    tmp_path: Path,
+) -> None:
+    """Duplicated platform service maps in Python must be rejected."""
+    component_name = "pola" + "ris"
+    duplicated_map = tmp_path / "duplicated_service_map.py"
+    duplicated_map.write_text(f"SERVICE_DEFAULT_PORTS = {{{component_name!r}: 8181}}\n")
+
+    result = run_architecture_drift(duplicated_map)
+
+    assert result.returncode == 2
+    assert "duplicated platform service map detected" in result.stderr
+
+
+def test_architecture_drift_rejects_non_python_platform_service_map(
+    tmp_path: Path,
+) -> None:
+    """Duplicated platform service maps in YAML must be rejected."""
+    component_name = "pola" + "ris"
+    duplicated_map = tmp_path / "duplicated_service_map.yaml"
+    duplicated_map.write_text(f'ports:\n  "{component_name}": 8181\n')
+
+    result = run_architecture_drift(duplicated_map)
+
+    assert result.returncode == 2
+    assert "duplicated platform service map detected" in result.stderr
+
+
+def test_architecture_drift_allows_nested_platform_service_config_map(
+    tmp_path: Path,
+) -> None:
+    """Nested service configuration maps are examples, not duplicate port tables."""
+    component_name = "pola" + "ris"
+    nested_config = tmp_path / "nested_service_config.py"
+    nested_config.write_text(
+        f"generator.add_plugin_values({{{component_name!r}: {{'enabled': True}}}})\n"
+    )
+
+    result = run_architecture_drift(nested_config)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- Harden `scripts/check-architecture-drift` so counter increments and root-test import counting do not terminate early under `set -euo pipefail`.
- Extend the drift guard to changed text files so duplicated platform service/port maps are blocked outside contract-owned files.
- Add CI helper regression coverage for summary reporting, duplicated service literal detection, and branch-diff execution.

## Release context

Refs #278. This is a narrow extracted slice from `feat/contract-layer-hard-reset`; it does not close #278. The final #278 decision still depends on #285 DevPod + Hetzner validation recording whether runtime contract-layer drift remains.

## Test plan

- `uv run pytest testing/ci/tests/test_architecture_drift_guard.py`
- `scripts/check-architecture-drift`
- `uv run ruff check testing/ci/tests/test_architecture_drift_guard.py`
- `bash -n scripts/check-architecture-drift`
- Pre-push hook passed: ruff, ruff format, mypy, dbt version requirements, bandit, uv-secure, unit tests + coverage, contract tests, no hardcoded sleep, traceability, Helm lint.
