### PR TITLE
Fix pypa/gh-action-pypi-publish SHA pin

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -160,7 +160,7 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b54a51d261f4731310329898 # v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           packages-dir: dist/
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- The commit SHA pinning `pypa/gh-action-pypi-publish@v1.12.4` was incorrect (off by a few chars), causing the publish job to fail with "unable to find version"
- Corrected to the actual v1.12.4 tag SHA: `76f52bc884231f62b9a034ebfe128415bbaabdfc`

## Test plan
- [ ] Merge, then re-run the PyPI Publish workflow against `v0.1.0-alpha.1` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)