### PR TITLE
Fix weekly CI: install Flux CLI before cluster setup

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -78,6 +78,15 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           ~/.local/bin/dbt --version
 
+      - name: Install Flux CLI
+        run: |
+          FLUX_VERSION="2.5.1"
+          curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" -o /tmp/flux.tar.gz
+          tar -xzf /tmp/flux.tar.gz -C /tmp
+          sudo install /tmp/flux /usr/local/bin/flux
+          rm -f /tmp/flux.tar.gz /tmp/flux
+          flux --version
+
       - name: Setup Kind cluster and deploy services
         run: CLUSTER_NAME=floe-weekly ./testing/k8s/setup-cluster.sh
         env:
@@ -134,6 +143,15 @@ jobs:
           rm -f /tmp/dbt-install.sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           ~/.local/bin/dbt --version
+
+      - name: Install Flux CLI
+        run: |
+          FLUX_VERSION="2.5.1"
+          curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" -o /tmp/flux.tar.gz
+          tar -xzf /tmp/flux.tar.gz -C /tmp
+          sudo install /tmp/flux /usr/local/bin/flux
+          rm -f /tmp/flux.tar.gz /tmp/flux
+          flux --version
 
       - name: Setup Kind cluster and deploy services
         run: CLUSTER_NAME=floe-e2e ./testing/k8s/setup-cluster.sh

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -82,9 +82,11 @@ jobs:
         run: |
           FLUX_VERSION="2.5.1"
           curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" -o /tmp/flux.tar.gz
+          curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_checksums.txt" -o /tmp/flux_checksums.txt
+          grep "flux_${FLUX_VERSION}_linux_amd64.tar.gz" /tmp/flux_checksums.txt | (cd /tmp && sha256sum -c -)
           tar -xzf /tmp/flux.tar.gz -C /tmp
           sudo install /tmp/flux /usr/local/bin/flux
-          rm -f /tmp/flux.tar.gz /tmp/flux
+          rm -f /tmp/flux.tar.gz /tmp/flux /tmp/flux_checksums.txt
           flux --version
 
       - name: Setup Kind cluster and deploy services
@@ -148,9 +150,11 @@ jobs:
         run: |
           FLUX_VERSION="2.5.1"
           curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" -o /tmp/flux.tar.gz
+          curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_checksums.txt" -o /tmp/flux_checksums.txt
+          grep "flux_${FLUX_VERSION}_linux_amd64.tar.gz" /tmp/flux_checksums.txt | (cd /tmp && sha256sum -c -)
           tar -xzf /tmp/flux.tar.gz -C /tmp
           sudo install /tmp/flux /usr/local/bin/flux
-          rm -f /tmp/flux.tar.gz /tmp/flux
+          rm -f /tmp/flux.tar.gz /tmp/flux /tmp/flux_checksums.txt
           flux --version
 
       - name: Setup Kind cluster and deploy services


### PR DESCRIPTION
## Summary
- Add Flux CLI v2.5.1 install step to both integration-tests and e2e-tests jobs in the weekly workflow
- The weekly build has failed every week since #243 added a Flux prerequisite check to `setup-cluster.sh` without a corresponding install step in the workflow
- Version pinned to match `testing/ci/common.sh` `FLUX_VERSION`

## Test plan
- [ ] Trigger weekly workflow manually via `workflow_dispatch` and confirm integration-tests job passes the cluster setup step
- [ ] Verify `flux --version` output matches 2.5.1 in CI logs

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)