### PR TITLE
Propagate DevPod remote E2E runner failures

### DIFF
--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -205,6 +205,16 @@ if [[ ! "${DEVPOD_UP_RECOVERY_INTERVAL}" =~ ^[0-9]+$ ]] || [[ "${DEVPOD_UP_RECOV
     exit 1
 fi
 
+if [[ "${DEVPOD_REMOTE_RUN_ROOT}" != /* ]]; then
+    error "Invalid DEVPOD_REMOTE_RUN_ROOT='${DEVPOD_REMOTE_RUN_ROOT}': value must be an absolute path"
+    exit 1
+fi
+
+if [[ "${DEVPOD_REMOTE_RUN_ROOT}" == *"/../"* || "${DEVPOD_REMOTE_RUN_ROOT}" == */.. ]]; then
+    error "Invalid DEVPOD_REMOTE_RUN_ROOT='${DEVPOD_REMOTE_RUN_ROOT}': parent traversal is not allowed"
+    exit 1
+fi
+
 if [[ "${DEVPOD_ENABLE_REMOTE_TUNNELS}" != "0" && "${DEVPOD_ENABLE_REMOTE_TUNNELS}" != "1" ]]; then
     error "Invalid DEVPOD_ENABLE_REMOTE_TUNNELS='${DEVPOD_ENABLE_REMOTE_TUNNELS}'. Use: 0|1"
     exit 1
@@ -506,11 +516,15 @@ poll_remote_e2e_run() {
     poll_script=$(cat <<REMOTE_SCRIPT
 set -euo pipefail
 run_dir=${run_dir_q}
+pid=""
 if [[ -f "\${run_dir}/exit-code" ]]; then
     printf 'complete:%s\n' "\$(cat "\${run_dir}/exit-code")"
     exit 0
 fi
-if [[ -f "\${run_dir}/pid" ]] && kill -0 "\$(cat "\${run_dir}/pid")" 2>/dev/null; then
+if [[ -f "\${run_dir}/pid" ]]; then
+    pid=\$(cat "\${run_dir}/pid")
+fi
+if [[ "\${pid}" =~ ^[0-9]+$ ]] && kill -0 "\${pid}" 2>/dev/null; then
     printf 'running\n'
     exit 0
 fi
@@ -594,7 +608,7 @@ run_remote_e2e_detached() {
     poll_status=$?
     if [[ "${poll_status}" -eq 0 ]]; then
         if ! fetch_remote_e2e_artifacts; then
-            return 2
+            return 2  # poll OK but evidence artifacts missing
         fi
         if [[ -f "${LOCAL_REMOTE_ARTIFACTS_DIR}/output.log" ]]; then
             log "--- Remote E2E output (last 30 lines) ---"

--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -322,7 +322,7 @@ resolve_flux_ref_commit() {
     esac
 
     git rev-parse --verify --quiet "\${local_ref}" 2>/dev/null && return 0
-    git ls-remote --exit-code origin "\${remote_ref}" 2>/dev/null | awk 'NR == 1 { print $1; exit }'
+    git ls-remote --exit-code origin "\${remote_ref}" 2>/dev/null | awk 'NR == 1 { print \$1; exit }'
 }
 
 resolve_flux_expected_revision() {
@@ -577,19 +577,25 @@ fetch_remote_e2e_artifacts() {
         log "Remote E2E artifacts saved to ${LOCAL_REMOTE_ARTIFACTS_DIR}"
     else
         error "Failed to fetch remote E2E artifact bundle from ${REMOTE_RUN_DIR}"
+        return 1
     fi
 }
 
 run_remote_e2e_detached() {
     local remote_dir=""
     local exit_code=""
+    local poll_status=0
 
     log "Starting detached remote E2E run in ${REMOTE_RUN_DIR}..."
     remote_dir="$(start_remote_e2e_run)" || return 1
     log "Remote E2E started: ${remote_dir}"
 
-    if exit_code="$(poll_remote_e2e_run)"; then
-        fetch_remote_e2e_artifacts || true
+    exit_code="$(poll_remote_e2e_run)"
+    poll_status=$?
+    if [[ "${poll_status}" -eq 0 ]]; then
+        if ! fetch_remote_e2e_artifacts; then
+            return 2
+        fi
         if [[ -f "${LOCAL_REMOTE_ARTIFACTS_DIR}/output.log" ]]; then
             log "--- Remote E2E output (last 30 lines) ---"
             tail -30 "${LOCAL_REMOTE_ARTIFACTS_DIR}/output.log" >&2 || true
@@ -598,9 +604,8 @@ run_remote_e2e_detached() {
         return "${exit_code}"
     fi
 
-    exit_code=$?
     fetch_remote_e2e_artifacts || true
-    return "${exit_code}"
+    return "${poll_status}"
 }
 
 establish_service_tunnels() {
@@ -737,3 +742,4 @@ fi
 
 log "Step 5/5: Cleaning up..."
 # Cleanup happens automatically via the EXIT trap
+exit "${TEST_EXIT_CODE}"

--- a/testing/tests/unit/test_demo_makefile_kubeconfig.py
+++ b/testing/tests/unit/test_demo_makefile_kubeconfig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest
@@ -113,4 +115,28 @@ def test_devpod_successful_remote_run_requires_artifact_fetch() -> None:
 
     assert "return 1" in fetch_body
     assert "if ! fetch_remote_e2e_artifacts; then" in run_body
-    assert "return 2" in run_body
+    assert "return 2  # poll OK but evidence artifacts missing" in run_body
+
+
+@pytest.mark.requirement("285")
+def test_devpod_remote_run_root_rejects_relative_and_parent_paths() -> None:
+    """Remote artifact root must be absolute and reject parent traversal."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+
+    assert 'if [[ "${DEVPOD_REMOTE_RUN_ROOT}" != /* ]]; then' in test_script
+    assert 'if [[ "${DEVPOD_REMOTE_RUN_ROOT}" == *"/../"*' in test_script
+    assert '"${DEVPOD_REMOTE_RUN_ROOT}" == */..' in test_script
+
+
+@pytest.mark.requirement("285")
+def test_devpod_remote_poll_validates_pid_file_before_kill() -> None:
+    """Remote E2E polling must validate PID file content before probing."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+    poll_body = test_script.split("poll_remote_e2e_run() {", 1)[1].split(
+        "\nfetch_remote_e2e_artifacts() {", 1
+    )[0]
+
+    assert 'pid=\\$(cat "\\${run_dir}/pid")' in poll_body
+    assert '[[ "\\${pid}" =~ ^[0-9]+$ ]]' in poll_body
+    assert 'kill -0 "\\${pid}"' in poll_body
+    assert 'kill -0 "$(cat "${run_dir}/pid")"' not in poll_body

--- a/testing/tests/unit/test_demo_makefile_kubeconfig.py
+++ b/testing/tests/unit/test_demo_makefile_kubeconfig.py
@@ -66,3 +66,51 @@ def test_devpod_sync_waits_for_tunnel_readiness_before_returning() -> None:
     assert 'kill -0 "${TUNNEL_PID}"' in sync_script
     assert "SSH tunnel process exited before Kubernetes became reachable" in sync_script
     assert "DEVPOD_TUNNEL_TIMEOUT=120" in env_example
+
+
+@pytest.mark.requirement("285")
+def test_devpod_remote_script_escapes_inner_awk_fields() -> None:
+    """Generated remote script must not expand awk $1 in the local heredoc."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+
+    assert "awk 'NR == 1 { print \\$1; exit }'" in test_script
+    assert "awk 'NR == 1 { print $1; exit }'" not in test_script
+
+
+@pytest.mark.requirement("285")
+def test_devpod_remote_poll_failure_status_is_preserved() -> None:
+    """Remote E2E lost-process failures must propagate instead of becoming success."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+    function_body = test_script.split("run_remote_e2e_detached() {", 1)[1].split(
+        "\nestablish_service_tunnels() {", 1
+    )[0]
+
+    assert "local poll_status=0" in function_body
+    assert 'exit_code="$(poll_remote_e2e_run)"' in function_body
+    assert "poll_status=$?" in function_body
+    assert 'return "${poll_status}"' in function_body
+
+
+@pytest.mark.requirement("285")
+def test_devpod_script_exits_with_e2e_status() -> None:
+    """The DevPod lifecycle script must fail when the remote E2E lane fails."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+    cleanup_section = test_script.split('log "Step 5/5: Cleaning up..."', 1)[1]
+
+    assert 'exit "${TEST_EXIT_CODE}"' in cleanup_section
+
+
+@pytest.mark.requirement("285")
+def test_devpod_successful_remote_run_requires_artifact_fetch() -> None:
+    """Release validation success must include fetched remote evidence artifacts."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+    fetch_body = test_script.split("fetch_remote_e2e_artifacts() {", 1)[1].split(
+        "\nrun_remote_e2e_detached() {", 1
+    )[0]
+    run_body = test_script.split("run_remote_e2e_detached() {", 1)[1].split(
+        "\nestablish_service_tunnels() {", 1
+    )[0]
+
+    assert "return 1" in fetch_body
+    assert "if ! fetch_remote_e2e_artifacts; then" in run_body
+    assert "return 2" in run_body


### PR DESCRIPTION
## Summary

Fixes the DevPod remote E2E lifecycle runner so release-validation failures are no longer masked as success.

## Root Cause

The final #285 DevPod + Hetzner lane failed before tests started:

- `scripts/devpod-test.sh: line 471: $1: unbound variable`
- remote process was lost without an `exit-code`
- artifact fetch failed because the remote run directory was absent
- the script still printed `E2E tests PASSED` and exited 0

The root causes were:

- an inner awk `$1` was not escaped inside the generated local heredoc, so local `set -u` expanded it before the remote script was written;
- `run_remote_e2e_detached` read `$?` after the `if` statement, losing the failed poll status;
- the top-level lifecycle script never exited with `TEST_EXIT_CODE`;
- successful remote validation did not require evidence artifact fetch to succeed.

## Changes

- Escapes the generated remote awk field reference as `\$1`.
- Preserves and returns the actual `poll_remote_e2e_run` status.
- Requires artifact fetch for successful remote runs, because #285 needs evidence artifacts.
- Exits the lifecycle script with `TEST_EXIT_CODE` after cleanup is armed.
- Adds regression tests for all four failure-propagation behaviors.

## Validation

- `uv run pytest testing/tests/unit/test_demo_makefile_kubeconfig.py -q`
- `uv run pytest testing/tests/unit/test_demo_makefile_kubeconfig.py testing/tests/unit/test_demo_packaging.py -q`
- `bash -n scripts/devpod-test.sh`
- `shellcheck -e SC1091 -e SC2317 scripts/devpod-test.sh`
- `uv run ruff check testing/tests/unit/test_demo_makefile_kubeconfig.py`
- `uv run ruff format --check testing/tests/unit/test_demo_makefile_kubeconfig.py`
- `git diff --check`
- pre-push hook: lint, format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, hardcoded sleep guard, traceability, Helm lint

## Follow-up

After this merges, rerun #285 from `main` with:

```bash
DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full make devpod-test
```
