### PR TITLE
[codex] Validate observability E2E assertions

### DIFF
--- a/docs/superpowers/plans/2026-05-05-w3-observability-quality-e2e.md
+++ b/docs/superpowers/plans/2026-05-05-w3-observability-quality-e2e.md
@@ -1,0 +1,632 @@
+# W3 Observability Quality E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove Customer 360 lineage, telemetry, and Great Expectations quality validation work end-to-end against real E2E services and Iceberg data.
+
+**Architecture:** Keep W3 in the local E2E lane and reuse existing Floe fixtures. Add the missing GX real-data path by allowing the GX plugin to validate an explicitly supplied pandas DataFrame, then add an E2E that loads Customer 360 Iceberg data and runs a concrete `QualitySuite`. Tighten Jaeger evidence so stale traces do not satisfy the Alpha observability requirement.
+
+**Tech Stack:** Python 3.10+, pytest, Pydantic v2 schemas, Great Expectations, pandas, PyIceberg/Polaris, Jaeger Query API, OpenTelemetry, existing Floe E2E fixtures.
+
+---
+
+## File Structure
+
+- Modify `plugins/floe-quality-gx/src/floe_quality_gx/executor.py`
+  - Add a `dataframe` connection path to `create_dataframe_from_connection()`.
+  - Keep existing DuckDB behavior intact.
+- Create `plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py`
+  - Unit coverage for the DataFrame handoff and defensive copying.
+- Create `tests/e2e/test_quality_gx_e2e.py`
+  - Real Customer 360 Iceberg table load plus GX plugin validation.
+- Modify `tests/e2e/test_observability.py`
+  - Tighten `test_otel_traces_in_jaeger` so it emits fresh compile-time traces inside a bounded Jaeger query window.
+- Existing files to read before editing:
+  - `plugins/floe-quality-gx/src/floe_quality_gx/plugin.py`
+  - `plugins/floe-quality-gx/src/floe_quality_gx/executor.py`
+  - `tests/e2e/conftest.py`
+  - `tests/e2e/test_data_pipeline.py`
+  - `tests/e2e/test_observability_roundtrip_e2e.py`
+  - `demo/customer-360/models/schema.yml`
+
+---
+
+### Task 1: Add DataFrame Handoff To GX Plugin
+
+**Files:**
+- Modify: `plugins/floe-quality-gx/src/floe_quality_gx/executor.py`
+- Create: `plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py`
+
+- [ ] **Step 1: Write failing unit tests for DataFrame connection support**
+
+Create `plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py`:
+
+```python
+"""Unit tests for DataFrame-backed Great Expectations validation."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from floe_core.schemas.quality_config import Dimension, SeverityLevel
+from floe_core.schemas.quality_score import QualityCheck, QualitySuite
+from floe_quality_gx import GreatExpectationsPlugin
+from floe_quality_gx.executor import create_dataframe_from_connection
+
+
+def test_create_dataframe_from_connection_accepts_explicit_dataframe() -> None:
+    """DataFrame connection config returns the supplied data for validation."""
+    source = pd.DataFrame(
+        {
+            "customer_id": ["C001", "C002"],
+            "segment": ["enterprise", "smb"],
+        }
+    )
+
+    result = create_dataframe_from_connection(
+        {"dialect": "pandas", "dataframe": source},
+        "mart_customer_360",
+    )
+
+    assert result.equals(source)
+    assert result is not source
+
+
+def test_create_dataframe_from_connection_rejects_non_dataframe() -> None:
+    """DataFrame connection config must fail loudly for wrong object types."""
+    with pytest.raises(
+        TypeError,
+        match="connection_config\\['dataframe'\\] must be a pandas DataFrame",
+    ):
+        create_dataframe_from_connection(
+            {"dialect": "pandas", "dataframe": [{"customer_id": "C001"}]},
+            "mart_customer_360",
+        )
+
+
+def test_gx_plugin_run_suite_validates_supplied_dataframe() -> None:
+    """GreatExpectationsPlugin.run_suite validates checks against supplied data."""
+    plugin = GreatExpectationsPlugin()
+    dataframe = pd.DataFrame(
+        {
+            "customer_id": ["C001", "C002", "C003"],
+            "segment": ["enterprise", "smb", "startup"],
+        }
+    )
+    suite = QualitySuite(
+        model_name="mart_customer_360",
+        checks=[
+            QualityCheck(
+                name="customer_id_not_null",
+                type="not_null",
+                column="customer_id",
+                dimension=Dimension.COMPLETENESS,
+                severity=SeverityLevel.CRITICAL,
+            ),
+            QualityCheck(
+                name="customer_id_unique",
+                type="unique",
+                column="customer_id",
+                dimension=Dimension.CONSISTENCY,
+                severity=SeverityLevel.CRITICAL,
+            ),
+            QualityCheck(
+                name="segment_values",
+                type="values_in_set",
+                column="segment",
+                dimension=Dimension.VALIDITY,
+                severity=SeverityLevel.WARNING,
+                parameters={"value_set": ["enterprise", "mid_market", "smb", "startup", "unknown"]},
+            ),
+            QualityCheck(
+                name="row_count_bounds",
+                type="row_count_between",
+                dimension=Dimension.COMPLETENESS,
+                severity=SeverityLevel.WARNING,
+                parameters={"min_value": 3, "max_value": 3},
+            ),
+        ],
+        timeout_seconds=30,
+    )
+
+    result = plugin.run_suite(suite, {"dialect": "pandas", "dataframe": dataframe})
+
+    assert result.model_name == "mart_customer_360"
+    assert result.suite_name == "mart_customer_360_suite"
+    assert result.passed is True
+    assert result.summary["total"] == 4
+    assert result.summary["passed"] == 4
+    assert result.summary["failed"] == 0
+    assert {check.check_name for check in result.checks} == {
+        "customer_id_not_null",
+        "customer_id_unique",
+        "segment_values",
+        "row_count_bounds",
+    }
+    assert all(check.passed for check in result.checks)
+    assert any(
+        check.check_name == "customer_id_not_null" and check.records_checked == 3
+        for check in result.checks
+    )
+```
+
+- [ ] **Step 2: Run the focused unit tests and verify they fail**
+
+Run:
+
+```bash
+pytest plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py -q
+```
+
+Expected: FAIL because `create_dataframe_from_connection()` currently returns an empty DataFrame for non-DuckDB dialects, and `run_suite()` cannot validate the supplied DataFrame.
+
+- [ ] **Step 3: Add explicit DataFrame support**
+
+Modify `plugins/floe-quality-gx/src/floe_quality_gx/executor.py` in `create_dataframe_from_connection()` after `dialect = connection_config.get("dialect", "duckdb")` and before the DuckDB branch:
+
+```python
+    if "dataframe" in connection_config or dialect in {"pandas", "dataframe"}:
+        dataframe = connection_config.get("dataframe")
+        if not isinstance(dataframe, pd.DataFrame):
+            msg = "connection_config['dataframe'] must be a pandas DataFrame"
+            raise TypeError(msg)
+        return dataframe.copy(deep=True)
+```
+
+Keep the existing DuckDB branch unchanged.
+
+- [ ] **Step 4: Run the focused unit tests and verify they pass**
+
+Run:
+
+```bash
+pytest plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run existing GX unit coverage**
+
+Run:
+
+```bash
+pytest plugins/floe-quality-gx/tests/unit -q
+```
+
+Expected: PASS. Existing DuckDB/empty-check behavior must remain unchanged.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add plugins/floe-quality-gx/src/floe_quality_gx/executor.py \
+  plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
+git commit -m "Add DataFrame-backed GX validation"
+```
+
+---
+
+### Task 2: Add Real-Iceberg GX E2E Validation
+
+**Files:**
+- Create: `tests/e2e/test_quality_gx_e2e.py`
+
+- [ ] **Step 1: Write the failing E2E test**
+
+Create `tests/e2e/test_quality_gx_e2e.py`:
+
+```python
+"""E2E tests for Great Expectations validation against real Iceberg data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+from floe_core.schemas.quality_config import Dimension, SeverityLevel
+from floe_core.schemas.quality_score import QualityCheck, QualitySuite
+from floe_quality_gx import GreatExpectationsPlugin
+
+from testing.base_classes.integration_test_base import IntegrationTestBase
+from testing.fixtures.polaris import rewrite_table_io_for_host_access
+
+
+@pytest.mark.e2e
+@pytest.mark.requirement("W3-QUALITY-GX")
+class TestGreatExpectationsIcebergE2E(IntegrationTestBase):
+    """Validate GX checks against Customer 360 data materialized in Iceberg."""
+
+    required_services: ClassVar[list[str]] = [
+        "polaris",
+        "minio",
+    ]
+
+    def _load_customer_360_dataframe(self, polaris_client: Any) -> Any:
+        """Load the Customer 360 mart table through Polaris and return pandas data."""
+        namespace = "customer_360"
+        table_name = "mart_customer_360"
+
+        available_tables = [table[1] for table in polaris_client.list_tables(namespace)]
+        assert table_name in available_tables, (
+            f"Expected {namespace}.{table_name} to exist after dbt_pipeline_result. "
+            f"Available tables: {available_tables}"
+        )
+
+        table = polaris_client.load_table(f"{namespace}.{table_name}")
+        rewrite_table_io_for_host_access(table)
+        dataframe = table.scan().to_arrow().to_pandas()
+        assert not dataframe.empty, f"{namespace}.{table_name} should contain real demo rows"
+        return dataframe
+
+    @pytest.mark.parametrize("dbt_pipeline_result", ["customer-360"], indirect=True)
+    def test_gx_plugin_validates_real_customer_360_iceberg_data(
+        self,
+        dbt_pipeline_result: tuple[str, Path],
+        polaris_client: Any,
+    ) -> None:
+        """GreatExpectationsPlugin validates checks against real Iceberg data."""
+        product, _project_dir = dbt_pipeline_result
+        assert product == "customer-360"
+        self.check_infrastructure("polaris")
+        self.check_infrastructure("minio")
+
+        dataframe = self._load_customer_360_dataframe(polaris_client)
+        row_count = len(dataframe)
+        assert row_count == 500, (
+            "Customer 360 mart should preserve one row per raw customer. "
+            f"Expected 500 rows, got {row_count}"
+        )
+
+        suite = QualitySuite(
+            model_name="mart_customer_360",
+            checks=[
+                QualityCheck(
+                    name="customer_id_not_null",
+                    type="not_null",
+                    column="customer_id",
+                    dimension=Dimension.COMPLETENESS,
+                    severity=SeverityLevel.CRITICAL,
+                ),
+                QualityCheck(
+                    name="customer_id_unique",
+                    type="unique",
+                    column="customer_id",
+                    dimension=Dimension.CONSISTENCY,
+                    severity=SeverityLevel.CRITICAL,
+                ),
+                QualityCheck(
+                    name="segment_values",
+                    type="values_in_set",
+                    column="segment",
+                    dimension=Dimension.VALIDITY,
+                    severity=SeverityLevel.WARNING,
+                    parameters={"value_set": ["enterprise", "mid_market", "smb", "startup", "unknown"]},
+                ),
+                QualityCheck(
+                    name="row_count_bounds",
+                    type="row_count_between",
+                    dimension=Dimension.COMPLETENESS,
+                    severity=SeverityLevel.WARNING,
+                    parameters={"min_value": 500, "max_value": 500},
+                ),
+            ],
+            timeout_seconds=60,
+        )
+
+        result = GreatExpectationsPlugin().run_suite(
+            suite,
+            {"dialect": "pandas", "dataframe": dataframe},
+        )
+
+        assert result.suite_name == "mart_customer_360_suite"
+        assert result.model_name == "mart_customer_360"
+        assert result.passed is True
+        assert result.summary["total"] == 4
+        assert result.summary["passed"] == 4
+        assert result.summary["failed"] == 0
+
+        check_names = {check.check_name for check in result.checks}
+        assert check_names == {
+            "customer_id_not_null",
+            "customer_id_unique",
+            "segment_values",
+            "row_count_bounds",
+        }
+        assert all(check.passed for check in result.checks)
+        assert any(
+            check.check_name == "customer_id_not_null"
+            and check.records_checked == row_count
+            and check.records_failed == 0
+            for check in result.checks
+        )
+```
+
+- [ ] **Step 2: Run the focused E2E test**
+
+Run with the local E2E stack active:
+
+```bash
+pytest tests/e2e/test_quality_gx_e2e.py -m e2e -q
+```
+
+Expected before Task 1 is implemented: FAIL because the GX plugin cannot validate the supplied DataFrame. Expected after Task 1: PASS if Polaris/MinIO/dbt E2E services are healthy.
+
+- [ ] **Step 3: If row count differs, inspect the generated mart before changing assertions**
+
+Run:
+
+```bash
+pytest tests/e2e/test_data_pipeline.py::TestDataPipeline::test_medallion_layers -q
+```
+
+Expected: PASS. The existing test asserts the Customer 360 mart row count is greater
+than zero and does not exceed the raw customer count. If the new exact `500`
+assertion fails, inspect the existing Customer 360 table contract with:
+
+```bash
+rg -n "mart_customer_360|raw_customers|SEED_ROW_COUNTS" tests/e2e/test_data_pipeline.py
+```
+
+Then update only the new E2E assertion to match the repo's existing Customer 360
+mart contract.
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add tests/e2e/test_quality_gx_e2e.py
+git commit -m "Add GX E2E validation for Customer 360 Iceberg data"
+```
+
+---
+
+### Task 3: Tighten Jaeger Trace Freshness
+
+**Files:**
+- Modify: `tests/e2e/test_observability.py`
+
+- [ ] **Step 1: Update imports for bounded fresh trace emission**
+
+Modify the imports near the top of `tests/e2e/test_observability.py` so `time` is available:
+
+```python
+import json
+import os
+import re
+import time
+from collections.abc import Callable
+```
+
+- [ ] **Step 2: Replace `test_otel_traces_in_jaeger` with a fresh compile-time trace check**
+
+In `tests/e2e/test_observability.py`, replace the body and signature of `test_otel_traces_in_jaeger` with:
+
+```python
+    @pytest.mark.e2e
+    @pytest.mark.requirement("FR-040")
+    @pytest.mark.requirement("FR-047")
+    def test_otel_traces_in_jaeger(
+        self,
+        e2e_namespace: str,
+        jaeger_client: httpx.Client,
+        dagster_client: Any,
+        project_root: Path,
+    ) -> None:
+        """Validate a fresh Customer 360 compilation trace is queryable in Jaeger."""
+        from floe_core.compilation.stages import compile_pipeline
+        from floe_core.telemetry.initialization import (
+            ensure_telemetry_initialized,
+            reset_telemetry,
+        )
+        from testing.fixtures.polling import wait_for_condition
+
+        self.check_infrastructure("dagster")
+        self.check_infrastructure("jaeger-query")
+
+        spec_path = project_root / "demo" / "customer-360" / "floe.yaml"
+        manifest_path = project_root / "demo" / "manifest.yaml"
+        service_name = "customer-360"
+        start_time = int(time.time() * 1_000_000)
+
+        saved_env: dict[str, str | None] = {
+            "OTEL_EXPORTER_OTLP_ENDPOINT": os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
+            "OTEL_EXPORTER_OTLP_INSECURE": os.environ.get("OTEL_EXPORTER_OTLP_INSECURE"),
+            "OTEL_SERVICE_NAME": os.environ.get("OTEL_SERVICE_NAME"),
+        }
+        try:
+            reset_telemetry()
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = ServiceEndpoint("otel-collector-grpc").url
+            os.environ["OTEL_EXPORTER_OTLP_INSECURE"] = "true"
+            os.environ["OTEL_SERVICE_NAME"] = service_name
+            ensure_telemetry_initialized()
+
+            artifacts = compile_pipeline(spec_path, manifest_path)
+            assert artifacts.metadata.product_name == service_name
+        finally:
+            reset_telemetry()
+            for key, value in saved_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        end_time = int(time.time() * 1_000_000)
+
+        def _fresh_trace_data() -> list[dict[str, Any]]:
+            response = jaeger_client.get(
+                "/api/traces",
+                params={
+                    "service": service_name,
+                    "start": start_time,
+                    "end": end_time + 60_000_000,
+                    "limit": 20,
+                },
+            )
+            if response.status_code != 200:
+                return []
+            return list(response.json().get("data") or [])
+
+        traces_found = wait_for_condition(
+            lambda: len(_fresh_trace_data()) > 0,
+            timeout=30.0,
+            interval=3.0,
+            description="fresh customer-360 compilation traces in Jaeger",
+            raise_on_timeout=False,
+        )
+        traces = _fresh_trace_data()
+        if not traces_found or not traces:
+            services_response = jaeger_client.get("/api/services")
+            services = (
+                services_response.json().get("data", [])
+                if services_response.status_code == 200
+                else []
+            )
+            pytest.fail(
+                "OBSERVABILITY GAP: No fresh traces found for 'customer-360' "
+                "inside the current test window.\n"
+                f"Available services: {services}\n"
+                "Expected compilation spans to export through OTel Collector to Jaeger."
+            )
+
+        first_trace = traces[0]
+        assert "traceID" in first_trace, "Trace missing traceID"
+        spans = first_trace.get("spans", [])
+        assert spans, "Fresh trace has no spans"
+
+        operation_names = [span.get("operationName", "") for span in spans]
+        assert all(operation_names), f"Fresh trace contains empty operation names: {operation_names}"
+
+        tag_keys = {
+            tag.get("key", "")
+            for span in spans
+            for tag in span.get("tags", [])
+        }
+        domain_attributes = [
+            key
+            for key in tag_keys
+            if key.startswith(("compile.", "governance.", "enforcement.", "floe."))
+        ]
+        assert domain_attributes, (
+            "TRACE GAP: Fresh customer-360 trace has no Floe domain attributes.\n"
+            f"Tag keys found: {sorted(tag_keys)}"
+        )
+```
+
+- [ ] **Step 3: Run the targeted Jaeger E2E**
+
+Run with the local E2E stack active:
+
+```bash
+pytest tests/e2e/test_observability.py::TestObservability::test_otel_traces_in_jaeger -m e2e -q
+```
+
+Expected: PASS when OTel Collector and Jaeger are healthy. FAIL should clearly say whether there are no fresh traces, no spans, or missing domain attributes.
+
+- [ ] **Step 4: Run the existing round-trip trace test**
+
+Run:
+
+```bash
+pytest tests/e2e/test_observability_roundtrip_e2e.py::TestObservabilityRoundTrip::test_compilation_generates_traces -m e2e -q
+```
+
+Expected: PASS. If this fails with the same no-fresh-traces message, fix telemetry export wiring rather than weakening assertions.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add tests/e2e/test_observability.py
+git commit -m "Require fresh Jaeger traces in observability E2E"
+```
+
+---
+
+### Task 4: Final Verification And Review
+
+**Files:**
+- Verify all files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run focused unit tests**
+
+```bash
+pytest plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py -q
+pytest plugins/floe-quality-gx/tests/unit -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused E2E tests**
+
+With the local E2E stack active, run:
+
+```bash
+pytest tests/e2e/test_quality_gx_e2e.py -m e2e -q
+pytest tests/e2e/test_observability.py::TestObservability::test_otel_traces_in_jaeger -m e2e -q
+pytest tests/e2e/test_lineage_roundtrip_e2e.py::TestLineageRoundTrip::test_runtime_lifecycle_runs_visible_for_compiled_product -m e2e -q
+```
+
+Expected: PASS. The lineage command is verification-only because existing tests already assert a fresh Customer 360 Marquez run.
+
+- [ ] **Step 3: Run lint/type checks for touched Python files**
+
+```bash
+ruff check plugins/floe-quality-gx/src/floe_quality_gx/executor.py \
+  plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py \
+  tests/e2e/test_quality_gx_e2e.py \
+  tests/e2e/test_observability.py
+ruff format --check plugins/floe-quality-gx/src/floe_quality_gx/executor.py \
+  plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py \
+  tests/e2e/test_quality_gx_e2e.py \
+  tests/e2e/test_observability.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the local E2E lane when practical**
+
+```bash
+make test-e2e
+```
+
+Expected: PASS. If this is too expensive for the current session, record the focused E2E results and explicitly state that full `make test-e2e` was not run.
+
+- [ ] **Step 5: Review changed files**
+
+```bash
+git diff --stat HEAD~3..HEAD
+git diff HEAD~3..HEAD -- plugins/floe-quality-gx/src/floe_quality_gx/executor.py
+git diff HEAD~3..HEAD -- tests/e2e/test_quality_gx_e2e.py
+git diff HEAD~3..HEAD -- tests/e2e/test_observability.py
+```
+
+Expected:
+
+- production change is limited to the GX DataFrame connection path;
+- new GX E2E uses real `dbt_pipeline_result`, `polaris_client`, and Iceberg table data;
+- Jaeger test uses a bounded time window around a fresh compilation;
+- no mocks are introduced in the E2E path.
+
+- [ ] **Step 6: Final commit if verification-only fixes were needed**
+
+Only if Task 4 required follow-up edits:
+
+```bash
+git add <changed-files>
+git commit -m "Stabilize W3 observability quality E2E validation"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage:
+  - Lineage fresh evidence is covered by Task 4 verification of the existing fresh-run lineage E2E.
+  - Telemetry fresh evidence is covered by Task 3.
+  - GX real-Iceberg evidence is covered by Tasks 1 and 2.
+  - Small production wiring fixes are limited to Task 1.
+- Placeholder scan:
+  - No placeholder markers or unspecified implementation steps are present.
+  - All code-changing steps include concrete code.
+- Type consistency:
+  - `QualityCheck`, `QualitySuite`, `Dimension`, and `SeverityLevel` imports match existing schema modules.
+  - DataFrame handoff uses `connection_config["dataframe"]` consistently in unit and E2E tests.
+  - Jaeger trace parsing follows the existing `{"data": [...]}` API shape used in current tests.

--- a/docs/superpowers/specs/2026-05-05-w3-observability-quality-e2e-design.md
+++ b/docs/superpowers/specs/2026-05-05-w3-observability-quality-e2e-design.md
@@ -1,0 +1,220 @@
+# W3 Observability And Quality E2E Design
+
+## Objective
+
+Add focused Alpha E2E assertions proving the Customer 360 demo emits and exposes
+real observability and quality evidence:
+
+- OpenLineage events arrive in Marquez with Customer 360 identities.
+- OpenTelemetry traces arrive in Jaeger with Customer 360 service/span evidence.
+- Great Expectations validates real Customer 360 data materialized in Iceberg.
+
+The work is test-led. Small production-code fixes are allowed only when stronger
+E2E assertions prove missing wiring in the exercised path.
+
+## Scope
+
+W3 belongs in the normal local `make test-e2e` lane. The assertions should reuse
+existing E2E fixtures and avoid becoming a second remote release-validation
+suite.
+
+In scope:
+
+- Tighten lineage evidence to fresh Customer 360 runs where current tests rely on
+  weaker or synthetic checks.
+- Tighten telemetry evidence to traces created inside a bounded test window.
+- Add the missing GX real-data path against Customer 360 Iceberg tables.
+- Add focused production wiring fixes if the E2E path cannot truthfully pass.
+
+Out of scope:
+
+- Custom lineage facet validation.
+- Trace sampling, performance, or retention validation.
+- Quality alerting integration.
+- Broad observability or plugin-system refactors.
+- Moving W3 exclusively to DevPod/Hetzner remote validation.
+
+## Existing Context
+
+The repository already has stronger observability coverage than the starting
+prompt implies:
+
+- `tests/e2e/test_lineage_roundtrip_e2e.py` includes fresh Marquez run checks for
+  runtime lineage.
+- `tests/e2e/test_observability.py` includes Marquez graph, emission-point, and
+  trace content assertions.
+- `tests/e2e/test_observability_roundtrip_e2e.py` validates compile-time traces
+  flowing through the OTel Collector into Jaeger.
+- `tests/e2e/test_data_pipeline.py` runs dbt quality checks through
+  `dbt test`.
+
+The remaining Alpha gap is Great Expectations against real Iceberg data. The
+main telemetry risk is accepting stale seeded traces instead of evidence created
+by the current test run.
+
+## Components
+
+### E2E Tests
+
+Prefer a new focused file, `tests/e2e/test_quality_gx_e2e.py`, for GX real-data
+validation. This keeps plugin-level GX evidence separate from dbt pipeline
+quality checks in `tests/e2e/test_data_pipeline.py`.
+
+Tighten existing observability tests in place when possible:
+
+- `tests/e2e/test_observability.py`
+- `tests/e2e/test_observability_roundtrip_e2e.py`
+- `tests/e2e/test_lineage_roundtrip_e2e.py`
+
+Avoid adding duplicate observability modules unless the existing files cannot be
+cleanly extended.
+
+### Fixtures
+
+Reuse existing fixtures before adding new ones:
+
+- `compiled_artifacts`
+- `dbt_pipeline_result`
+- `polaris_client`
+- `marquez_client`
+- `jaeger_client`
+- `trigger_lineage_run`
+- `wait_for_condition`
+
+Add helper functions only when they remove duplicated polling, parsing, or
+freshness logic.
+
+### Production Code
+
+Production edits are permitted only when an E2E assertion proves a missing
+integration point. Likely allowed areas:
+
+- `plugins/floe-quality-gx/src/floe_quality_gx/`
+- telemetry exporter initialization or service-name wiring
+- lineage event emission or identity propagation
+
+Do not add test-specific demo assumptions to production code.
+
+## Data Flow
+
+1. Compile `demo/customer-360/floe.yaml` with the real demo manifest.
+2. Derive expected product, namespace, service, model, and table identities from
+   `CompiledArtifacts` or existing demo fixture conventions.
+3. Trigger or reuse a fresh Customer 360 execution through existing E2E fixtures.
+4. Query external systems for concrete evidence:
+   - Marquez for fresh OpenLineage jobs, runs, events, and datasets.
+   - Jaeger for traces in the test time window.
+   - Polaris/Iceberg for materialized Customer 360 tables.
+5. Run `GreatExpectationsPlugin.run_suite()` against a DataFrame loaded from a
+   real Iceberg table.
+6. Assert names, states, span operations, attributes, check results, and record
+   counts.
+
+This preserves ownership boundaries: dbt owns SQL compilation, Iceberg owns
+table storage, Marquez and Jaeger own observability backends, and GX owns
+quality validation.
+
+## Lineage Requirements
+
+Lineage E2E evidence must be tied to the current Customer 360 run.
+
+Assertions should verify:
+
+- artifact-derived lineage namespace and product job name are present;
+- a fresh Marquez run appears after the test snapshot;
+- the fresh run reaches `COMPLETED`;
+- expected model or dataset names are present when the test targets graph
+  completeness;
+- synthetic Marquez POSTs do not count as Alpha runtime evidence.
+
+Existing synthetic Marquez API tests can remain as backend smoke coverage, but
+they must not be the only proof for W3.
+
+## Telemetry Requirements
+
+Telemetry E2E evidence must be fresh or bounded by a timestamp captured around
+the compile or execution action.
+
+Assertions should verify:
+
+- Jaeger returns traces for `customer-360`;
+- traces were created in the test's bounded time window;
+- spans have non-empty operation names;
+- spans include useful Floe/domain attributes such as `compile.*`,
+  `governance.*`, `enforcement.*`, or `floe.*`;
+- parent-child span relationships are asserted where the tested path should
+  create nested spans.
+
+Seeded traces from previous runs should not satisfy W3 by themselves.
+
+## Quality GX Requirements
+
+The GX test should prove the plugin validates real Customer 360 data that was
+materialized into Iceberg.
+
+Recommended flow:
+
+1. Use `dbt_pipeline_result` parametrized for `customer-360` to run seed and
+   model materialization.
+2. Load a stable Customer 360 table through `polaris_client`.
+3. Convert the table scan to a pandas DataFrame.
+4. Build a concrete `QualitySuite` with checks such as:
+   - `customer_id` not null;
+   - `customer_id` unique on a dimension table;
+   - row count between expected bounds;
+   - a known categorical/status column values in an expected set, if available.
+5. Execute `GreatExpectationsPlugin.run_suite()` against the loaded data.
+6. Assert:
+   - suite name and model name;
+   - all checks passed;
+   - expected check names are present;
+   - summary total, passed, and failed counts;
+   - records were checked for column-level validations.
+
+If the current plugin can only load DuckDB tables through connection config, the
+E2E may pass the Iceberg-loaded DataFrame into the existing validation executor
+directly, or production code may be minimally extended to support an explicit
+DataFrame/Arrow handoff. Prefer the smallest truthful integration surface.
+
+## Error Handling
+
+W3 tests should fail loudly. Do not skip required Alpha evidence.
+
+Failure messages should distinguish:
+
+- infrastructure unavailable: Jaeger, Marquez, Polaris, MinIO, OTel Collector,
+  or Dagster cannot be reached;
+- no fresh evidence: the backend is reachable, but the current test run produced
+  no new trace, lineage, or quality result;
+- wrong evidence: data exists, but names, states, attributes, or validation
+  results do not match Customer 360 expectations;
+- plugin wiring failure: GX, telemetry, or lineage plugin cannot run against the
+  real E2E data path.
+
+Use bounded polling for Jaeger and Marquez. GX validation is synchronous once
+the Iceberg data is loaded and should fail directly.
+
+## Verification Plan
+
+Implementation should proceed test-first:
+
+1. Add the W3 E2E assertions.
+2. Run focused GX E2E validation:
+   `pytest tests/e2e/test_quality_gx_e2e.py -m e2e`
+3. Run targeted observability tests if they are changed.
+4. Apply minimal production wiring fixes only for failures proven by the tests.
+5. Add focused unit or contract coverage for any touched production code.
+6. Run lint/type checks for touched Python files.
+7. Run the normal local E2E lane when practical:
+   `make test-e2e`
+
+## Acceptance Criteria
+
+- Lineage evidence is fresh and tied to Customer 360 artifact-derived identities.
+- Jaeger evidence is fresh or time-windowed and tied to `customer-360`.
+- GX validates real Iceberg-backed Customer 360 data with concrete result
+  assertions.
+- No mocks are used in the E2E path.
+- Existing E2E cleanup semantics remain intact.
+- Production changes, if any, are limited to wiring required by the new E2E
+  assertions.

--- a/plugins/floe-quality-gx/src/floe_quality_gx/executor.py
+++ b/plugins/floe-quality-gx/src/floe_quality_gx/executor.py
@@ -297,6 +297,13 @@ def create_dataframe_from_connection(
 
     dialect = connection_config.get("dialect", "duckdb")
 
+    if "dataframe" in connection_config or dialect in {"pandas", "dataframe"}:
+        dataframe = connection_config.get("dataframe")
+        if not isinstance(dataframe, pd.DataFrame):
+            msg = "connection_config['dataframe'] must be a pandas DataFrame"
+            raise TypeError(msg)
+        return dataframe.copy(deep=True)
+
     if dialect == "duckdb":
         import duckdb
 

--- a/plugins/floe-quality-gx/src/floe_quality_gx/executor.py
+++ b/plugins/floe-quality-gx/src/floe_quality_gx/executor.py
@@ -285,6 +285,8 @@ def create_dataframe_from_connection(
 
     This is a placeholder that should be enhanced to support
     various connection types (DuckDB, PostgreSQL, Snowflake).
+    When ``connection_config`` includes a ``dataframe`` key, the supplied
+    DataFrame takes precedence over the configured dialect.
 
     Args:
         connection_config: Database connection configuration.

--- a/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
+++ b/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from floe_quality_gx import GreatExpectationsPlugin
 
 
+@pytest.mark.requirement("W3-QUALITY-GX")
 def test_create_dataframe_from_connection_accepts_pandas_dataframe() -> None:
     """DataFrame connection configs return equivalent data as a defensive copy."""
     from floe_quality_gx.executor import create_dataframe_from_connection
@@ -44,6 +45,7 @@ def test_create_dataframe_from_connection_accepts_pandas_dataframe() -> None:
         {"dataframe": None},
     ],
 )
+@pytest.mark.requirement("W3-QUALITY-GX")
 def test_create_dataframe_from_connection_rejects_non_dataframe_values(
     connection_config: dict[str, Any],
 ) -> None:
@@ -57,6 +59,7 @@ def test_create_dataframe_from_connection_rejects_non_dataframe_values(
         create_dataframe_from_connection(connection_config, table_name="customers")
 
 
+@pytest.mark.requirement("W3-QUALITY-GX")
 def test_run_suite_validates_supplied_dataframe(
     gx_plugin: GreatExpectationsPlugin,
 ) -> None:

--- a/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
+++ b/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
@@ -1,0 +1,123 @@
+"""Unit tests for DataFrame-backed Great Expectations validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+import pytest
+from floe_core.schemas.quality_config import Dimension, SeverityLevel
+from floe_core.schemas.quality_score import QualityCheck, QualitySuite
+
+if TYPE_CHECKING:
+    from floe_quality_gx import GreatExpectationsPlugin
+
+
+def test_create_dataframe_from_connection_accepts_pandas_dataframe() -> None:
+    """DataFrame connection configs return equivalent data as a defensive copy."""
+    from floe_quality_gx.executor import create_dataframe_from_connection
+
+    source_df = pd.DataFrame(
+        {
+            "customer_id": [1, 2, 3],
+            "status": ["active", "pending", "active"],
+        }
+    )
+
+    result = create_dataframe_from_connection(
+        {"dialect": "pandas", "dataframe": source_df},
+        table_name="customers",
+    )
+
+    pd.testing.assert_frame_equal(result, source_df)
+    assert result is not source_df
+
+    result.loc[0, "status"] = "inactive"
+    assert source_df.loc[0, "status"] == "active"
+
+
+@pytest.mark.parametrize(
+    "connection_config",
+    [
+        {"dialect": "pandas", "dataframe": [{"customer_id": 1}]},
+        {"dialect": "dataframe", "dataframe": "not a dataframe"},
+        {"dataframe": None},
+    ],
+)
+def test_create_dataframe_from_connection_rejects_non_dataframe_values(
+    connection_config: dict[str, Any],
+) -> None:
+    """DataFrame connection configs require a pandas DataFrame value."""
+    from floe_quality_gx.executor import create_dataframe_from_connection
+
+    with pytest.raises(
+        TypeError,
+        match=r"connection_config\['dataframe'\] must be a pandas DataFrame",
+    ):
+        create_dataframe_from_connection(connection_config, table_name="customers")
+
+
+def test_run_suite_validates_supplied_dataframe(
+    gx_plugin: GreatExpectationsPlugin,
+) -> None:
+    """run_suite validates a pandas DataFrame supplied in connection_config."""
+    source_df = pd.DataFrame(
+        {
+            "customer_id": [1, 2, 3],
+            "email": ["a@example.com", "b@example.com", "c@example.com"],
+            "status": ["active", "pending", "active"],
+        }
+    )
+    suite = QualitySuite(
+        model_name="customers",
+        checks=[
+            QualityCheck(
+                name="customer_id_not_null",
+                type="not_null",
+                column="customer_id",
+                dimension=Dimension.COMPLETENESS,
+                severity=SeverityLevel.CRITICAL,
+            ),
+            QualityCheck(
+                name="customer_id_unique",
+                type="unique",
+                column="customer_id",
+                dimension=Dimension.CONSISTENCY,
+                severity=SeverityLevel.CRITICAL,
+            ),
+            QualityCheck(
+                name="status_values_in_set",
+                type="values_in_set",
+                column="status",
+                dimension=Dimension.VALIDITY,
+                severity=SeverityLevel.WARNING,
+                parameters={"value_set": ["active", "pending"]},
+            ),
+            QualityCheck(
+                name="row_count_between",
+                type="row_count_between",
+                dimension=Dimension.COMPLETENESS,
+                severity=SeverityLevel.CRITICAL,
+                parameters={"min_value": 3, "max_value": 3},
+            ),
+        ],
+    )
+
+    result = gx_plugin.run_suite(
+        suite,
+        {"dialect": "pandas", "dataframe": source_df},
+    )
+
+    assert result.suite_name == "customers_suite"
+    assert result.model_name == "customers"
+    assert result.summary["total"] == 4
+    assert result.summary["passed"] == 4
+    assert result.summary["failed"] == 0
+    assert [check.check_name for check in result.checks] == [
+        "customer_id_not_null",
+        "customer_id_unique",
+        "status_values_in_set",
+        "row_count_between",
+    ]
+    assert all(check.passed for check in result.checks)
+    assert result.checks[0].records_checked == 3

--- a/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
+++ b/plugins/floe-quality-gx/tests/unit/test_dataframe_connection.py
@@ -64,12 +64,11 @@ def test_run_suite_validates_supplied_dataframe(
     source_df = pd.DataFrame(
         {
             "customer_id": [1, 2, 3],
-            "email": ["a@example.com", "b@example.com", "c@example.com"],
-            "status": ["active", "pending", "active"],
+            "segment": ["enterprise", "smb", "startup"],
         }
     )
     suite = QualitySuite(
-        model_name="customers",
+        model_name="mart_customer_360",
         checks=[
             QualityCheck(
                 name="customer_id_not_null",
@@ -86,18 +85,18 @@ def test_run_suite_validates_supplied_dataframe(
                 severity=SeverityLevel.CRITICAL,
             ),
             QualityCheck(
-                name="status_values_in_set",
+                name="segment_values",
                 type="values_in_set",
-                column="status",
+                column="segment",
                 dimension=Dimension.VALIDITY,
                 severity=SeverityLevel.WARNING,
-                parameters={"value_set": ["active", "pending"]},
+                parameters={"value_set": ["enterprise", "mid_market", "smb", "startup", "unknown"]},
             ),
             QualityCheck(
-                name="row_count_between",
+                name="row_count_bounds",
                 type="row_count_between",
                 dimension=Dimension.COMPLETENESS,
-                severity=SeverityLevel.CRITICAL,
+                severity=SeverityLevel.WARNING,
                 parameters={"min_value": 3, "max_value": 3},
             ),
         ],
@@ -108,16 +107,17 @@ def test_run_suite_validates_supplied_dataframe(
         {"dialect": "pandas", "dataframe": source_df},
     )
 
-    assert result.suite_name == "customers_suite"
-    assert result.model_name == "customers"
+    assert result.suite_name == "mart_customer_360_suite"
+    assert result.model_name == "mart_customer_360"
+    assert result.passed is True
     assert result.summary["total"] == 4
     assert result.summary["passed"] == 4
     assert result.summary["failed"] == 0
     assert [check.check_name for check in result.checks] == [
         "customer_id_not_null",
         "customer_id_unique",
-        "status_values_in_set",
-        "row_count_between",
+        "segment_values",
+        "row_count_bounds",
     ]
     assert all(check.passed for check in result.checks)
     assert result.checks[0].records_checked == 3

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -522,8 +522,8 @@ class TestObservability(IntegrationTestBase):
             dagster_client: Dagster GraphQL client.
             project_root: Repository root fixture.
         """
-        from floe_core.compiler import compile_pipeline
-        from floe_core.telemetry import (
+        from floe_core.compilation.stages import compile_pipeline
+        from floe_core.telemetry.initialization import (
             ensure_telemetry_initialized,
             reset_telemetry,
         )

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -527,6 +527,7 @@ class TestObservability(IntegrationTestBase):
             ensure_telemetry_initialized,
             reset_telemetry,
         )
+        from opentelemetry import trace as otel_trace
 
         from testing.fixtures.polling import wait_for_condition
 
@@ -537,6 +538,7 @@ class TestObservability(IntegrationTestBase):
         spec_path = project_root / "demo" / "customer-360" / "floe.yaml"
         manifest_path = project_root / "demo" / "manifest.yaml"
         service_name = "customer-360"
+        test_run_id = f"w3-observability-{e2e_namespace}"
         start_time = int(time.time() * 1_000_000)
 
         saved_env = {
@@ -550,7 +552,11 @@ class TestObservability(IntegrationTestBase):
             os.environ["OTEL_EXPORTER_OTLP_INSECURE"] = "true"
             os.environ["OTEL_SERVICE_NAME"] = service_name
             ensure_telemetry_initialized()
-            artifacts = compile_pipeline(spec_path, manifest_path)
+            tracer = otel_trace.get_tracer("floe.e2e.observability")
+            with tracer.start_as_current_span("w3_observability_compile") as span:
+                span.set_attribute("floe.test_run_id", test_run_id)
+                span.set_attribute("floe.product_name", service_name)
+                artifacts = compile_pipeline(spec_path, manifest_path)
             assert artifacts.metadata.product_name == service_name
         finally:
             reset_telemetry()
@@ -576,16 +582,34 @@ class TestObservability(IntegrationTestBase):
                 return []
             return list(response.json().get("data") or [])
 
-        traces_available = wait_for_condition(
-            lambda: len(_fresh_trace_data()) > 0,
+        def _trace_tag_pairs(trace: dict[str, Any]) -> list[tuple[str, Any]]:
+            return [
+                (str(tag.get("key")), tag.get("value"))
+                for span in trace.get("spans", [])
+                for tag in span.get("tags", [])
+                if isinstance(tag, dict) and tag.get("key")
+            ]
+
+        def _matching_trace(traces: list[dict[str, Any]]) -> dict[str, Any] | None:
+            for trace in traces:
+                if any(
+                    key == "floe.test_run_id" and value == test_run_id
+                    for key, value in _trace_tag_pairs(trace)
+                ):
+                    return trace
+            return None
+
+        wait_for_condition(
+            lambda: _matching_trace(_fresh_trace_data()) is not None,
             timeout=30.0,
             interval=3.0,
             description="fresh customer-360 compilation traces in Jaeger",
             raise_on_timeout=False,
         )
-        traces = _fresh_trace_data() if traces_available else []
+        traces = _fresh_trace_data()
+        matching_trace = _matching_trace(traces)
 
-        if not traces:
+        if matching_trace is None:
             services: list[Any] = []
             services_error = ""
             try:
@@ -601,35 +625,34 @@ class TestObservability(IntegrationTestBase):
             pytest.fail(
                 "OBSERVABILITY GAP: No fresh traces found for 'customer-360' inside "
                 "the current test window.\n"
-                f"Available Jaeger services: {services}.{services_error}"
+                f"Available Jaeger services: {services}. "
+                f"Traces in window: {len(traces)}.{services_error}"
             )
 
         # Validate trace structure contains real spans
-        first_trace = traces[0]
-        assert "traceID" in first_trace, "Trace missing traceID"
-        assert "spans" in first_trace, "Trace missing spans"
-        assert len(first_trace["spans"]) > 0, (
+        assert "traceID" in matching_trace, "Trace missing traceID"
+        assert "spans" in matching_trace, "Trace missing spans"
+        assert len(matching_trace["spans"]) > 0, (
             "Trace exists but has no spans. OTel instrumentation is emitting "
             "empty traces without span data."
         )
 
-        spans = first_trace["spans"]
+        spans = matching_trace["spans"]
         assert all(span.get("operationName") for span in spans), (
             "At least one span has empty operationName -- OTel instrumentation "
             "is not setting span names"
         )
 
-        tag_keys = {
-            tag.get("key")
-            for span in spans
-            for tag in span.get("tags", [])
-            if isinstance(tag, dict) and tag.get("key")
-        }
+        tag_keys = {key for key, _value in _trace_tag_pairs(matching_trace)}
         assert any(
             str(key).startswith(("compile.", "governance.", "enforcement.", "floe."))
             for key in tag_keys
         ), (
             "TRACE GAP: Fresh customer-360 trace has no Floe domain attributes.\n"
+            f"Tag keys found: {sorted(str(key) for key in tag_keys)}"
+        )
+        assert any(str(key).startswith("compile.") for key in tag_keys), (
+            "TRACE GAP: Fresh customer-360 trace has no compile span attributes.\n"
             f"Tag keys found: {sorted(str(key) for key in tag_keys)}"
         )
 

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -506,43 +507,102 @@ class TestObservability(IntegrationTestBase):
         e2e_namespace: str,
         jaeger_client: httpx.Client,
         dagster_client: Any,
+        project_root: Path,
     ) -> None:
-        """Validate that OTel traces with real spans exist in Jaeger for the customer-360 service.
+        """Validate that fresh OTel traces exist in Jaeger for customer-360 compilation.
 
         Demands that:
-        1. Jaeger contains traces for the 'customer-360' service
+        1. Jaeger contains traces for this test's compilation window
         2. Traces contain spans with operation names
-        3. The services list includes 'customer-360'
+        3. Spans carry Floe domain attributes
 
         Args:
             e2e_namespace: Unique namespace for test isolation.
             jaeger_client: Jaeger query HTTP client.
             dagster_client: Dagster GraphQL client.
+            project_root: Repository root fixture.
         """
+        from floe_core.compiler import compile_pipeline
+        from floe_core.telemetry import (
+            ensure_telemetry_initialized,
+            reset_telemetry,
+        )
+
+        from testing.fixtures.polling import wait_for_condition
+
         # Check infrastructure availability - FAIL if not available
         self.check_infrastructure("dagster")
         self.check_infrastructure("jaeger-query")
 
-        # Query Jaeger for customer-360 service traces
+        spec_path = project_root / "demo" / "customer-360" / "floe.yaml"
+        manifest_path = project_root / "demo" / "manifest.yaml"
         service_name = "customer-360"
-        traces_response = jaeger_client.get(
-            "/api/traces",
-            params={"service": service_name, "limit": 5},
-        )
-        assert traces_response.status_code == 200, (
-            f"Jaeger traces query failed: {traces_response.status_code}"
-        )
-        traces_json = traces_response.json()
-        assert "data" in traces_json, "Jaeger traces response missing 'data' key"
+        start_time = int(time.time() * 1_000_000)
 
-        traces = traces_json["data"]
-        assert len(traces) > 0, (
-            "OBSERVABILITY GAP: No traces found for 'customer-360' service in Jaeger.\n"
-            "The OTel pipeline is not emitting traces during compilation or pipeline execution.\n"
-            "Fix: Configure OTel SDK in floe-core compilation "
-            "stages to emit spans.\n"
-            "Expected: Each compilation stage should emit a span."
+        saved_env = {
+            "OTEL_EXPORTER_OTLP_ENDPOINT": os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"),
+            "OTEL_EXPORTER_OTLP_INSECURE": os.environ.get("OTEL_EXPORTER_OTLP_INSECURE"),
+            "OTEL_SERVICE_NAME": os.environ.get("OTEL_SERVICE_NAME"),
+        }
+        try:
+            reset_telemetry()
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = ServiceEndpoint("otel-collector-grpc").url
+            os.environ["OTEL_EXPORTER_OTLP_INSECURE"] = "true"
+            os.environ["OTEL_SERVICE_NAME"] = service_name
+            ensure_telemetry_initialized()
+            artifacts = compile_pipeline(spec_path, manifest_path)
+            assert artifacts.metadata.product_name == service_name
+        finally:
+            reset_telemetry()
+            for key, value in saved_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        end_time = int(time.time() * 1_000_000)
+
+        def _fresh_trace_data() -> list[dict[str, Any]]:
+            response = jaeger_client.get(
+                "/api/traces",
+                params={
+                    "service": service_name,
+                    "start": start_time,
+                    "end": end_time + 60_000_000,
+                    "limit": 20,
+                },
+            )
+            if response.status_code != 200:
+                return []
+            return list(response.json().get("data") or [])
+
+        traces_available = wait_for_condition(
+            lambda: len(_fresh_trace_data()) > 0,
+            timeout=30.0,
+            interval=3.0,
+            description="fresh customer-360 compilation traces in Jaeger",
+            raise_on_timeout=False,
         )
+        traces = _fresh_trace_data() if traces_available else []
+
+        if not traces:
+            services: list[Any] = []
+            services_error = ""
+            try:
+                services_response = jaeger_client.get("/api/services")
+                if services_response.status_code == 200:
+                    services = list(services_response.json().get("data") or [])
+                else:
+                    services_error = (
+                        f" Jaeger services endpoint returned {services_response.status_code}."
+                    )
+            except Exception as exc:
+                services_error = f" Jaeger services endpoint failed: {exc}."
+            pytest.fail(
+                "OBSERVABILITY GAP: No fresh traces found for 'customer-360' inside "
+                "the current test window.\n"
+                f"Available Jaeger services: {services}.{services_error}"
+            )
 
         # Validate trace structure contains real spans
         first_trace = traces[0]
@@ -553,25 +613,24 @@ class TestObservability(IntegrationTestBase):
             "empty traces without span data."
         )
 
-        # Validate spans have required attributes for pipeline debugging
-        first_span = first_trace["spans"][0]
-        assert "operationName" in first_span, "Span missing operationName"
-        assert len(first_span["operationName"]) > 0, (
-            "Span has empty operationName -- OTel instrumentation not setting span names"
+        spans = first_trace["spans"]
+        assert all(span.get("operationName") for span in spans), (
+            "At least one span has empty operationName -- OTel instrumentation "
+            "is not setting span names"
         )
 
-        # Verify services list includes customer-360
-        response = jaeger_client.get("/api/services")
-        assert response.status_code == 200, (
-            f"Jaeger services endpoint failed: {response.status_code}"
-        )
-        services_json = response.json()
-        assert "data" in services_json, "Jaeger services response missing 'data' key"
-        services = services_json["data"]
-        assert "customer-360" in services, (
-            f"OBSERVABILITY GAP: 'customer-360' not in Jaeger services list.\n"
-            f"Services found: {services}\n"
-            "Fix: Configure OTel SDK with service.name='customer-360'"
+        tag_keys = {
+            tag.get("key")
+            for span in spans
+            for tag in span.get("tags", [])
+            if isinstance(tag, dict) and tag.get("key")
+        }
+        assert any(
+            str(key).startswith(("compile.", "governance.", "enforcement.", "floe."))
+            for key in tag_keys
+        ), (
+            "TRACE GAP: Fresh customer-360 trace has no Floe domain attributes.\n"
+            f"Tag keys found: {sorted(str(key) for key in tag_keys)}"
         )
 
     @pytest.mark.e2e

--- a/tests/e2e/test_quality_gx_e2e.py
+++ b/tests/e2e/test_quality_gx_e2e.py
@@ -1,0 +1,128 @@
+"""E2E tests for Great Expectations validation against real Iceberg data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+from floe_core.schemas.quality_config import Dimension, SeverityLevel
+from floe_core.schemas.quality_score import QualityCheck, QualitySuite
+from floe_quality_gx import GreatExpectationsPlugin
+
+from testing.base_classes.integration_test_base import IntegrationTestBase
+from testing.fixtures.polaris import rewrite_table_io_for_host_access
+
+
+@pytest.mark.e2e
+@pytest.mark.requirement("W3-QUALITY-GX")
+class TestGreatExpectationsIcebergE2E(IntegrationTestBase):
+    """E2E validation for GX checks over Customer 360 Iceberg data."""
+
+    required_services: ClassVar[list[str]] = ["polaris", "minio"]
+
+    def _load_customer_360_dataframe(self, polaris_client: Any) -> Any:
+        """Load the Customer 360 mart table from Iceberg as a pandas DataFrame."""
+        namespace = "customer_360"
+        table_name = "mart_customer_360"
+        tables = polaris_client.list_tables(namespace)
+        table_names = [table[-1] if isinstance(table, tuple | list) else table for table in tables]
+        assert table_name in table_names, (
+            f"Expected Iceberg table {namespace}.{table_name} to exist. "
+            f"Available tables in {namespace}: {tables}"
+        )
+
+        table = polaris_client.load_table(f"{namespace}.{table_name}")
+        rewrite_table_io_for_host_access(table)
+        dataframe = table.scan().to_arrow().to_pandas()
+        assert not dataframe.empty, f"Expected {namespace}.{table_name} to contain rows"
+        return dataframe
+
+    @pytest.mark.parametrize("dbt_pipeline_result", ["customer-360"], indirect=True)
+    def test_gx_plugin_validates_real_customer_360_iceberg_data(
+        self,
+        dbt_pipeline_result: tuple[str, Path],
+        polaris_client: Any,
+    ) -> None:
+        """Validate real Customer 360 Iceberg data through Great Expectations."""
+        product, _project_dir = dbt_pipeline_result
+        assert product == "customer-360"
+        self.check_infrastructure("polaris")
+        self.check_infrastructure("minio")
+
+        dataframe = self._load_customer_360_dataframe(polaris_client)
+        row_count = len(dataframe)
+        assert row_count == 500, (
+            "Customer 360 mart should have one row per raw customer; "
+            f"expected 500 rows, got {row_count}"
+        )
+
+        suite = QualitySuite(
+            model_name="mart_customer_360",
+            timeout_seconds=60,
+            checks=[
+                QualityCheck(
+                    name="customer_id_not_null",
+                    type="not_null",
+                    column="customer_id",
+                    dimension=Dimension.COMPLETENESS,
+                    severity=SeverityLevel.CRITICAL,
+                ),
+                QualityCheck(
+                    name="customer_id_unique",
+                    type="unique",
+                    column="customer_id",
+                    dimension=Dimension.CONSISTENCY,
+                    severity=SeverityLevel.CRITICAL,
+                ),
+                QualityCheck(
+                    name="segment_values",
+                    type="values_in_set",
+                    column="segment",
+                    dimension=Dimension.VALIDITY,
+                    severity=SeverityLevel.WARNING,
+                    parameters={
+                        "value_set": [
+                            "enterprise",
+                            "mid_market",
+                            "smb",
+                            "startup",
+                            "unknown",
+                        ]
+                    },
+                ),
+                QualityCheck(
+                    name="row_count_bounds",
+                    type="row_count_between",
+                    dimension=Dimension.COMPLETENESS,
+                    severity=SeverityLevel.WARNING,
+                    parameters={"min_value": 500, "max_value": 500},
+                ),
+            ],
+        )
+
+        result = GreatExpectationsPlugin().run_suite(
+            suite,
+            {"dialect": "pandas", "dataframe": dataframe},
+        )
+
+        assert result.suite_name == "mart_customer_360_suite"
+        assert result.model_name == "mart_customer_360"
+        assert result.passed is True
+        assert result.summary["total"] == 4
+        assert result.summary["passed"] == 4
+        assert result.summary["failed"] == 0
+
+        check_names = {check.check_name for check in result.checks}
+        assert check_names == {
+            "customer_id_not_null",
+            "customer_id_unique",
+            "segment_values",
+            "row_count_bounds",
+        }
+        assert all(check.passed for check in result.checks)
+
+        checks_by_name = {check.check_name: check for check in result.checks}
+        customer_id_not_null = checks_by_name["customer_id_not_null"]
+        assert customer_id_not_null.records_checked == row_count
+        assert customer_id_not_null.records_failed == 0

--- a/tests/e2e/test_quality_gx_e2e.py
+++ b/tests/e2e/test_quality_gx_e2e.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, ClassVar
 
+import pandas as pd
 import pytest
 from floe_core.schemas.quality_config import Dimension, SeverityLevel
 from floe_core.schemas.quality_score import QualityCheck, QualitySuite
@@ -21,7 +22,7 @@ class TestGreatExpectationsIcebergE2E(IntegrationTestBase):
 
     required_services: ClassVar[list[str]] = ["polaris", "minio"]
 
-    def _load_customer_360_dataframe(self, polaris_client: Any) -> Any:
+    def _load_customer_360_dataframe(self, polaris_client: Any) -> pd.DataFrame:
         """Load the Customer 360 mart table from Iceberg as a pandas DataFrame."""
         namespace = "customer_360"
         table_name = "mart_customer_360"


### PR DESCRIPTION
## Summary

This PR strengthens W3 observability and quality E2E validation after the storage/catalogue refactor landed on `main`.

- Adds the W3 observability quality E2E design and plan artifacts.
- Adds DataFrame-backed Great Expectations validation coverage for Customer 360 Iceberg data.
- Strengthens observability E2E assertions so Jaeger trace checks use fresh current-run evidence rather than seeded or stale traces.
- Aligns telemetry imports with the canonical runtime surface after the composability-layer refactor.

## Validation

Remote DevPod / Hetzner full E2E run:

```text
DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full make devpod-test
```

Evidence from run `devpod-run-20260507T060348Z-77916` against commit `bf5710c7069bbd168440255b890f6db194784c8e`:

- Bootstrap: 10 passed
- Platform blackbox: 253 passed, 86 deselected, 1 warning
- Developer workflow: 69 passed
- Destructive E2E: 7 passed, 332 deselected
- Overall remote lane: E2E tests PASSED

Observability-specific remote assertions passed for Jaeger traces, Marquez/OpenLineage events, trace-lineage correlation, non-blocking telemetry behavior, trace content validation, four compilation emission points, and compilation OTel spans.

Cleanup was also verified after the run: DevPod workspace/machine deletion completed and direct Hetzner API inventory showed no remaining servers, volumes, load balancers, floating IPs, or SSH keys.