### PR TITLE
Add identity and secret composition contracts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2229,7 +2229,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "testing/fixtures/golden/oci_pull/pull_plugins_config.json",
-        "hashed_secret": "37293cdd49cf70af411aa28a5f3f7687fdee6596",
+        "hashed_secret": "462c75a2514e57018a8531e5e11fdaea1d97cca1",
         "is_verified": false,
         "line_number": 5,
         "is_secret": false
@@ -2239,7 +2239,7 @@
       {
         "type": "Hex High Entropy String",
         "filename": "testing/fixtures/golden/oci_pull/pull_success_artifact_structure.json",
-        "hashed_secret": "bbea3270a14f9ff7ff9429c9a80336d4a298477f",
+        "hashed_secret": "69ac65072e39d8fbcd89feb3c833187ab66e2afb",
         "is_verified": false,
         "line_number": 5
       }

--- a/docs/architecture/interfaces/catalog-plugin.md
+++ b/docs/architecture/interfaces/catalog-plugin.md
@@ -30,6 +30,14 @@ binding and emits Polaris-owned `storageConfigInfo` inputs, endpoint/internal
 endpoint, path-style access, STS unavailable/enabled semantics, allowed
 locations, and storage Secret references.
 
+Through `get_storage_requirements()`, catalog requirements may name
+`credential_modes`, `secret_projection_modes`, `identity_modes`, and provider
+labels. The composition resolver validates those requirements against the
+selected storage, secrets, and identity plugins before deployment bindings are
+rendered. Catalog plugins still own catalog-specific translation, such as
+Polaris bootstrap payloads or Glue IAM assumptions; `floe-core` only validates
+the shared composition vocabulary.
+
 ## Interface Definition
 
 ```python

--- a/docs/architecture/interfaces/identity-plugin.md
+++ b/docs/architecture/interfaces/identity-plugin.md
@@ -7,6 +7,28 @@
 
 IdentityPlugin abstracts identity providers (Keycloak, Dex, Okta, Auth0), enabling consistent OIDC-based authentication across all floe services.
 
+## Composition Capabilities
+
+Identity plugins declare workload identity support with
+`get_identity_capabilities(self) -> PluginCapabilities`. The composition
+resolver uses this declaration to validate storage and catalog requirements
+that rely on identity-based credentials.
+
+Supported `identity_modes` are:
+
+- `aws-irsa` - AWS IAM Roles for Service Accounts.
+- `aws-pod-identity` - AWS EKS Pod Identity.
+- `gcp-workload-identity` - Google Kubernetes Engine Workload Identity.
+- `azure-workload-identity` - Azure workload identity federation.
+- `azure-managed-identity` - Azure managed identity.
+- `oidc-federation` - Generic OIDC federation for providers that support
+  workload identity through OIDC trust.
+
+`floe-core` validates named modes and provider labels only. Plugins own
+provider-specific translation, including service account annotations,
+federated credential objects, IAM role bindings, tenant IDs, and other
+cloud-specific resources.
+
 ## Interface Definition
 
 ```python

--- a/docs/architecture/interfaces/secrets-plugin.md
+++ b/docs/architecture/interfaces/secrets-plugin.md
@@ -7,6 +7,29 @@
 
 SecretsPlugin abstracts credential storage and retrieval, supporting Kubernetes Secrets, External Secrets Operator (ESO), HashiCorp Vault, and other secret management solutions.
 
+## Composition Capabilities
+
+Secrets plugins declare their credential projection surface with
+`get_secret_capabilities(self) -> PluginCapabilities`. The composition resolver
+uses this secret-free declaration to validate storage and catalog requirements
+before deployment bindings are rendered.
+
+Supported `secret_projection_modes` are:
+
+- `kubernetes-secret` - Credentials are available through a Kubernetes Secret
+  reference.
+- `external-secret-sync` - Credentials are synchronized by an external secrets
+  controller and referenced without embedding secret values.
+- `csi-secret-volume` - Credentials are projected through a CSI secret volume.
+- `environment` - Credentials are projected as environment variables from a
+  managed secret source.
+
+Capabilities must not contain raw secret values. Provider-specific fields, such
+as Infisical project IDs, Vault paths, or cloud secret manager identifiers,
+remain in provider-owned plugin config or provider-owned deployment bindings.
+`floe-core` validates named modes and provider labels; the secrets plugin owns
+translation into its runtime or controller-specific resources.
+
 ## Interface Definition
 
 ```python

--- a/docs/architecture/interfaces/storage-plugin.md
+++ b/docs/architecture/interfaces/storage-plugin.md
@@ -31,6 +31,14 @@ capability, provisioning intent, runtime fragments, and credential-ref facts.
 Polaris translates those facts into `storageConfigInfo`; MinIO does not know
 Polaris bootstrap JSON.
 
+Storage credential capabilities use the shared composition vocabulary.
+`credential_modes` may include `kubernetes-secret`, `external-secret-sync`,
+`csi-secret-volume`, `environment`, `workload-identity`, and `none`.
+`secret_projection_modes` and `identity_modes` describe how the selected
+credential mode is realized through secrets or workload identity plugins. The
+selected deployment credential mode must be one of the storage plugin's
+declared modes before deployment bindings are rendered.
+
 ## Interface Definition
 
 The snippet below shows the target semantic contract. The current migration-era

--- a/docs/architecture/plugin-composition-uplift-tracker.md
+++ b/docs/architecture/plugin-composition-uplift-tracker.md
@@ -34,7 +34,7 @@ clear target state.
 | Compute / dbt | 3 | In storage composition PR for DuckDB/dbt profile path | Runtime storage binding consumption, profile generation, endpoint/credential consistency |
 | Orchestrator / Dagster | 3 | In storage composition PR for Dagster runtime path | Run pod env/Secret refs, Iceberg resource binding, endpoint consistency |
 | Helm / deployment renderer | 3 | In storage composition PR | Render resolved deployment bindings; no semantic storage decisions in templates |
-| Secrets / identity | 1 | Minimal in storage composition PR | Credential modes and Secret refs; broader identity provider uplift later |
+| Secrets / identity | 2 | PCU-005 implemented | Credential projection and workload identity modes are typed capabilities validated by the resolver |
 
 ## Follow-On Plugin Families
 
@@ -85,5 +85,5 @@ clear target state.
 | PCU-002 | Catalog | Add Glue catalog design | Glue rejects incompatible S3-compatible storage and accepts native S3 |
 | PCU-003 | Catalog | Add Nessie catalog design | Nessie integration documents server-side vs client-side storage access |
 | PCU-004 | Ingestion | Add landing/quarantine/checkpoint bucket requirements | Ingestion consumes storage bucket requirements |
-| PCU-005 | Security | Connect credential binding to identity/secrets plugins | Workload identity and external secret modes are resolver-validated |
+| PCU-005 | Security | Connect credential binding to identity/secrets plugins | Implemented: workload identity and external secret modes are resolver-validated |
 | PCU-006 | Network | Generate network policies from deployment bindings | Policies use plugin endpoints rather than static chart service assumptions |

--- a/docs/superpowers/plans/2026-05-07-identity-secret-composition.md
+++ b/docs/superpowers/plans/2026-05-07-identity-secret-composition.md
@@ -1,0 +1,1687 @@
+# Identity And Secret Composition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement PCU-005 by making identity and secret credential delivery a typed, resolver-validated plugin composition contract.
+
+**Architecture:** Extend compiled plugin references with selected `secrets` and `identity` providers, then add typed secret projection and workload identity capability fields to the composition model. Provider plugins declare side-effect-free capabilities, and `CompositionResolver` validates storage/catalog credential requirements against selected secrets and identity providers while preserving the current MinIO plus Polaris Kubernetes Secret path.
+
+**Tech Stack:** Python 3.11, Pydantic v2, pytest, Floe plugin registry, Floe composition resolver, existing `floe-core` compilation pipeline.
+
+---
+
+## File Structure
+
+- Modify `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+  - Add `secrets` and `identity` optional `PluginRef` fields to `ResolvedPlugins`.
+  - Keep the contract secret-free and backward-compatible for artifacts that omit these fields.
+- Modify `packages/floe-core/src/floe_core/compilation/resolver.py`
+  - Pass through `manifest.plugins.secrets` and `manifest.plugins.identity` into `ResolvedPlugins`.
+- Modify `packages/floe-core/src/floe_core/composition/models.py`
+  - Add typed aliases for credential, secret projection, and identity modes.
+  - Add `secret_projection_modes`, `identity_modes`, and `providers` to `CapabilitySet` and `RequirementSet`.
+- Modify `packages/floe-core/src/floe_core/composition/__init__.py`
+  - Export new mode aliases if the implementation exports them from `models.py`.
+- Modify `packages/floe-core/src/floe_core/plugins/secrets.py`
+  - Add default `get_secret_capabilities()` method returning an empty secrets capability.
+- Modify `packages/floe-core/src/floe_core/plugins/identity.py`
+  - Add default `get_identity_capabilities()` method returning an empty identity capability.
+- Modify `plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py`
+  - Declare `kubernetes-secret` projection support and `kubernetes` provider.
+- Modify `plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py`
+  - Declare `external-secret-sync` and `kubernetes-secret` projection support with `infisical` provider.
+- Modify `plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py`
+  - Declare `oidc-federation` identity support with `oidc` provider.
+- Modify `packages/floe-core/src/floe_core/composition/resolver.py`
+  - Validate secret projection and identity requirements in addition to current storage/catalog compatibility checks.
+- Modify `packages/floe-core/src/floe_core/compilation/stages.py`
+  - Collect selected secrets and identity capabilities and pass them to `CompositionResolver`.
+- Modify `docs/architecture/plugin-composition-uplift-tracker.md`
+  - Update PCU-005 status after implementation lands.
+- Modify `docs/architecture/interfaces/secrets-plugin.md`
+  - Document `get_secret_capabilities()` and projection vocabulary.
+- Modify `docs/architecture/interfaces/identity-plugin.md`
+  - Document `get_identity_capabilities()` and identity-mode vocabulary.
+- Modify `docs/architecture/interfaces/storage-plugin.md`
+  - Reference the new credential vocabulary from storage capabilities.
+- Modify `docs/architecture/interfaces/catalog-plugin.md`
+  - Reference the new credential vocabulary from catalog requirements.
+- Test files:
+  - `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`
+  - `packages/floe-core/tests/unit/compilation/test_resolver.py` if present; otherwise use `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`
+  - `packages/floe-core/tests/unit/composition/test_resolver.py`
+  - `plugins/floe-secrets-k8s/tests/unit/test_plugin.py`
+  - `plugins/floe-secrets-infisical/tests/unit/test_plugin.py`
+  - `plugins/floe-identity-keycloak/tests/unit/test_init.py`
+  - `tests/contract/test_storage_binding_security.py`
+
+## Task 1: Add Secrets And Identity To Resolved Plugins
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`
+- Modify: `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+- Modify: `packages/floe-core/src/floe_core/compilation/resolver.py`
+
+- [ ] **Step 1: Write the failing `ResolvedPlugins` schema test**
+
+Add this test to `class TestResolvedPlugins` in `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`:
+
+```python
+    @pytest.mark.requirement("PCU-005")
+    def test_valid_resolved_plugins_includes_secrets_and_identity(self) -> None:
+        """ResolvedPlugins should expose selected security providers."""
+        plugins = ResolvedPlugins(
+            compute=PluginRef(type="duckdb", version="0.9.0"),
+            orchestrator=PluginRef(type="dagster", version="1.5.0"),
+            secrets=PluginRef(
+                type="k8s",
+                version="0.1.0",
+                config={"namespace": "floe-system"},
+            ),
+            identity=PluginRef(
+                type="keycloak",
+                version="0.1.0",
+                config={"realm": "floe"},
+            ),
+        )
+
+        assert plugins.secrets is not None
+        assert plugins.secrets.type == "k8s"
+        assert plugins.secrets.config == {"namespace": "floe-system"}
+        assert plugins.identity is not None
+        assert plugins.identity.type == "keycloak"
+        assert plugins.identity.config == {"realm": "floe"}
+```
+
+- [ ] **Step 2: Run the schema test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestResolvedPlugins::test_valid_resolved_plugins_includes_secrets_and_identity -q
+```
+
+Expected: FAIL with Pydantic extra-field validation errors for `secrets` and `identity`.
+
+- [ ] **Step 3: Add fields to `ResolvedPlugins`**
+
+In `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`, add the two fields after `lineage_backend`:
+
+```python
+    secrets: PluginRef | None = Field(
+        default=None,
+        description="Resolved secrets plugin (optional)",
+    )
+    identity: PluginRef | None = Field(
+        default=None,
+        description="Resolved identity plugin (optional)",
+    )
+```
+
+Update the `ResolvedPlugins` docstring attribute list so it names `secrets` and `identity`.
+
+- [ ] **Step 4: Run the schema test and verify it passes**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestResolvedPlugins::test_valid_resolved_plugins_includes_secrets_and_identity -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing resolver pass-through test**
+
+Add this test to `packages/floe-core/tests/unit/compilation/test_resolver.py` if that file exists. If it does not exist, create it with the imports shown here:
+
+```python
+"""Unit tests for platform plugin resolution."""
+
+from __future__ import annotations
+
+from floe_core.compilation.resolver import resolve_plugins
+from floe_core.schemas.manifest import PlatformManifest
+from floe_core.schemas.metadata import ManifestMetadata
+from floe_core.schemas.plugins import PluginSelection, PluginsConfig
+```
+
+Then add:
+
+```python
+def test_resolve_plugins_preserves_secrets_and_identity_selections() -> None:
+    """Compilation should expose selected security providers in artifacts."""
+    manifest = PlatformManifest(
+        metadata=ManifestMetadata(name="platform", version="1.0.0"),
+        plugins=PluginsConfig(
+            compute=PluginSelection(type="duckdb", version="0.9.0"),
+            orchestrator=PluginSelection(type="dagster", version="1.5.0"),
+            secrets=PluginSelection(
+                type="k8s",
+                version="0.1.0",
+                config={"namespace": "floe-system"},
+            ),
+            identity=PluginSelection(
+                type="keycloak",
+                version="0.1.0",
+                config={"realm": "floe"},
+            ),
+        ),
+    )
+
+    resolved = resolve_plugins(manifest)
+
+    assert resolved.secrets is not None
+    assert resolved.secrets.type == "k8s"
+    assert resolved.secrets.config == {"namespace": "floe-system"}
+    assert resolved.identity is not None
+    assert resolved.identity.type == "keycloak"
+    assert resolved.identity.config == {"realm": "floe"}
+```
+
+- [ ] **Step 6: Run the resolver test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/compilation/test_resolver.py::test_resolve_plugins_preserves_secrets_and_identity_selections -q
+```
+
+Expected: FAIL because `resolve_plugins()` does not set `secrets` or `identity`.
+
+- [ ] **Step 7: Pass through secrets and identity selections**
+
+In `packages/floe-core/src/floe_core/compilation/resolver.py`, update `resolve_plugins()`:
+
+```python
+    return ResolvedPlugins(
+        compute=_to_plugin_ref(plugins.compute),  # type: ignore[arg-type]
+        orchestrator=_to_plugin_ref(plugins.orchestrator),  # type: ignore[arg-type]
+        catalog=_to_plugin_ref(plugins.catalog),
+        storage=_to_plugin_ref(plugins.storage),
+        ingestion=_to_plugin_ref(plugins.ingestion),
+        semantic=_to_plugin_ref(plugins.semantic_layer),
+        lineage_backend=_to_plugin_ref(plugins.lineage_backend),
+        secrets=_to_plugin_ref(plugins.secrets),
+        identity=_to_plugin_ref(plugins.identity),
+    )
+```
+
+- [ ] **Step 8: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestResolvedPlugins::test_valid_resolved_plugins_includes_secrets_and_identity \
+  packages/floe-core/tests/unit/compilation/test_resolver.py::test_resolve_plugins_preserves_secrets_and_identity_selections \
+  -q
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/schemas/compiled_artifacts.py \
+  packages/floe-core/src/floe_core/compilation/resolver.py \
+  packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py \
+  packages/floe-core/tests/unit/compilation/test_resolver.py
+git commit -m "feat: expose resolved identity and secrets plugins"
+```
+
+## Task 2: Add Typed Credential Composition Vocabulary
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/composition/test_resolver.py`
+- Modify: `packages/floe-core/src/floe_core/composition/models.py`
+- Modify: `packages/floe-core/src/floe_core/composition/__init__.py`
+
+- [ ] **Step 1: Write failing model tests**
+
+Append these tests to `packages/floe-core/tests/unit/composition/test_resolver.py`:
+
+```python
+def test_capability_set_accepts_security_composition_modes() -> None:
+    """CapabilitySet should carry secret projection and identity capabilities."""
+    capabilities = CapabilitySet(
+        credential_modes=["kubernetes-secret", "workload-identity"],
+        secret_projection_modes=["kubernetes-secret", "external-secret-sync"],
+        identity_modes=["aws-irsa", "oidc-federation"],
+        providers=["kubernetes", "aws", "oidc"],
+    )
+
+    assert capabilities.secret_projection_modes == [
+        "kubernetes-secret",
+        "external-secret-sync",
+    ]
+    assert capabilities.identity_modes == ["aws-irsa", "oidc-federation"]
+    assert capabilities.providers == ["kubernetes", "aws", "oidc"]
+
+
+def test_requirement_set_accepts_security_composition_modes() -> None:
+    """RequirementSet should describe required secret and identity modes."""
+    requirements = RequirementSet(
+        credential_modes=["external-secret-sync"],
+        secret_projection_modes=["external-secret-sync"],
+        identity_modes=["gcp-workload-identity"],
+        providers=["gcp"],
+    )
+
+    assert requirements.credential_modes == ["external-secret-sync"]
+    assert requirements.secret_projection_modes == ["external-secret-sync"]
+    assert requirements.identity_modes == ["gcp-workload-identity"]
+    assert requirements.providers == ["gcp"]
+```
+
+- [ ] **Step 2: Run the model tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/composition/test_resolver.py::test_capability_set_accepts_security_composition_modes \
+  packages/floe-core/tests/unit/composition/test_resolver.py::test_requirement_set_accepts_security_composition_modes \
+  -q
+```
+
+Expected: FAIL because `CapabilitySet` and `RequirementSet` reject the new fields.
+
+- [ ] **Step 3: Add mode aliases and fields**
+
+In `packages/floe-core/src/floe_core/composition/models.py`, replace the current import section with:
+
+```python
+from typing import Literal, TypeAlias
+```
+
+Then add these aliases after the imports:
+
+```python
+CredentialMode: TypeAlias = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+    "workload-identity",
+    "none",
+]
+SecretProjectionMode: TypeAlias = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+]
+IdentityMode: TypeAlias = Literal[
+    "aws-irsa",
+    "aws-pod-identity",
+    "gcp-workload-identity",
+    "azure-workload-identity",
+    "azure-managed-identity",
+    "oidc-federation",
+]
+```
+
+Update `CapabilitySet`:
+
+```python
+class CapabilitySet(BaseModel):
+    """Structured capabilities emitted by a plugin for composition checks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    protocols: list[str] = Field(default_factory=list)
+    credential_modes: list[CredentialMode] = Field(default_factory=list)
+    secret_projection_modes: list[SecretProjectionMode] = Field(default_factory=list)
+    identity_modes: list[IdentityMode] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
+    path_style_access: bool | None = None
+    sts: bool | None = None
+```
+
+Update `RequirementSet`:
+
+```python
+class RequirementSet(BaseModel):
+    """Structured peer requirements consumed by the composition resolver."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    protocols: list[str] = Field(default_factory=list)
+    credential_modes: list[CredentialMode] = Field(default_factory=list)
+    secret_projection_modes: list[SecretProjectionMode] = Field(default_factory=list)
+    identity_modes: list[IdentityMode] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
+    requires_server_side_storage_access: bool | None = None
+    supports_no_sts: bool | None = None
+    supports_path_style_access: bool | None = None
+```
+
+- [ ] **Step 4: Export the aliases**
+
+In `packages/floe-core/src/floe_core/composition/__init__.py`, include these imports:
+
+```python
+from floe_core.composition.models import (
+    CapabilitySet,
+    CompositionIssue,
+    CompositionValidationResult,
+    CredentialMode,
+    IdentityMode,
+    PluginCapabilities,
+    PluginRequirements,
+    RequirementSet,
+    SecretProjectionMode,
+)
+```
+
+Update `__all__` to include:
+
+```python
+    "CredentialMode",
+    "IdentityMode",
+    "SecretProjectionMode",
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py -q
+```
+
+Expected: existing resolver tests and the new model tests PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/composition/models.py \
+  packages/floe-core/src/floe_core/composition/__init__.py \
+  packages/floe-core/tests/unit/composition/test_resolver.py
+git commit -m "feat: add credential composition mode vocabulary"
+```
+
+## Task 3: Add Provider Capability Methods
+
+**Files:**
+- Modify: `packages/floe-core/src/floe_core/plugins/secrets.py`
+- Modify: `packages/floe-core/src/floe_core/plugins/identity.py`
+- Modify: `plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py`
+- Modify: `plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py`
+- Modify: `plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py`
+- Modify: `plugins/floe-secrets-k8s/tests/unit/test_plugin.py`
+- Modify: `plugins/floe-secrets-infisical/tests/unit/test_plugin.py`
+- Modify: `plugins/floe-identity-keycloak/tests/unit/test_init.py`
+
+- [ ] **Step 1: Write failing K8s secrets capability test**
+
+Add to `plugins/floe-secrets-k8s/tests/unit/test_plugin.py` in `class TestK8sSecretsPluginMetadata`:
+
+```python
+    @pytest.mark.requirement("PCU-005")
+    def test_secret_capabilities(self) -> None:
+        """K8s secrets plugin should declare Kubernetes Secret projection."""
+        plugin = K8sSecretsPlugin()
+
+        capabilities = plugin.get_secret_capabilities()
+
+        assert capabilities.plugin_type == "secrets"
+        assert capabilities.plugin_name == "k8s"
+        assert capabilities.capabilities.secret_projection_modes == ["kubernetes-secret"]
+        assert capabilities.capabilities.providers == ["kubernetes"]
+```
+
+- [ ] **Step 2: Write failing Infisical secrets capability test**
+
+Add to `plugins/floe-secrets-infisical/tests/unit/test_plugin.py` in `class TestInfisicalSecretsPluginMetadata`:
+
+```python
+    @pytest.mark.requirement("PCU-005")
+    def test_secret_capabilities(
+        self,
+        plugin: InfisicalSecretsPlugin,
+    ) -> None:
+        """Infisical plugin should declare external secret sync support."""
+        capabilities = plugin.get_secret_capabilities()
+
+        assert capabilities.plugin_type == "secrets"
+        assert capabilities.plugin_name == "infisical"
+        assert capabilities.capabilities.secret_projection_modes == [
+            "external-secret-sync",
+            "kubernetes-secret",
+        ]
+        assert capabilities.capabilities.providers == ["infisical", "kubernetes"]
+```
+
+- [ ] **Step 3: Write failing Keycloak identity capability test**
+
+Add to `plugins/floe-identity-keycloak/tests/unit/test_init.py` in `class TestLazyImports`:
+
+```python
+    @pytest.mark.requirement("PCU-005")
+    def test_keycloak_identity_capabilities(self) -> None:
+        """Keycloak plugin should declare OIDC federation support."""
+        from pydantic import SecretStr
+
+        from floe_identity_keycloak import KeycloakIdentityConfig, KeycloakIdentityPlugin
+
+        plugin = KeycloakIdentityPlugin(
+            KeycloakIdentityConfig(
+                server_url="https://keycloak.example.com",
+                realm="floe",
+                client_id="floe-client",
+                client_secret=SecretStr("not-a-real-secret"),
+            )
+        )
+
+        capabilities = plugin.get_identity_capabilities()
+
+        assert capabilities.plugin_type == "identity"
+        assert capabilities.plugin_name == "keycloak"
+        assert capabilities.capabilities.identity_modes == ["oidc-federation"]
+        assert capabilities.capabilities.providers == ["oidc"]
+```
+
+- [ ] **Step 4: Run capability tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest \
+  plugins/floe-secrets-k8s/tests/unit/test_plugin.py::TestK8sSecretsPluginMetadata::test_secret_capabilities \
+  plugins/floe-secrets-infisical/tests/unit/test_plugin.py::TestInfisicalSecretsPluginMetadata::test_secret_capabilities \
+  plugins/floe-identity-keycloak/tests/unit/test_init.py::TestLazyImports::test_keycloak_identity_capabilities \
+  -q
+```
+
+Expected: FAIL because the capability methods do not exist.
+
+- [ ] **Step 5: Add default `SecretsPlugin.get_secret_capabilities()`**
+
+In `packages/floe-core/src/floe_core/plugins/secrets.py`, add this import:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+```
+
+Add this method to `SecretsPlugin`:
+
+```python
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return secret projection capabilities for composition validation.
+
+        The default is intentionally empty so existing secrets plugins remain
+        discoverable until they adopt composition explicitly.
+        """
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(),
+        )
+```
+
+- [ ] **Step 6: Add default `IdentityPlugin.get_identity_capabilities()`**
+
+In `packages/floe-core/src/floe_core/plugins/identity.py`, add this import:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+```
+
+Add this method to `IdentityPlugin`:
+
+```python
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        """Return workload identity capabilities for composition validation.
+
+        The default is intentionally empty so existing identity plugins remain
+        discoverable until they adopt composition explicitly.
+        """
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(),
+        )
+```
+
+- [ ] **Step 7: Add K8s capability declaration**
+
+In `plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py`, add:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+```
+
+Add this method to `K8sSecretsPlugin` near the metadata methods:
+
+```python
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return Kubernetes Secret projection capabilities."""
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["kubernetes-secret"],
+                secret_projection_modes=["kubernetes-secret"],
+                providers=["kubernetes"],
+            ),
+        )
+```
+
+- [ ] **Step 8: Add Infisical capability declaration**
+
+In `plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py`, add:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+```
+
+Add this method to `InfisicalSecretsPlugin` near the metadata methods:
+
+```python
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return Infisical external secret sync capabilities."""
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["external-secret-sync", "kubernetes-secret"],
+                secret_projection_modes=["external-secret-sync", "kubernetes-secret"],
+                providers=["infisical", "kubernetes"],
+            ),
+        )
+```
+
+- [ ] **Step 9: Add Keycloak capability declaration**
+
+In `plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py`, add:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+```
+
+Add this method to `KeycloakIdentityPlugin` near the metadata properties:
+
+```python
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        """Return OIDC federation capabilities for workload identity checks."""
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["workload-identity"],
+                identity_modes=["oidc-federation"],
+                providers=["oidc"],
+            ),
+        )
+```
+
+- [ ] **Step 10: Run focused provider tests**
+
+Run:
+
+```bash
+uv run pytest \
+  plugins/floe-secrets-k8s/tests/unit/test_plugin.py::TestK8sSecretsPluginMetadata::test_secret_capabilities \
+  plugins/floe-secrets-infisical/tests/unit/test_plugin.py::TestInfisicalSecretsPluginMetadata::test_secret_capabilities \
+  plugins/floe-identity-keycloak/tests/unit/test_init.py::TestLazyImports::test_keycloak_identity_capabilities \
+  -q
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 11: Commit Task 3**
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/plugins/secrets.py \
+  packages/floe-core/src/floe_core/plugins/identity.py \
+  plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py \
+  plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py \
+  plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py \
+  plugins/floe-secrets-k8s/tests/unit/test_plugin.py \
+  plugins/floe-secrets-infisical/tests/unit/test_plugin.py \
+  plugins/floe-identity-keycloak/tests/unit/test_init.py
+git commit -m "feat: declare identity and secret plugin capabilities"
+```
+
+## Task 4: Validate Secret Projection And Identity Modes In The Resolver
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/composition/test_resolver.py`
+- Modify: `packages/floe-core/src/floe_core/composition/resolver.py`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Append these tests to `packages/floe-core/tests/unit/composition/test_resolver.py`:
+
+```python
+def test_resolver_accepts_kubernetes_secret_with_implicit_baseline() -> None:
+    """Existing MinIO and Polaris path must stay valid without secrets plugin."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="polaris",
+        requirements=RequirementSet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_rejects_external_secret_sync_without_secrets_plugin() -> None:
+    """External secret sync requires an explicit secrets provider."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROVIDER_MISSING",
+            message=(
+                "catalog glue requires secret projection mode external-secret-sync "
+                "but no secrets plugin was selected"
+            ),
+            plugins=["catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_accepts_external_secret_sync_with_matching_secrets_plugin() -> None:
+    """External secret sync succeeds when selected secrets plugin supports it."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_rejects_unsupported_secret_projection_mode() -> None:
+    """Selected secrets provider must support the requested projection mode."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="azure-blob",
+        capabilities=CapabilitySet(
+            protocols=["azure-blob"],
+            credential_modes=["csi-secret-volume"],
+            secret_projection_modes=["csi-secret-volume"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="rest",
+        requirements=RequirementSet(
+            protocols=["azure-blob"],
+            credential_modes=["csi-secret-volume"],
+            secret_projection_modes=["csi-secret-volume"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+            message=(
+                "catalog rest requires secret projection mode csi-secret-volume; "
+                "secrets infisical provides ['external-secret-sync']"
+            ),
+            plugins=["secrets:infisical", "catalog:rest"],
+        )
+    ]
+
+
+def test_resolver_rejects_identity_mode_without_identity_plugin() -> None:
+    """Workload identity requires an explicit identity provider."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_PROVIDER_MISSING",
+            message=(
+                "catalog glue requires identity mode aws-irsa "
+                "but no identity plugin was selected"
+            ),
+            plugins=["catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_rejects_unsupported_identity_mode() -> None:
+    """Selected identity provider must support the requested identity mode."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="keycloak",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["oidc-federation"],
+            providers=["oidc"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires identity mode aws-irsa; "
+                "identity keycloak provides ['oidc-federation']"
+            ),
+            plugins=["identity:keycloak", "catalog:glue"],
+        )
+    ]
+```
+
+- [ ] **Step 2: Run resolver tests and verify new ones fail**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py -q
+```
+
+Expected: existing tests PASS; new secret/identity resolver tests FAIL.
+
+- [ ] **Step 3: Implement resolver helpers**
+
+In `packages/floe-core/src/floe_core/composition/resolver.py`, update `validate()` and add helper methods. The resulting class should contain these methods:
+
+```python
+class CompositionResolver:
+    """Validate that selected plugin capabilities satisfy peer requirements."""
+
+    def validate(
+        self,
+        capabilities: list[PluginCapabilities],
+        requirements: list[PluginRequirements],
+    ) -> CompositionValidationResult:
+        """Return compatibility issues for the selected plugin graph."""
+        issues: list[CompositionIssue] = []
+        storage = next((item for item in capabilities if item.plugin_type == "storage"), None)
+        secrets = next((item for item in capabilities if item.plugin_type == "secrets"), None)
+        identity = next((item for item in capabilities if item.plugin_type == "identity"), None)
+
+        for requirement in requirements:
+            if requirement.plugin_type != "catalog":
+                continue
+            if storage is None:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_STORAGE_MISSING",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires storage "
+                            "capabilities but no storage plugin was selected"
+                        ),
+                        plugins=[requirement.ref],
+                    )
+                )
+                continue
+            issues.extend(self._validate_storage_for_catalog(storage, requirement))
+            issues.extend(self._validate_secret_projection(secrets, requirement))
+            issues.extend(self._validate_identity(identity, requirement))
+
+        return CompositionValidationResult(
+            valid=not any(issue.severity == "error" for issue in issues),
+            issues=issues,
+        )
+```
+
+Add these helpers below `_validate_storage_for_catalog()`:
+
+```python
+    def _validate_secret_projection(
+        self,
+        secrets: PluginCapabilities | None,
+        requirement: PluginRequirements,
+    ) -> list[CompositionIssue]:
+        """Validate required secret projection modes against secrets provider."""
+        issues: list[CompositionIssue] = []
+        for mode in requirement.requirements.secret_projection_modes:
+            if mode in ("kubernetes-secret", "environment"):
+                if secrets is None:
+                    continue
+            if secrets is None:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_SECRET_PROVIDER_MISSING",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires secret projection "
+                            f"mode {mode} but no secrets plugin was selected"
+                        ),
+                        plugins=[requirement.ref],
+                    )
+                )
+                continue
+            provided_modes = list(secrets.capabilities.secret_projection_modes)
+            if mode not in provided_modes:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires secret projection "
+                            f"mode {mode}; secrets {secrets.plugin_name} provides {provided_modes}"
+                        ),
+                        plugins=[secrets.ref, requirement.ref],
+                    )
+                )
+        return issues
+
+    def _validate_identity(
+        self,
+        identity: PluginCapabilities | None,
+        requirement: PluginRequirements,
+    ) -> list[CompositionIssue]:
+        """Validate required workload identity modes against identity provider."""
+        issues: list[CompositionIssue] = []
+        requires_workload_identity = "workload-identity" in requirement.requirements.credential_modes
+        required_modes = list(requirement.requirements.identity_modes)
+        if not requires_workload_identity and not required_modes:
+            return issues
+
+        if identity is None:
+            mode = required_modes[0] if required_modes else "workload-identity"
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_IDENTITY_PROVIDER_MISSING",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires identity mode {mode} "
+                        "but no identity plugin was selected"
+                    ),
+                    plugins=[requirement.ref],
+                )
+            )
+            return issues
+
+        provided_modes = list(identity.capabilities.identity_modes)
+        for mode in required_modes:
+            if mode not in provided_modes:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires identity mode {mode}; "
+                            f"identity {identity.plugin_name} provides {provided_modes}"
+                        ),
+                        plugins=[identity.ref, requirement.ref],
+                    )
+                )
+        return issues
+```
+
+- [ ] **Step 4: Run resolver tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py -q
+```
+
+Expected: all resolver tests PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/composition/resolver.py \
+  packages/floe-core/tests/unit/composition/test_resolver.py
+git commit -m "feat: validate identity and secret composition modes"
+```
+
+## Task 5: Wire Security Capabilities Into Compilation
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`
+- Modify: `packages/floe-core/src/floe_core/compilation/stages.py`
+- Modify: `tests/contract/test_storage_binding_security.py`
+
+- [ ] **Step 1: Add fake provider classes to the compilation test**
+
+In `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`, add imports near the existing plugin imports:
+
+```python
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
+from floe_core.plugins.identity import IdentityPlugin, TokenValidationResult, UserInfo
+from floe_core.plugins.secrets import SecretsPlugin
+```
+
+Add these classes above the first test:
+
+```python
+class FakeSecretsPlugin(SecretsPlugin):
+    """Secrets plugin used to prove compiler composition wiring."""
+
+    @property
+    def name(self) -> str:
+        return "fake-secrets"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def get_secret(self, key: str) -> str | None:
+        return None
+
+    def set_secret(self, key: str, value: str, metadata: dict[str, Any] | None = None) -> None:
+        return None
+
+    def list_secrets(self, prefix: str = "") -> list[str]:
+        return []
+
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["external-secret-sync"],
+                secret_projection_modes=["external-secret-sync"],
+                providers=["infisical"],
+            ),
+        )
+
+
+class FakeIdentityPlugin(IdentityPlugin):
+    """Identity plugin used to prove compiler composition wiring."""
+
+    @property
+    def name(self) -> str:
+        return "fake-identity"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def authenticate(self, credentials: dict[str, Any]) -> str | None:
+        return None
+
+    def get_user_info(self, token: str) -> UserInfo | None:
+        return None
+
+    def validate_token(self, token: str) -> TokenValidationResult:
+        return TokenValidationResult(valid=False)
+
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["workload-identity"],
+                identity_modes=["aws-irsa"],
+                providers=["aws"],
+            ),
+        )
+```
+
+- [ ] **Step 2: Write failing compiler wiring test**
+
+Append this test to `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`:
+
+```python
+def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compilation should validate non-baseline credential modes with providers."""
+
+    class IdentityStoragePlugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "s3"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return StorageDeploymentBinding(
+                provider="s3",
+                protocol="s3",
+                endpoint=StorageServiceEndpoint(
+                    internal_url="https://s3.us-east-1.amazonaws.com",
+                    external_url="https://s3.us-east-1.amazonaws.com",
+                    region="us-east-1",
+                    warehouse_path="s3://warehouse",
+                    path_style_access=False,
+                ),
+                warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
+                credentials=StorageCredentialBinding(
+                    mode="workload-identity",
+                    service_account_ref="floe-runtime",
+                ),
+                capabilities=StorageCapabilities(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    sts_supported=True,
+                    path_style_access=False,
+                ),
+                dbt=DbtStorageBinding(
+                    profile_name="floe",
+                    target_name="dev",
+                    schema_name="analytics",
+                ),
+                dagster=DagsterStorageBinding(
+                    resource_key="s3_storage",
+                    asset_io_manager_key="iceberg_io_manager",
+                ),
+            )
+
+    class IdentityCatalogPlugin(CatalogPlugin):
+        @property
+        def name(self) -> str:
+            return "glue"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def connect(self, config: dict[str, Any]) -> Any:
+            raise NotImplementedError
+
+        def create_namespace(self, namespace: str, properties: dict[str, str] | None = None) -> None:
+            return None
+
+        def vend_credentials(self, table_path: str, operations: list[str]) -> dict[str, Any]:
+            return {}
+
+        def list_namespaces(self, parent: str | None = None) -> list[str]:
+            return []
+
+        def delete_namespace(self, namespace: str) -> None:
+            return None
+
+        def create_table(self, identifier: str, schema: dict[str, Any], **kwargs: Any) -> None:
+            return None
+
+        def list_tables(self, namespace: str) -> list[str]:
+            return []
+
+        def drop_table(self, identifier: str, purge: bool = False) -> None:
+            return None
+
+        def get_storage_requirements(self) -> PluginRequirements:
+            return PluginRequirements(
+                plugin_type="catalog",
+                plugin_name="glue",
+                requirements=RequirementSet(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    identity_modes=["aws-irsa"],
+                    providers=["aws"],
+                ),
+            )
+
+        def build_catalog_deployment(
+            self,
+            storage: StorageDeploymentBinding,
+        ) -> CatalogDeploymentBinding:
+            return CatalogDeploymentBinding(
+                provider="polaris",
+                polaris=PolarisCatalogDeploymentBinding(
+                    storage_type="S3",
+                    default_base_location="s3://warehouse",
+                    allowed_locations=["s3://warehouse"],
+                    endpoint=storage.endpoint.external_url,
+                    endpoint_internal=storage.endpoint.internal_url,
+                    path_style_access=False,
+                    sts_unavailable=False,
+                    credential_refs={
+                        "accessKeyId": CredentialRef(source="none", name="none"),
+                        "secretAccessKey": CredentialRef(source="none", name="none"),
+                    },
+                ),
+            )
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return IdentityStoragePlugin()
+            if plugin_type == PluginType.CATALOG:
+                return IdentityCatalogPlugin()
+            if plugin_type == PluginType.SECRETS:
+                return FakeSecretsPlugin()
+            if plugin_type == PluginType.IDENTITY:
+                return FakeIdentityPlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["catalog"] = {"type": "glue"}
+    manifest["plugins"]["secrets"] = {"type": "fake-secrets"}
+    manifest["plugins"]["identity"] = {"type": "fake-identity"}
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    artifacts = compile_pipeline(
+        ROOT / "demo" / "customer-360" / "floe.yaml",
+        manifest_path,
+        emit_lineage=False,
+    )
+
+    assert artifacts.plugins is not None
+    assert artifacts.plugins.secrets is not None
+    assert artifacts.plugins.secrets.type == "fake-secrets"
+    assert artifacts.plugins.identity is not None
+    assert artifacts.plugins.identity.type == "fake-identity"
+    assert artifacts.deployment is not None
+    assert artifacts.deployment.storage is not None
+    assert artifacts.deployment.storage.credentials.mode == "workload-identity"
+```
+
+- [ ] **Step 3: Run compiler wiring test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py::test_compile_passes_selected_secret_and_identity_capabilities_to_resolver -q
+```
+
+Expected: FAIL because compilation does not collect selected secrets or identity capabilities for resolver validation.
+
+- [ ] **Step 4: Add helper functions in compilation stages**
+
+In `packages/floe-core/src/floe_core/compilation/stages.py`, inside `_build_storage_deployment_binding()`, import:
+
+```python
+    from floe_core.plugins.identity import IdentityPlugin
+    from floe_core.plugins.secrets import SecretsPlugin
+```
+
+Before calling `CompositionResolver().validate(...)`, collect optional capabilities:
+
+```python
+        composition_capabilities = [storage_capabilities]
+
+        if plugins.secrets is not None:
+            registry.configure(
+                PluginType.SECRETS,
+                plugins.secrets.type,
+                plugins.secrets.config or {},
+            )
+            secrets_plugin = registry.get(PluginType.SECRETS, plugins.secrets.type)
+            if not isinstance(secrets_plugin, SecretsPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.secrets.type!r} is not a SecretsPlugin",
+                        suggestion="Use a plugin registered under the floe.secrets entry point group",
+                        context={"secrets_plugin": plugins.secrets.type},
+                    )
+                )
+            composition_capabilities.append(secrets_plugin.get_secret_capabilities())
+
+        if plugins.identity is not None:
+            registry.configure(
+                PluginType.IDENTITY,
+                plugins.identity.type,
+                plugins.identity.config or {},
+            )
+            identity_plugin = registry.get(PluginType.IDENTITY, plugins.identity.type)
+            if not isinstance(identity_plugin, IdentityPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.identity.type!r} is not an IdentityPlugin",
+                        suggestion="Use a plugin registered under the floe.identity entry point group",
+                        context={"identity_plugin": plugins.identity.type},
+                    )
+                )
+            composition_capabilities.append(identity_plugin.get_identity_capabilities())
+
+        composition = CompositionResolver().validate(
+            composition_capabilities,
+            [catalog_requirements],
+        )
+```
+
+Replace the previous call that passed only `[storage_capabilities]`.
+
+- [ ] **Step 5: Run compiler wiring test**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py::test_compile_passes_selected_secret_and_identity_capabilities_to_resolver -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add security contract assertion for plugin refs**
+
+In `tests/contract/test_storage_binding_security.py`, extend `test_compiled_artifact_does_not_contain_minio_secret_values()`:
+
+```python
+    assert artifacts.plugins is not None
+    payload = artifacts.model_dump_json()
+    assert "credentialSecretName" not in payload
+```
+
+If this assertion fails because chart-only keys are not present but plugin config carries `credential_secret_name`, change the assertion to:
+
+```python
+    assert artifacts.plugins is not None
+    assert artifacts.plugins.storage is not None
+    assert artifacts.plugins.storage.config is not None
+    assert "credential_secret_name" in artifacts.plugins.storage.config
+```
+
+This keeps the test honest about current behavior: the plugin config may name a Secret, but raw Secret values must remain absent.
+
+- [ ] **Step 7: Run focused compilation and security tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py \
+  tests/contract/test_storage_binding_security.py \
+  -q
+```
+
+Expected: tests PASS.
+
+- [ ] **Step 8: Commit Task 5**
+
+```bash
+git add \
+  packages/floe-core/src/floe_core/compilation/stages.py \
+  packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py \
+  tests/contract/test_storage_binding_security.py
+git commit -m "feat: validate security provider capabilities during compile"
+```
+
+## Task 6: Update Architecture Documentation
+
+**Files:**
+- Modify: `docs/architecture/plugin-composition-uplift-tracker.md`
+- Modify: `docs/architecture/interfaces/secrets-plugin.md`
+- Modify: `docs/architecture/interfaces/identity-plugin.md`
+- Modify: `docs/architecture/interfaces/storage-plugin.md`
+- Modify: `docs/architecture/interfaces/catalog-plugin.md`
+
+- [ ] **Step 1: Update PCU-005 tracker**
+
+In `docs/architecture/plugin-composition-uplift-tracker.md`, find the
+`Secrets / identity` row in the immediate-priority table and replace it with:
+
+
+```markdown
+| Secrets / identity | 2 | PCU-005 implemented | Credential projection and workload identity modes are typed capabilities validated by the resolver |
+```
+
+In the Future Tracking Items table, update PCU-005 from:
+
+```markdown
+| PCU-005 | Security | Connect credential binding to identity/secrets plugins | Workload identity and external secret modes are resolver-validated |
+```
+
+to:
+
+```markdown
+| PCU-005 | Security | Connect credential binding to identity/secrets plugins | Implemented: workload identity and external secret modes are resolver-validated |
+```
+
+- [ ] **Step 2: Update secrets plugin interface docs**
+
+In `docs/architecture/interfaces/secrets-plugin.md`, add this section after the interface introduction:
+
+```markdown
+## Composition Capabilities
+
+Secrets plugins declare how they can project sensitive material into runtime
+consumers without exposing secret values in compiled artifacts.
+
+```python
+def get_secret_capabilities(self) -> PluginCapabilities:
+    """Return secret projection capabilities for composition validation."""
+```
+
+Supported projection modes:
+
+| Mode | Meaning |
+| --- | --- |
+| `kubernetes-secret` | Runtime consumers reference existing or managed Kubernetes Secret keys. |
+| `external-secret-sync` | A controller syncs external secret manager values into Kubernetes resources. |
+| `csi-secret-volume` | Secrets are mounted through the Secrets Store CSI Driver or equivalent. |
+| `environment` | Local or development environment variable projection. |
+
+Capabilities are secret-free. Provider-specific fields such as Vault roles,
+Infisical identity IDs, AWS Secret ARNs, or Azure Key Vault object names remain
+in provider-owned configuration or deployment bindings.
+```
+
+- [ ] **Step 3: Update identity plugin interface docs**
+
+In `docs/architecture/interfaces/identity-plugin.md`, add this section after the interface introduction:
+
+```markdown
+## Composition Capabilities
+
+Identity plugins declare workload identity modes that selected storage,
+catalog, compute, or runtime plugins can require.
+
+```python
+def get_identity_capabilities(self) -> PluginCapabilities:
+    """Return workload identity capabilities for composition validation."""
+```
+
+Supported identity modes:
+
+| Mode | Meaning |
+| --- | --- |
+| `aws-irsa` | EKS IAM Roles for Service Accounts. |
+| `aws-pod-identity` | EKS Pod Identity association. |
+| `gcp-workload-identity` | GKE Workload Identity Federation. |
+| `azure-workload-identity` | Microsoft Entra Workload ID for AKS workloads. |
+| `azure-managed-identity` | Azure managed identity used by AKS or provider integrations. |
+| `oidc-federation` | Generic OIDC federation for services such as Keycloak or Snowflake WIF. |
+
+Core validates the named modes and provider labels only. Provider plugins own
+cloud-specific translation such as IAM role trust policies, GCP service account
+bindings, Azure federated credentials, or OIDC issuer details.
+```
+
+- [ ] **Step 4: Update storage and catalog docs**
+
+In `docs/architecture/interfaces/storage-plugin.md`, add a paragraph near the storage deployment binding section:
+
+```markdown
+Storage credential capabilities use the shared composition vocabulary.
+`credential_modes` preserves broad compatibility (`kubernetes-secret`,
+`external-secret-sync`, `csi-secret-volume`, `environment`,
+`workload-identity`, `none`), while `secret_projection_modes` and
+`identity_modes` describe how the credential mode is realized.
+```
+
+In `docs/architecture/interfaces/catalog-plugin.md`, add a paragraph near `get_storage_requirements()`:
+
+```markdown
+Catalog storage requirements may name required credential modes, secret
+projection modes, identity modes, and provider labels. The composition resolver
+validates these requirements against selected storage, secrets, and identity
+plugins before deployment bindings are rendered.
+```
+
+- [ ] **Step 5: Run documentation checks**
+
+Run:
+
+```bash
+uv run pre-commit run --files \
+  docs/architecture/plugin-composition-uplift-tracker.md \
+  docs/architecture/interfaces/secrets-plugin.md \
+  docs/architecture/interfaces/identity-plugin.md \
+  docs/architecture/interfaces/storage-plugin.md \
+  docs/architecture/interfaces/catalog-plugin.md
+```
+
+Expected: hooks PASS.
+
+- [ ] **Step 6: Commit Task 6**
+
+```bash
+git add \
+  docs/architecture/plugin-composition-uplift-tracker.md \
+  docs/architecture/interfaces/secrets-plugin.md \
+  docs/architecture/interfaces/identity-plugin.md \
+  docs/architecture/interfaces/storage-plugin.md \
+  docs/architecture/interfaces/catalog-plugin.md
+git commit -m "docs: describe identity and secret composition contract"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+uv run pytest \
+  packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestResolvedPlugins \
+  packages/floe-core/tests/unit/compilation/test_resolver.py \
+  packages/floe-core/tests/unit/composition/test_resolver.py \
+  packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py \
+  plugins/floe-secrets-k8s/tests/unit/test_plugin.py::TestK8sSecretsPluginMetadata \
+  plugins/floe-secrets-infisical/tests/unit/test_plugin.py::TestInfisicalSecretsPluginMetadata \
+  plugins/floe-identity-keycloak/tests/unit/test_init.py::TestLazyImports \
+  tests/contract/test_storage_binding_security.py \
+  -q
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 2: Run lint and typecheck**
+
+Run:
+
+```bash
+make lint
+make typecheck
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 3: Run unit test suite**
+
+Run:
+
+```bash
+make test-unit
+```
+
+Expected: unit suite PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+```
+
+Expected: worktree is clean after commits; diff is limited to core composition, provider capability declarations, tests, and architecture docs.
+
+- [ ] **Step 5: Prepare PR summary evidence**
+
+Collect these facts for the PR body or handoff:
+
+```text
+Focused pytest: PASS
+make lint: PASS
+make typecheck: PASS
+make test-unit: PASS
+Security invariant: compiled artifacts and Helm values contain credential refs and mode names, not raw secret values
+Compatibility invariant: MinIO plus Polaris Kubernetes Secret path remains valid without explicit secrets plugin
+```

--- a/docs/superpowers/specs/2026-05-07-identity-secret-composition-design.md
+++ b/docs/superpowers/specs/2026-05-07-identity-secret-composition-design.md
@@ -1,0 +1,439 @@
+# Identity And Secret Composition Design
+
+Status: Approved for planning
+Date: 2026-05-07
+Author: Codex
+
+## Summary
+
+Floe should implement PCU-005 by making credential delivery a typed
+composition contract instead of an implicit string convention. The immediate
+goal is to connect current storage and catalog credential bindings to selected
+secrets and identity plugins, while preserving the working MinIO plus Polaris
+Kubernetes Secret path.
+
+The design extends the storage composition model rather than creating a
+separate security subsystem:
+
+```text
+selected plugins
+  -> plugin capabilities and requirements
+  -> composition resolver
+  -> secret-free deployment bindings
+  -> Helm, RBAC, network, and runtime renderers
+```
+
+Credential composition has two distinct concerns:
+
+- Secret projection: how sensitive material reaches Kubernetes or runtime
+  consumers.
+- Workload identity: how a pod, service, catalog, or compute engine gets
+  authority without static credentials.
+
+Keeping these concerns separate lets Floe support Kubernetes Secrets, external
+secret managers, CSI-mounted secrets, AWS IRSA, EKS Pod Identity, GKE Workload
+Identity, Azure Workload ID, managed identities, OIDC federation, and future
+data-platform identity models without forcing every provider into one generic
+credential mode.
+
+## Research Validation
+
+The approved contract was checked against common customer data-platform
+patterns and official provider behavior:
+
+- Kubernetes Secrets remain the common baseline for Kubernetes-native
+  deployments. They can be created independently of consuming pods and consumed
+  by reference, which matches Floe's secret-free artifact rule.
+  Source: https://kubernetes.io/docs/concepts/configuration/secret/
+- AWS customers commonly use both secret projection and identity federation.
+  Amazon EKS supports IRSA and EKS Pod Identity, both mapping IAM authority to
+  Kubernetes service accounts rather than distributing long-lived credentials.
+  External Secrets Operator also supports AWS Secrets Manager and SSM Parameter
+  Store with service-account-token based authentication.
+  Sources:
+  https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html,
+  https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html,
+  https://external-secrets.io/latest/provider/aws-access/
+- GKE Workload Identity Federation is the recommended GKE mechanism for
+  Kubernetes workloads accessing Google Cloud APIs without static service
+  account key files. External Secrets Operator supports Google Secret Manager
+  through Workload Identity Federation.
+  Sources:
+  https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity,
+  https://external-secrets.io/v0.20.3/provider/google-secrets-manager/
+- AKS commonly uses Microsoft Entra Workload ID or managed identity. Azure Key
+  Vault can be projected through the Secrets Store CSI Driver, and the CSI
+  driver can also sync mounted objects into Kubernetes Secrets.
+  Sources:
+  https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview,
+  https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver,
+  https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access
+- Vault and Infisical validate the provider-owned translation boundary. Vault
+  supports Kubernetes and JWT/OIDC authentication modes. Infisical's Kubernetes
+  operator syncs external secrets into managed Kubernetes Secret resources
+  through CRDs.
+  Sources:
+  https://developer.hashicorp.com/vault/docs/auth/kubernetes,
+  https://docs.hashicorp.com/vault/docs/auth/jwt,
+  https://infisical.com/docs/integrations/platforms/kubernetes/infisical-secret-crd
+- Databricks and Snowflake validate identity as a data-platform concern, not
+  only a Kubernetes concern. Unity Catalog uses storage credentials and
+  external locations backed by cloud identity mechanisms, while Snowflake
+  supports workload identity federation to avoid long-lived passwords, API
+  keys, key pairs, or access tokens for service-to-service authentication.
+  Sources:
+  https://docs.databricks.com/aws/en/connect/unity-catalog/cloud-storage/s3/s3-external-location-manual,
+  https://learn.microsoft.com/en-us/azure/databricks/connect/unity-catalog/cloud-storage/storage-credentials,
+  https://docs.snowflake.com/en/en/user-guide/workload-identity-federation
+
+## Current Problem
+
+The storage composition closeout introduced useful building blocks:
+
+- `StorageCredentialBinding` is secret-free.
+- `CredentialRef` lets catalog and Helm projections reference credential
+  identity without raw values.
+- `StorageCapabilities.credential_modes` describes the current storage-side
+  credential mode.
+- `CompositionResolver` already rejects incompatible storage and catalog
+  protocol or credential-mode combinations.
+- `floe helm generate` renders MinIO and Polaris values from deployment
+  bindings, not from plugin config.
+
+The remaining PCU-005 gap is that credential modes are still self-contained
+strings on storage/catalog. There is no selected secrets or identity provider
+that can validate whether a mode is actually supported in the customer
+platform.
+
+Examples:
+
+- `kubernetes-secret` currently works, but the resolver does not know whether
+  the platform chose native Kubernetes Secrets, Infisical sync, Vault sync, or
+  an implicit Kubernetes baseline.
+- `workload-identity` can appear as a generic mode, but AWS IRSA, EKS Pod
+  Identity, GKE Workload Identity, Azure Workload ID, and generic OIDC
+  federation have different provider constraints.
+- External secret and CSI-volume modes are not representable as first-class
+  capabilities, so future chart/RBAC/network work would have to infer behavior
+  from provider-specific config.
+- `CompiledArtifacts.plugins` currently omits `secrets` and `identity`, even
+  though both are first-class platform manifest plugin categories.
+
+## Goals
+
+- Add `secrets` and `identity` to `ResolvedPlugins` so compiled artifacts show
+  the selected providers without rereading the platform manifest.
+- Keep `CompiledArtifacts` secret-free: no raw credentials in artifacts,
+  generated chart values, logs, or tests.
+- Separate secret projection modes from workload identity modes.
+- Preserve the current MinIO plus Polaris Kubernetes Secret path.
+- Make unsupported credential combinations fail in the resolver with
+  actionable composition issues.
+- Keep provider-specific translation in provider plugins, not in Helm or the
+  generic resolver.
+- Give future RBAC, network policy, and deployment renderers a typed surface
+  they can consume.
+- Update architecture docs when public contracts change.
+
+## Non-Goals
+
+- Do not implement native AWS S3, GCS, Azure Blob, Glue, Databricks, or
+  Snowflake providers in this branch.
+- Do not add `deployment.secrets` or `deployment.identity` renderer bindings
+  yet. Those belong with RBAC, network, and deployment rendering follow-up.
+- Do not make external secret managers retrieve secret values during compile.
+- Do not make Helm rediscover plugin config.
+- Do not require explicit `secrets:k8s` for the existing MinIO plus Polaris
+  Kubernetes Secret path.
+- Do not turn local `environment` credentials into a production default.
+
+## Architecture Decision
+
+Use typed provider capability surfaces plus generic credential requirements.
+
+### Resolved Plugin Contract
+
+Extend `ResolvedPlugins` with two optional fields:
+
+```python
+class ResolvedPlugins(BaseModel):
+    compute: PluginRef
+    orchestrator: PluginRef
+    catalog: PluginRef | None = None
+    storage: PluginRef | None = None
+    ingestion: PluginRef | None = None
+    semantic: PluginRef | None = None
+    lineage_backend: PluginRef | None = None
+    secrets: PluginRef | None = None
+    identity: PluginRef | None = None
+```
+
+The compiler already resolves manifest plugin selections through
+`resolve_plugins()`. That function should pass through `manifest.plugins.secrets`
+and `manifest.plugins.identity` the same way it passes through storage,
+catalog, and lineage backend selections.
+
+### Composition Vocabulary
+
+Extend composition models with typed capability and requirement fields that are
+specific enough for validation but neutral enough for providers:
+
+```python
+SecretProjectionMode = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+]
+
+IdentityMode = Literal[
+    "aws-irsa",
+    "aws-pod-identity",
+    "gcp-workload-identity",
+    "azure-workload-identity",
+    "azure-managed-identity",
+    "oidc-federation",
+]
+
+CredentialMode = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+    "workload-identity",
+    "none",
+]
+```
+
+`credential_modes` remains for backward compatibility and for storage/catalog
+matching. New fields disambiguate how a credential mode is realized:
+
+```python
+class CapabilitySet(BaseModel):
+    protocols: list[str] = Field(default_factory=list)
+    credential_modes: list[str] = Field(default_factory=list)
+    secret_projection_modes: list[str] = Field(default_factory=list)
+    identity_modes: list[str] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
+    path_style_access: bool | None = None
+    sts: bool | None = None
+
+
+class RequirementSet(BaseModel):
+    protocols: list[str] = Field(default_factory=list)
+    credential_modes: list[str] = Field(default_factory=list)
+    secret_projection_modes: list[str] = Field(default_factory=list)
+    identity_modes: list[str] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
+    requires_server_side_storage_access: bool | None = None
+    supports_no_sts: bool | None = None
+    supports_path_style_access: bool | None = None
+```
+
+Provider labels are coarse compatibility scopes such as `kubernetes`, `aws`,
+`gcp`, `azure`, `vault`, and `infisical`. Provider-specific fields such as IAM
+role ARN, GCP service account email, Azure client ID, Vault role, or Infisical
+identity ID remain in provider-owned config or future provider-owned deployment
+bindings.
+
+### Secrets Plugin Capabilities
+
+`SecretsPlugin` should expose a side-effect-free capability method:
+
+```python
+def get_secret_capabilities(self) -> PluginCapabilities:
+    """Return secret projection capabilities for composition validation."""
+```
+
+Reference behavior:
+
+- `floe-secrets-k8s` supports provider `kubernetes` and projection mode
+  `kubernetes-secret`.
+- `floe-secrets-infisical` supports provider `infisical` and projection mode
+  `external-secret-sync`; if it renders managed Kubernetes Secrets, it may also
+  support `kubernetes-secret` as a projection output.
+- Future Vault or ESO plugins can declare `external-secret-sync`,
+  `csi-secret-volume`, or both.
+
+The default base method may return no capabilities to preserve compatibility
+for plugins that have not adopted composition yet.
+
+### Identity Plugin Capabilities
+
+`IdentityPlugin` should expose a side-effect-free capability method:
+
+```python
+def get_identity_capabilities(self) -> PluginCapabilities:
+    """Return workload identity capabilities for composition validation."""
+```
+
+Reference behavior:
+
+- `floe-identity-keycloak` supports provider `oidc` and identity mode
+  `oidc-federation` if it can supply OIDC issuer/JWKS information without raw
+  client secret material.
+- Future AWS, GCP, or Azure identity plugins declare cloud-native identity
+  modes such as `aws-irsa`, `aws-pod-identity`, `gcp-workload-identity`,
+  `azure-workload-identity`, or `azure-managed-identity`.
+
+Identity plugins should validate and translate their own provider-specific
+details. Core should not know IAM trust policy shape, GCP annotation names, or
+Azure federated credential fields beyond the typed mode vocabulary.
+
+### Resolver Rules
+
+The resolver should validate the selected graph in these steps:
+
+1. Continue validating storage protocols and storage/catalog credential mode
+   compatibility.
+2. If a selected storage or catalog binding uses `kubernetes-secret`, accept it
+   when either:
+   - no explicit secrets plugin is selected, using the implicit Kubernetes
+     baseline; or
+   - a selected secrets plugin declares `kubernetes-secret`.
+3. If a selected requirement uses `external-secret-sync`, require a selected
+   secrets plugin with `external-secret-sync`.
+4. If a selected requirement uses `csi-secret-volume`, require a selected
+   secrets plugin with `csi-secret-volume` and leave renderer support as a
+   later deployment precondition.
+5. If a selected requirement uses `environment`, allow it only for local/dev
+   requirements. Do not let it become a production deployment default.
+6. If a selected requirement uses generic `workload-identity`, require an
+   explicit identity mode or a selected identity plugin that can satisfy the
+   requested provider.
+7. If a requirement names a specific identity mode, require a selected identity
+   plugin that declares that mode.
+
+New public issue codes should be actionable and distinct:
+
+- `COMPOSITION_SECRET_PROVIDER_MISSING`
+- `COMPOSITION_SECRET_PROJECTION_UNSUPPORTED`
+- `COMPOSITION_IDENTITY_PROVIDER_MISSING`
+- `COMPOSITION_IDENTITY_MODE_UNSUPPORTED`
+
+The existing `COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED` remains for direct
+storage/catalog credential-mode mismatches.
+
+### Compile-Time Integration
+
+The compiler should build capability inputs from resolved providers:
+
+- Storage capability comes from `StorageDeploymentBinding.capabilities`.
+- Catalog requirements come from `CatalogPlugin.get_storage_requirements()`.
+- Secrets capability comes from `SecretsPlugin.get_secret_capabilities()`, when
+  selected.
+- Identity capability comes from `IdentityPlugin.get_identity_capabilities()`,
+  when selected.
+
+The current implicit Kubernetes baseline should be modeled as a resolver
+default, not as a hidden plugin in `CompiledArtifacts.plugins`.
+
+Compilation remains side-effect free. Plugins should not read secret values,
+create Kubernetes resources, call cloud APIs, or mutate external identity
+systems during this validation.
+
+## Data Flow
+
+```text
+manifest.plugins
+  -> resolve_plugins()
+  -> ResolvedPlugins(secrets=?, identity=?)
+  -> storage deployment binding
+  -> catalog storage requirements
+  -> optional secrets capabilities
+  -> optional identity capabilities
+  -> CompositionResolver.validate()
+  -> DeploymentConfig(storage=?, catalog=?)
+  -> renderers consume secret-free refs and mode hints
+```
+
+The output remains secret-free. Raw values can exist only in external systems,
+Kubernetes Secret resources, runtime environment variables, or provider SDK
+calls outside compiled artifacts.
+
+## Compatibility Matrix
+
+| Customer path | Secret projection | Workload identity | Expected result |
+| --- | --- | --- | --- |
+| MinIO + Polaris on Kind | `kubernetes-secret` | none | Valid with implicit Kubernetes baseline |
+| MinIO + Polaris + explicit K8s secrets plugin | `kubernetes-secret` | none | Valid when `secrets:k8s` declares the mode |
+| AWS S3 + Glue on EKS with IRSA | none or external sync | `aws-irsa` | Valid only with AWS identity capability |
+| AWS S3 + Glue on EKS Pod Identity | none or external sync | `aws-pod-identity` | Valid only with AWS identity capability |
+| GCS on GKE | none or external sync | `gcp-workload-identity` | Valid only with GCP identity capability |
+| ADLS or Key Vault on AKS | `csi-secret-volume` or external sync | `azure-workload-identity` or `azure-managed-identity` | Valid only with Azure-capable providers |
+| Vault-backed Kubernetes workloads | `external-secret-sync` or `csi-secret-volume` | `oidc-federation` or Kubernetes auth | Valid only with Vault/identity capabilities |
+| Infisical operator | `external-secret-sync` to Kubernetes Secret | optional Kubernetes auth | Valid with Infisical secrets capability |
+| Snowflake WIF compute path | none | `oidc-federation` or cloud-native identity | Future compute requirement, validated by identity capability |
+
+## Testing Strategy
+
+Add focused tests before or alongside implementation:
+
+- `ResolvedPlugins` schema tests proving `secrets` and `identity` are accepted
+  and serialized as `PluginRef` values without secret material.
+- Resolver tests for:
+  - current MinIO plus Polaris Kubernetes Secret path remaining valid with no
+    explicit secrets plugin;
+  - explicit `secrets:k8s` satisfying `kubernetes-secret`;
+  - `external-secret-sync` failing without a secrets plugin;
+  - unsupported projection mode failing with
+    `COMPOSITION_SECRET_PROJECTION_UNSUPPORTED`;
+  - `workload-identity` failing without an identity plugin;
+  - unsupported specific identity mode failing with
+    `COMPOSITION_IDENTITY_MODE_UNSUPPORTED`.
+- Reference plugin tests for K8s Secrets, Infisical, and Keycloak capability
+  declarations.
+- Contract/security tests proving compiled artifacts and generated Helm values
+  contain refs and mode names, not raw credential values.
+- Compilation tests proving selected `secrets` and `identity` plugin refs flow
+  from manifest to compiled artifacts.
+
+## Documentation Updates
+
+Update:
+
+- `docs/architecture/plugin-composition-uplift-tracker.md` to move PCU-005
+  from planned to implemented or in progress, depending on final branch state.
+- `docs/architecture/interfaces/secrets-plugin.md` with the capability method
+  and projection vocabulary.
+- `docs/architecture/interfaces/identity-plugin.md` with the capability method
+  and identity-mode vocabulary.
+- `docs/architecture/interfaces/storage-plugin.md` and
+  `docs/architecture/interfaces/catalog-plugin.md` where credential
+  requirements reference the new vocabulary.
+
+Do not document provider-specific configuration fields as core fields unless
+they are implemented in this branch.
+
+## Risks And Mitigations
+
+- Risk: one generic `workload-identity` mode hides incompatible cloud
+  semantics.
+  Mitigation: keep generic `credential_modes` for backward compatibility but
+  require provider-specific `identity_modes` for real validation.
+- Risk: adding explicit secrets and identity providers breaks the current demo.
+  Mitigation: preserve implicit Kubernetes baseline for `kubernetes-secret`.
+- Risk: provider plugins leak raw secret material through capabilities.
+  Mitigation: capabilities contain only modes, providers, references, and
+  public endpoint metadata. Tests reject raw credential-looking values.
+- Risk: core becomes a cloud-provider rule engine.
+  Mitigation: core validates named modes and provider labels only; plugins own
+  provider-specific translation.
+- Risk: renderers need more information than this branch emits.
+  Mitigation: defer `deployment.secrets` and `deployment.identity` bindings to
+  RBAC/network/deployment follow-up after this validation contract lands.
+
+## Acceptance Criteria
+
+- `CompiledArtifacts.plugins` includes selected `secrets` and `identity`
+  plugin refs when configured.
+- Current MinIO plus Polaris Kubernetes Secret composition remains valid.
+- External secret and workload identity modes are resolver-validated, not
+  convention-driven.
+- Unsupported credential, projection, or identity modes fail with actionable
+  composition issues.
+- Reference K8s, Infisical, and Keycloak plugins declare side-effect-free
+  capabilities.
+- Compiled artifacts and generated Helm values remain free of raw secret
+  material.
+- Architecture docs describe the adopted identity/secrets composition contract.

--- a/packages/floe-core/src/floe_core/compilation/resolver.py
+++ b/packages/floe-core/src/floe_core/compilation/resolver.py
@@ -109,6 +109,8 @@ def resolve_plugins(manifest: PlatformManifest) -> ResolvedPlugins:
         ingestion=_to_plugin_ref(plugins.ingestion),
         semantic=_to_plugin_ref(plugins.semantic_layer),
         lineage_backend=_to_plugin_ref(plugins.lineage_backend),
+        secrets=_to_plugin_ref(plugins.secrets),
+        identity=_to_plugin_ref(plugins.identity),
     )
 
 

--- a/packages/floe-core/src/floe_core/compilation/resolver.py
+++ b/packages/floe-core/src/floe_core/compilation/resolver.py
@@ -28,6 +28,7 @@ from floe_core.schemas.compiled_artifacts import (
     ResolvedModel,
     ResolvedPlugins,
     ResolvedTransforms,
+    sanitize_plugin_config_for_artifact,
 )
 from floe_core.schemas.floe_spec import FloeSpec
 from floe_core.schemas.manifest import PlatformManifest
@@ -55,6 +56,8 @@ def _to_plugin_ref(
     plugin_type = getattr(plugin, "type", "")
     version = getattr(plugin, "version", None) or default_version
     config = getattr(plugin, "config", None)
+    if config is not None:
+        config = sanitize_plugin_config_for_artifact(config)
     return PluginRef(type=plugin_type, version=version, config=config)
 
 

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -407,17 +407,18 @@ def _build_storage_deployment_binding(
             )
         ) from exc
 
-    credential_modes = cast(
-        "list[CredentialMode]",
-        list(storage_binding.capabilities.credential_modes),
-    )
-    secret_projection_modes = cast(
-        "list[SecretProjectionMode]",
-        [
-            mode
-            for mode in credential_modes
-            if mode in {"kubernetes-secret", "external-secret-sync", "environment"}
-        ],
+    selected_credential_mode = cast("CredentialMode", storage_binding.credentials.mode)
+    credential_modes = [selected_credential_mode]
+    secret_projection_modes = (
+        cast("list[SecretProjectionMode]", [selected_credential_mode])
+        if selected_credential_mode
+        in {
+            "kubernetes-secret",
+            "external-secret-sync",
+            "csi-secret-volume",
+            "environment",
+        }
+        else []
     )
     identity_modes = cast(
         "list[IdentityMode]",

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -26,7 +26,7 @@ import time
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import UUID
 
 import structlog
@@ -260,7 +260,13 @@ def _build_storage_deployment_binding(
         return None
 
     from floe_core.compilation.errors import CompilationError, CompilationException
-    from floe_core.composition.models import CapabilitySet, PluginCapabilities
+    from floe_core.composition.models import (
+        CapabilitySet,
+        CredentialMode,
+        IdentityMode,
+        PluginCapabilities,
+        SecretProjectionMode,
+    )
     from floe_core.composition.resolver import CompositionResolver
     from floe_core.plugin_errors import PluginError
     from floe_core.plugin_registry import PluginRegistry
@@ -323,6 +329,114 @@ def _build_storage_deployment_binding(
             )
         ) from exc
 
+    composition_capabilities: list[PluginCapabilities] = []
+
+    try:
+        if plugins.secrets is not None:
+            registry.configure(
+                PluginType.SECRETS,
+                plugins.secrets.type,
+                plugins.secrets.config or {},
+            )
+            secrets_plugin = registry.get(PluginType.SECRETS, plugins.secrets.type)
+            if not isinstance(secrets_plugin, SecretsPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.secrets.type!r} is not a SecretsPlugin",
+                        suggestion=(
+                            "Use a plugin registered under the floe.secrets entry point group"
+                        ),
+                        context={"secrets_plugin": plugins.secrets.type},
+                    )
+                )
+            composition_capabilities.append(secrets_plugin.get_secret_capabilities())
+    except CompilationException:
+        raise
+    except PluginError as exc:
+        plugin_name = plugins.secrets.type if plugins.secrets is not None else "<unknown>"
+        raise CompilationException(
+            CompilationError(
+                stage=CompilationStage.RESOLVE,
+                code="E201",
+                message=f"Secrets plugin {plugin_name!r} could not be resolved",
+                suggestion=(
+                    "Install the secrets plugin package and verify "
+                    "plugins.secrets.type in the platform manifest"
+                ),
+                context={"secrets_plugin": plugin_name},
+            )
+        ) from exc
+
+    try:
+        if plugins.identity is not None:
+            registry.configure(
+                PluginType.IDENTITY,
+                plugins.identity.type,
+                plugins.identity.config or {},
+            )
+            identity_plugin = registry.get(PluginType.IDENTITY, plugins.identity.type)
+            if not isinstance(identity_plugin, IdentityPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.identity.type!r} is not an IdentityPlugin",
+                        suggestion=(
+                            "Use a plugin registered under the floe.identity entry point group"
+                        ),
+                        context={"identity_plugin": plugins.identity.type},
+                    )
+                )
+            composition_capabilities.append(identity_plugin.get_identity_capabilities())
+    except CompilationException:
+        raise
+    except PluginError as exc:
+        plugin_name = plugins.identity.type if plugins.identity is not None else "<unknown>"
+        raise CompilationException(
+            CompilationError(
+                stage=CompilationStage.RESOLVE,
+                code="E201",
+                message=f"Identity plugin {plugin_name!r} could not be resolved",
+                suggestion=(
+                    "Install the identity plugin package and verify "
+                    "plugins.identity.type in the platform manifest"
+                ),
+                context={"identity_plugin": plugin_name},
+            )
+        ) from exc
+
+    credential_modes = cast(
+        "list[CredentialMode]",
+        list(storage_binding.capabilities.credential_modes),
+    )
+    secret_projection_modes = cast(
+        "list[SecretProjectionMode]",
+        [
+            mode
+            for mode in credential_modes
+            if mode in {"kubernetes-secret", "external-secret-sync", "environment"}
+        ],
+    )
+    identity_modes = cast(
+        "list[IdentityMode]",
+        list(storage_binding.capabilities.identity_modes),
+    )
+    storage_capabilities = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name=storage_plugin.name,
+        capabilities=CapabilitySet(
+            protocols=storage_binding.capabilities.protocols,
+            credential_modes=credential_modes,
+            secret_projection_modes=secret_projection_modes,
+            identity_modes=identity_modes,
+            path_style_access=storage_binding.capabilities.path_style_access,
+            sts=storage_binding.capabilities.sts_supported,
+        ),
+    )
+    composition_capabilities.insert(0, storage_capabilities)
+
     if plugins.catalog is None:
         return DeploymentConfig(storage=storage_binding)
 
@@ -360,79 +474,6 @@ def _build_storage_deployment_binding(
 
     try:
         catalog_requirements = catalog_plugin.get_storage_requirements()
-        composition_capabilities: list[PluginCapabilities] = []
-
-        if plugins.secrets is not None:
-            registry.configure(
-                PluginType.SECRETS,
-                plugins.secrets.type,
-                plugins.secrets.config or {},
-            )
-            secrets_plugin = registry.get(PluginType.SECRETS, plugins.secrets.type)
-            if not isinstance(secrets_plugin, SecretsPlugin):
-                raise CompilationException(
-                    CompilationError(
-                        stage=CompilationStage.RESOLVE,
-                        code="E201",
-                        message=f"Plugin {plugins.secrets.type!r} is not a SecretsPlugin",
-                        suggestion=(
-                            "Use a plugin registered under the floe.secrets entry point group"
-                        ),
-                        context={"secrets_plugin": plugins.secrets.type},
-                    )
-                )
-            composition_capabilities.append(secrets_plugin.get_secret_capabilities())
-
-        identity_capabilities: PluginCapabilities | None = None
-        if plugins.identity is not None:
-            registry.configure(
-                PluginType.IDENTITY,
-                plugins.identity.type,
-                plugins.identity.config or {},
-            )
-            identity_plugin = registry.get(PluginType.IDENTITY, plugins.identity.type)
-            if not isinstance(identity_plugin, IdentityPlugin):
-                raise CompilationException(
-                    CompilationError(
-                        stage=CompilationStage.RESOLVE,
-                        code="E201",
-                        message=f"Plugin {plugins.identity.type!r} is not an IdentityPlugin",
-                        suggestion=(
-                            "Use a plugin registered under the floe.identity entry point group"
-                        ),
-                        context={"identity_plugin": plugins.identity.type},
-                    )
-                )
-            identity_capabilities = identity_plugin.get_identity_capabilities()
-            composition_capabilities.append(identity_capabilities)
-
-        credential_modes = list(storage_binding.capabilities.credential_modes)
-        secret_projection_modes = [
-            mode
-            for mode in credential_modes
-            if mode in {"kubernetes-secret", "external-secret-sync", "environment"}
-        ]
-        identity_modes = list(getattr(storage_binding.capabilities, "identity_modes", []))
-        if (
-            not identity_modes
-            and "workload-identity" in credential_modes
-            and identity_capabilities is not None
-        ):
-            identity_modes = list(identity_capabilities.capabilities.identity_modes)
-
-        storage_capabilities = PluginCapabilities(
-            plugin_type="storage",
-            plugin_name=storage_plugin.name,
-            capabilities=CapabilitySet(
-                protocols=storage_binding.capabilities.protocols,
-                credential_modes=credential_modes,
-                secret_projection_modes=secret_projection_modes,
-                identity_modes=identity_modes,
-                path_style_access=storage_binding.capabilities.path_style_access,
-                sts=storage_binding.capabilities.sts_supported,
-            ),
-        )
-        composition_capabilities.insert(0, storage_capabilities)
 
         composition = CompositionResolver().validate(
             composition_capabilities,

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
         ResolvedPlugins,
     )
     from floe_core.schemas.manifest import GovernanceConfig, PlatformManifest
+    from floe_core.schemas.plugins import PluginsConfig, PluginSelection
 
 logger = structlog.get_logger(__name__)
 
@@ -252,8 +253,19 @@ def _build_lineage_config(manifest: PlatformManifest) -> dict[str, Any] | None:
     return config
 
 
+def _runtime_plugin_config(
+    selection: PluginSelection | None,
+    fallback: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return manifest config for runtime plugin setup, falling back to artifact config."""
+    if selection is not None and selection.config is not None:
+        return selection.config
+    return fallback or {}
+
+
 def _build_storage_deployment_binding(
     plugins: ResolvedPlugins,
+    manifest_plugins: PluginsConfig,
 ) -> DeploymentConfig | None:
     """Build deployment bindings from resolved storage plugin configuration."""
     if plugins.storage is None:
@@ -278,11 +290,12 @@ def _build_storage_deployment_binding(
 
     registry = PluginRegistry()
     registry.discover_all()
+    storage_config = _runtime_plugin_config(manifest_plugins.storage, plugins.storage.config)
     try:
         registry.configure(
             PluginType.STORAGE,
             plugins.storage.type,
-            plugins.storage.config or {},
+            storage_config,
         )
         storage_plugin = registry.get(PluginType.STORAGE, plugins.storage.type)
     except PluginError as exc:
@@ -332,10 +345,14 @@ def _build_storage_deployment_binding(
 
     try:
         if plugins.secrets is not None:
+            secrets_config = _runtime_plugin_config(
+                manifest_plugins.secrets,
+                plugins.secrets.config,
+            )
             registry.configure(
                 PluginType.SECRETS,
                 plugins.secrets.type,
-                plugins.secrets.config or {},
+                secrets_config,
             )
             secrets_plugin = registry.get(PluginType.SECRETS, plugins.secrets.type)
             if not isinstance(secrets_plugin, SecretsPlugin):
@@ -370,10 +387,14 @@ def _build_storage_deployment_binding(
 
     try:
         if plugins.identity is not None:
+            identity_config = _runtime_plugin_config(
+                manifest_plugins.identity,
+                plugins.identity.config,
+            )
             registry.configure(
                 PluginType.IDENTITY,
                 plugins.identity.type,
-                plugins.identity.config or {},
+                identity_config,
             )
             identity_plugin = registry.get(PluginType.IDENTITY, plugins.identity.type)
             if not isinstance(identity_plugin, IdentityPlugin):
@@ -462,11 +483,12 @@ def _build_storage_deployment_binding(
     if plugins.catalog is None:
         return DeploymentConfig(storage=storage_binding)
 
+    catalog_config = _runtime_plugin_config(manifest_plugins.catalog, plugins.catalog.config)
     try:
         registry.configure(
             PluginType.CATALOG,
             plugins.catalog.type,
-            plugins.catalog.config or {},
+            catalog_config,
         )
         catalog_plugin = registry.get(PluginType.CATALOG, plugins.catalog.type)
     except PluginError as exc:
@@ -819,7 +841,7 @@ def compile_pipeline(
                 attributes={"compile.stage": CompilationStage.COMPILE.value},
             ) as compile_span:
                 log.info("compilation_stage_start", stage=CompilationStage.COMPILE.value)
-                deployment = _build_storage_deployment_binding(plugins)
+                deployment = _build_storage_deployment_binding(plugins, resolved_manifest.plugins)
                 storage_dbt_binding = None
                 if deployment is not None and deployment.storage is not None:
                     storage_dbt_binding = deployment.storage.dbt

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -262,7 +262,6 @@ def _build_storage_deployment_binding(
     from floe_core.compilation.errors import CompilationError, CompilationException
     from floe_core.composition.models import (
         CapabilitySet,
-        CredentialMode,
         IdentityMode,
         PluginCapabilities,
         SecretProjectionMode,
@@ -407,7 +406,7 @@ def _build_storage_deployment_binding(
             )
         ) from exc
 
-    selected_credential_mode = cast("CredentialMode", storage_binding.credentials.mode)
+    selected_credential_mode = storage_binding.credentials.mode
     declared_credential_modes = list(storage_binding.capabilities.credential_modes)
     if selected_credential_mode not in declared_credential_modes:
         raise CompilationException(

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -266,6 +266,8 @@ def _build_storage_deployment_binding(
     from floe_core.plugin_registry import PluginRegistry
     from floe_core.plugin_types import PluginType
     from floe_core.plugins.catalog import CatalogPlugin
+    from floe_core.plugins.identity import IdentityPlugin
+    from floe_core.plugins.secrets import SecretsPlugin
     from floe_core.plugins.storage import StoragePlugin
     from floe_core.schemas.compiled_artifacts import DeploymentConfig
 
@@ -357,19 +359,83 @@ def _build_storage_deployment_binding(
         )
 
     try:
+        catalog_requirements = catalog_plugin.get_storage_requirements()
+        composition_capabilities: list[PluginCapabilities] = []
+
+        if plugins.secrets is not None:
+            registry.configure(
+                PluginType.SECRETS,
+                plugins.secrets.type,
+                plugins.secrets.config or {},
+            )
+            secrets_plugin = registry.get(PluginType.SECRETS, plugins.secrets.type)
+            if not isinstance(secrets_plugin, SecretsPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.secrets.type!r} is not a SecretsPlugin",
+                        suggestion=(
+                            "Use a plugin registered under the floe.secrets entry point group"
+                        ),
+                        context={"secrets_plugin": plugins.secrets.type},
+                    )
+                )
+            composition_capabilities.append(secrets_plugin.get_secret_capabilities())
+
+        identity_capabilities: PluginCapabilities | None = None
+        if plugins.identity is not None:
+            registry.configure(
+                PluginType.IDENTITY,
+                plugins.identity.type,
+                plugins.identity.config or {},
+            )
+            identity_plugin = registry.get(PluginType.IDENTITY, plugins.identity.type)
+            if not isinstance(identity_plugin, IdentityPlugin):
+                raise CompilationException(
+                    CompilationError(
+                        stage=CompilationStage.RESOLVE,
+                        code="E201",
+                        message=f"Plugin {plugins.identity.type!r} is not an IdentityPlugin",
+                        suggestion=(
+                            "Use a plugin registered under the floe.identity entry point group"
+                        ),
+                        context={"identity_plugin": plugins.identity.type},
+                    )
+                )
+            identity_capabilities = identity_plugin.get_identity_capabilities()
+            composition_capabilities.append(identity_capabilities)
+
+        credential_modes = list(storage_binding.capabilities.credential_modes)
+        secret_projection_modes = [
+            mode
+            for mode in credential_modes
+            if mode in {"kubernetes-secret", "external-secret-sync", "environment"}
+        ]
+        identity_modes = list(getattr(storage_binding.capabilities, "identity_modes", []))
+        if (
+            not identity_modes
+            and "workload-identity" in credential_modes
+            and identity_capabilities is not None
+        ):
+            identity_modes = list(identity_capabilities.capabilities.identity_modes)
+
         storage_capabilities = PluginCapabilities(
             plugin_type="storage",
             plugin_name=storage_plugin.name,
             capabilities=CapabilitySet(
                 protocols=storage_binding.capabilities.protocols,
-                credential_modes=storage_binding.capabilities.credential_modes,
+                credential_modes=credential_modes,
+                secret_projection_modes=secret_projection_modes,
+                identity_modes=identity_modes,
                 path_style_access=storage_binding.capabilities.path_style_access,
                 sts=storage_binding.capabilities.sts_supported,
             ),
         )
-        catalog_requirements = catalog_plugin.get_storage_requirements()
+        composition_capabilities.insert(0, storage_capabilities)
+
         composition = CompositionResolver().validate(
-            [storage_capabilities],
+            composition_capabilities,
             [catalog_requirements],
         )
         if not composition.valid:

--- a/packages/floe-core/src/floe_core/compilation/stages.py
+++ b/packages/floe-core/src/floe_core/compilation/stages.py
@@ -408,6 +408,28 @@ def _build_storage_deployment_binding(
         ) from exc
 
     selected_credential_mode = cast("CredentialMode", storage_binding.credentials.mode)
+    declared_credential_modes = list(storage_binding.capabilities.credential_modes)
+    if selected_credential_mode not in declared_credential_modes:
+        raise CompilationException(
+            CompilationError(
+                stage=CompilationStage.RESOLVE,
+                code="E201",
+                message=(
+                    f"Storage plugin {storage_plugin.name!r} selected credential mode "
+                    f"{selected_credential_mode!r} but declares credential modes "
+                    f"{declared_credential_modes}"
+                ),
+                suggestion=(
+                    "Update the storage plugin deployment binding so the selected "
+                    "credential mode is included in StorageCapabilities.credential_modes."
+                ),
+                context={
+                    "storage_plugin": storage_plugin.name,
+                    "selected_credential_mode": selected_credential_mode,
+                    "declared_credential_modes": declared_credential_modes,
+                },
+            )
+        )
     credential_modes = [selected_credential_mode]
     secret_projection_modes = (
         cast("list[SecretProjectionMode]", [selected_credential_mode])

--- a/packages/floe-core/src/floe_core/composition/__init__.py
+++ b/packages/floe-core/src/floe_core/composition/__init__.py
@@ -3,8 +3,11 @@
 from floe_core.composition.models import (
     CompositionIssue,
     CompositionValidationResult,
+    CredentialMode,
+    IdentityMode,
     PluginCapabilities,
     PluginRequirements,
+    SecretProjectionMode,
 )
 from floe_core.composition.resolver import CompositionResolver
 
@@ -12,6 +15,9 @@ __all__ = [
     "CompositionIssue",
     "CompositionResolver",
     "CompositionValidationResult",
+    "CredentialMode",
+    "IdentityMode",
     "PluginCapabilities",
     "PluginRequirements",
+    "SecretProjectionMode",
 ]

--- a/packages/floe-core/src/floe_core/composition/models.py
+++ b/packages/floe-core/src/floe_core/composition/models.py
@@ -2,9 +2,32 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
+
+CredentialMode: TypeAlias = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+    "workload-identity",
+    "none",
+]
+SecretProjectionMode: TypeAlias = Literal[
+    "kubernetes-secret",
+    "external-secret-sync",
+    "csi-secret-volume",
+    "environment",
+]
+IdentityMode: TypeAlias = Literal[
+    "aws-irsa",
+    "aws-pod-identity",
+    "gcp-workload-identity",
+    "azure-workload-identity",
+    "azure-managed-identity",
+    "oidc-federation",
+]
 
 
 class CapabilitySet(BaseModel):
@@ -13,7 +36,10 @@ class CapabilitySet(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     protocols: list[str] = Field(default_factory=list)
-    credential_modes: list[str] = Field(default_factory=list)
+    credential_modes: list[CredentialMode] = Field(default_factory=list)
+    secret_projection_modes: list[SecretProjectionMode] = Field(default_factory=list)
+    identity_modes: list[IdentityMode] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
     path_style_access: bool | None = None
     sts: bool | None = None
 
@@ -24,7 +50,10 @@ class RequirementSet(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     protocols: list[str] = Field(default_factory=list)
-    credential_modes: list[str] = Field(default_factory=list)
+    credential_modes: list[CredentialMode] = Field(default_factory=list)
+    secret_projection_modes: list[SecretProjectionMode] = Field(default_factory=list)
+    identity_modes: list[IdentityMode] = Field(default_factory=list)
+    providers: list[str] = Field(default_factory=list)
     requires_server_side_storage_access: bool | None = None
     supports_no_sts: bool | None = None
     supports_path_style_access: bool | None = None

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -41,9 +41,16 @@ class CompositionResolver:
                 )
                 continue
             issues.extend(self._validate_storage_for_catalog(storage, requirement))
-            issues.extend(self._validate_secret_projection(secrets, requirement))
+            compatible_credential_modes = self._compatible_credential_modes(storage, requirement)
+            issues.extend(self._validate_secret_projection(secrets, storage, requirement))
             if self._requires_identity_validation(storage, requirement):
-                issues.extend(self._validate_identity(identity, requirement))
+                issues.extend(
+                    self._validate_identity(
+                        identity,
+                        requirement,
+                        compatible_credential_modes,
+                    )
+                )
 
         return CompositionValidationResult(
             valid=not any(issue.severity == "error" for issue in issues),
@@ -90,70 +97,95 @@ class CompositionResolver:
 
         return issues
 
+    def _compatible_credential_modes(
+        self,
+        storage: PluginCapabilities,
+        requirement: PluginRequirements,
+    ) -> list[str]:
+        """Return credential modes accepted by both storage and catalog."""
+        storage_modes = list(storage.capabilities.credential_modes)
+        required_modes = set(requirement.requirements.credential_modes)
+        return [mode for mode in storage_modes if mode in required_modes]
+
     def _requires_identity_validation(
         self,
         storage: PluginCapabilities,
         requirement: PluginRequirements,
     ) -> bool:
         """Return whether selected storage/catalog modes require identity validation."""
-        storage_modes = set(storage.capabilities.credential_modes)
-        required_modes = set(requirement.requirements.credential_modes)
-        workload_identity_selected = "workload-identity" in storage_modes.intersection(
-            required_modes
+        compatible_modes = self._compatible_credential_modes(storage, requirement)
+        non_identity_modes = [mode for mode in compatible_modes if mode != "workload-identity"]
+        if non_identity_modes:
+            return False
+        return "workload-identity" in compatible_modes or bool(
+            requirement.requirements.identity_modes
         )
-        return workload_identity_selected or bool(requirement.requirements.identity_modes)
 
     def _validate_secret_projection(
         self,
         secrets: PluginCapabilities | None,
+        storage: PluginCapabilities,
         requirement: PluginRequirements,
     ) -> list[CompositionIssue]:
         """Validate required secret projection modes against secrets provider."""
         issues: list[CompositionIssue] = []
-        for mode in requirement.requirements.secret_projection_modes:
-            if mode in ("kubernetes-secret", "environment"):
-                if secrets is None:
-                    continue
-            if secrets is None:
-                issues.append(
-                    CompositionIssue(
-                        severity="error",
-                        code="COMPOSITION_SECRET_PROVIDER_MISSING",
-                        message=(
-                            f"catalog {requirement.plugin_name} requires secret projection "
-                            f"mode {mode} but no secrets plugin was selected"
-                        ),
-                        plugins=[requirement.ref],
-                    )
+        compatible_modes = self._compatible_secret_projection_modes(storage, requirement)
+        if not compatible_modes:
+            return issues
+
+        if any(mode in ("kubernetes-secret", "environment") for mode in compatible_modes):
+            return issues
+
+        mode = compatible_modes[0]
+        if secrets is None:
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_SECRET_PROVIDER_MISSING",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires secret projection "
+                        f"mode {mode} but no secrets plugin was selected"
+                    ),
+                    plugins=[requirement.ref],
                 )
-                continue
-            provided_modes = list(secrets.capabilities.secret_projection_modes)
-            if mode not in provided_modes:
-                issues.append(
-                    CompositionIssue(
-                        severity="error",
-                        code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
-                        message=(
-                            f"catalog {requirement.plugin_name} requires secret projection "
-                            f"mode {mode}; secrets {secrets.plugin_name} provides {provided_modes}"
-                        ),
-                        plugins=[secrets.ref, requirement.ref],
-                    )
+            )
+            return issues
+
+        provided_modes = list(secrets.capabilities.secret_projection_modes)
+        if not set(provided_modes).intersection(compatible_modes):
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires secret projection "
+                        f"mode {mode}; secrets {secrets.plugin_name} provides {provided_modes}"
+                    ),
+                    plugins=[secrets.ref, requirement.ref],
                 )
+            )
         return issues
+
+    def _compatible_secret_projection_modes(
+        self,
+        storage: PluginCapabilities,
+        requirement: PluginRequirements,
+    ) -> list[str]:
+        """Return secret projection modes accepted by storage and catalog."""
+        storage_modes = list(storage.capabilities.secret_projection_modes)
+        required_modes = set(requirement.requirements.secret_projection_modes)
+        return [mode for mode in storage_modes if mode in required_modes]
 
     def _validate_identity(
         self,
         identity: PluginCapabilities | None,
         requirement: PluginRequirements,
+        compatible_credential_modes: list[str],
     ) -> list[CompositionIssue]:
         """Validate required workload identity modes against identity provider."""
         issues: list[CompositionIssue] = []
-        requires_workload_identity = (
-            "workload-identity" in requirement.requirements.credential_modes
-        )
         required_modes = list(requirement.requirements.identity_modes)
-        if not requires_workload_identity and not required_modes:
+        if "workload-identity" not in compatible_credential_modes and not required_modes:
             return issues
 
         if identity is None:
@@ -172,17 +204,17 @@ class CompositionResolver:
             return issues
 
         provided_modes = list(identity.capabilities.identity_modes)
-        for mode in required_modes:
-            if mode not in provided_modes:
-                issues.append(
-                    CompositionIssue(
-                        severity="error",
-                        code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
-                        message=(
-                            f"catalog {requirement.plugin_name} requires identity mode {mode}; "
-                            f"identity {identity.plugin_name} provides {provided_modes}"
-                        ),
-                        plugins=[identity.ref, requirement.ref],
-                    )
+        if required_modes and not set(provided_modes).intersection(required_modes):
+            mode = required_modes[0]
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires identity mode {mode}; "
+                        f"identity {identity.plugin_name} provides {provided_modes}"
+                    ),
+                    plugins=[identity.ref, requirement.ref],
                 )
+            )
         return issues

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -21,6 +21,8 @@ class CompositionResolver:
         """Return compatibility issues for the selected plugin graph."""
         issues: list[CompositionIssue] = []
         storage = next((item for item in capabilities if item.plugin_type == "storage"), None)
+        secrets = next((item for item in capabilities if item.plugin_type == "secrets"), None)
+        identity = next((item for item in capabilities if item.plugin_type == "identity"), None)
 
         for requirement in requirements:
             if requirement.plugin_type != "catalog":
@@ -39,6 +41,9 @@ class CompositionResolver:
                 )
                 continue
             issues.extend(self._validate_storage_for_catalog(storage, requirement))
+            issues.extend(self._validate_secret_projection(secrets, requirement))
+            if self._requires_identity_validation(storage, requirement):
+                issues.extend(self._validate_identity(identity, requirement))
 
         return CompositionValidationResult(
             valid=not any(issue.severity == "error" for issue in issues),
@@ -83,4 +88,101 @@ class CompositionResolver:
                 )
             )
 
+        return issues
+
+    def _requires_identity_validation(
+        self,
+        storage: PluginCapabilities,
+        requirement: PluginRequirements,
+    ) -> bool:
+        """Return whether selected storage/catalog modes require identity validation."""
+        storage_modes = set(storage.capabilities.credential_modes)
+        required_modes = set(requirement.requirements.credential_modes)
+        workload_identity_selected = "workload-identity" in storage_modes.intersection(
+            required_modes
+        )
+        return workload_identity_selected or bool(requirement.requirements.identity_modes)
+
+    def _validate_secret_projection(
+        self,
+        secrets: PluginCapabilities | None,
+        requirement: PluginRequirements,
+    ) -> list[CompositionIssue]:
+        """Validate required secret projection modes against secrets provider."""
+        issues: list[CompositionIssue] = []
+        for mode in requirement.requirements.secret_projection_modes:
+            if mode in ("kubernetes-secret", "environment"):
+                if secrets is None:
+                    continue
+            if secrets is None:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_SECRET_PROVIDER_MISSING",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires secret projection "
+                            f"mode {mode} but no secrets plugin was selected"
+                        ),
+                        plugins=[requirement.ref],
+                    )
+                )
+                continue
+            provided_modes = list(secrets.capabilities.secret_projection_modes)
+            if mode not in provided_modes:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires secret projection "
+                            f"mode {mode}; secrets {secrets.plugin_name} provides {provided_modes}"
+                        ),
+                        plugins=[secrets.ref, requirement.ref],
+                    )
+                )
+        return issues
+
+    def _validate_identity(
+        self,
+        identity: PluginCapabilities | None,
+        requirement: PluginRequirements,
+    ) -> list[CompositionIssue]:
+        """Validate required workload identity modes against identity provider."""
+        issues: list[CompositionIssue] = []
+        requires_workload_identity = (
+            "workload-identity" in requirement.requirements.credential_modes
+        )
+        required_modes = list(requirement.requirements.identity_modes)
+        if not requires_workload_identity and not required_modes:
+            return issues
+
+        if identity is None:
+            mode = required_modes[0] if required_modes else "workload-identity"
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_IDENTITY_PROVIDER_MISSING",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires identity mode {mode} "
+                        "but no identity plugin was selected"
+                    ),
+                    plugins=[requirement.ref],
+                )
+            )
+            return issues
+
+        provided_modes = list(identity.capabilities.identity_modes)
+        for mode in required_modes:
+            if mode not in provided_modes:
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires identity mode {mode}; "
+                            f"identity {identity.plugin_name} provides {provided_modes}"
+                        ),
+                        plugins=[identity.ref, requirement.ref],
+                    )
+                )
         return issues

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -151,7 +151,9 @@ class CompositionResolver:
         if not compatible_modes:
             return issues
 
-        if any(mode in ("kubernetes-secret", "environment") for mode in compatible_modes):
+        if secrets is None and any(
+            mode in ("kubernetes-secret", "environment") for mode in compatible_modes
+        ):
             return issues
 
         mode = compatible_modes[0]

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -151,21 +151,31 @@ class CompositionResolver:
         if not compatible_modes:
             return issues
 
-        if secrets is None and any(
-            mode in ("kubernetes-secret", "environment") for mode in compatible_modes
+        required_providers = list(requirement.requirements.providers)
+        if (
+            secrets is None
+            and any(mode in ("kubernetes-secret", "environment") for mode in compatible_modes)
+            and not required_providers
         ):
             return issues
 
         mode = compatible_modes[0]
         if secrets is None:
+            message = (
+                f"catalog {requirement.plugin_name} requires secret projection "
+                f"mode {mode} but no secrets plugin was selected"
+            )
+            if required_providers:
+                message = (
+                    f"catalog {requirement.plugin_name} requires one of secret "
+                    f"providers {required_providers} for secret projection mode {mode} "
+                    "but no secrets plugin was selected"
+                )
             issues.append(
                 CompositionIssue(
                     severity="error",
                     code="COMPOSITION_SECRET_PROVIDER_MISSING",
-                    message=(
-                        f"catalog {requirement.plugin_name} requires secret projection "
-                        f"mode {mode} but no secrets plugin was selected"
-                    ),
+                    message=message,
                     plugins=[requirement.ref],
                 )
             )
@@ -180,6 +190,22 @@ class CompositionResolver:
                     message=(
                         f"catalog {requirement.plugin_name} requires secret projection "
                         f"mode {mode}; secrets {secrets.plugin_name} provides {provided_modes}"
+                    ),
+                    plugins=[secrets.ref, requirement.ref],
+                )
+            )
+            return issues
+
+        provided_providers = list(secrets.capabilities.providers)
+        if required_providers and not set(required_providers).intersection(provided_providers):
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_SECRET_PROVIDER_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires one of secret "
+                        f"providers {required_providers}; secrets {secrets.plugin_name} "
+                        f"provides {provided_providers}"
                     ),
                     plugins=[secrets.ref, requirement.ref],
                 )
@@ -248,6 +274,21 @@ class CompositionResolver:
             and compatible_modes
             and set(provided_modes).intersection(compatible_modes)
         ):
+            required_providers = list(requirement.requirements.providers)
+            provided_providers = list(identity.capabilities.providers)
+            if required_providers and not set(required_providers).intersection(provided_providers):
+                issues.append(
+                    CompositionIssue(
+                        severity="error",
+                        code="COMPOSITION_IDENTITY_PROVIDER_UNSUPPORTED",
+                        message=(
+                            f"catalog {requirement.plugin_name} requires one of identity "
+                            f"providers {required_providers}; identity "
+                            f"{identity.plugin_name} provides {provided_providers}"
+                        ),
+                        plugins=[identity.ref, requirement.ref],
+                    )
+                )
             return issues
 
         if required_modes and len(required_modes) == 1 and compatible_modes:

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -47,6 +47,7 @@ class CompositionResolver:
                 issues.extend(
                     self._validate_identity(
                         identity,
+                        storage,
                         requirement,
                         compatible_credential_modes,
                     )
@@ -129,7 +130,24 @@ class CompositionResolver:
     ) -> list[CompositionIssue]:
         """Validate required secret projection modes against secrets provider."""
         issues: list[CompositionIssue] = []
+        storage_modes = list(storage.capabilities.secret_projection_modes)
+        required_modes = list(requirement.requirements.secret_projection_modes)
         compatible_modes = self._compatible_secret_projection_modes(storage, requirement)
+        if required_modes and storage_modes and not compatible_modes:
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires one of secret "
+                        f"projection modes {required_modes}; storage {storage.plugin_name} "
+                        f"provides {storage_modes}"
+                    ),
+                    plugins=[storage.ref, requirement.ref],
+                )
+            )
+            return issues
+
         if not compatible_modes:
             return issues
 
@@ -179,6 +197,7 @@ class CompositionResolver:
     def _validate_identity(
         self,
         identity: PluginCapabilities | None,
+        storage: PluginCapabilities,
         requirement: PluginRequirements,
         compatible_credential_modes: list[str],
     ) -> list[CompositionIssue]:
@@ -203,8 +222,17 @@ class CompositionResolver:
             )
             return issues
 
+        storage_modes = list(storage.capabilities.identity_modes)
         provided_modes = list(identity.capabilities.identity_modes)
-        if required_modes and not set(provided_modes).intersection(required_modes):
+        compatible_modes = [mode for mode in storage_modes if mode in set(required_modes)]
+        if (
+            required_modes
+            and compatible_modes
+            and set(provided_modes).intersection(compatible_modes)
+        ):
+            return issues
+
+        if required_modes and len(required_modes) == 1 and compatible_modes:
             mode = required_modes[0]
             issues.append(
                 CompositionIssue(
@@ -215,6 +243,22 @@ class CompositionResolver:
                         f"identity {identity.plugin_name} provides {provided_modes}"
                     ),
                     plugins=[identity.ref, requirement.ref],
+                )
+            )
+            return issues
+
+        if required_modes:
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires one of identity "
+                        f"modes {required_modes}; storage {storage.plugin_name} "
+                        f"provides {storage_modes}; identity {identity.plugin_name} "
+                        f"provides {provided_modes}"
+                    ),
+                    plugins=[storage.ref, identity.ref, requirement.ref],
                 )
             )
         return issues

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -224,6 +224,22 @@ class CompositionResolver:
 
         storage_modes = list(storage.capabilities.identity_modes)
         provided_modes = list(identity.capabilities.identity_modes)
+        if "workload-identity" in compatible_credential_modes and not required_modes:
+            issues.append(
+                CompositionIssue(
+                    severity="error",
+                    code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+                    message=(
+                        f"catalog {requirement.plugin_name} requires workload identity "
+                        "but does not declare concrete identity modes; storage "
+                        f"{storage.plugin_name} provides {storage_modes}; identity "
+                        f"{identity.plugin_name} provides {provided_modes}"
+                    ),
+                    plugins=[storage.ref, identity.ref, requirement.ref],
+                )
+            )
+            return issues
+
         compatible_modes = [mode for mode in storage_modes if mode in set(required_modes)]
         if (
             required_modes

--- a/packages/floe-core/src/floe_core/composition/resolver.py
+++ b/packages/floe-core/src/floe_core/composition/resolver.py
@@ -133,7 +133,7 @@ class CompositionResolver:
         storage_modes = list(storage.capabilities.secret_projection_modes)
         required_modes = list(requirement.requirements.secret_projection_modes)
         compatible_modes = self._compatible_secret_projection_modes(storage, requirement)
-        if required_modes and storage_modes and not compatible_modes:
+        if required_modes and not compatible_modes:
             issues.append(
                 CompositionIssue(
                     severity="error",

--- a/packages/floe-core/src/floe_core/plugins/identity.py
+++ b/packages/floe-core/src/floe_core/plugins/identity.py
@@ -21,6 +21,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
 from floe_core.plugin_metadata import PluginMetadata
 
 
@@ -220,6 +221,18 @@ class IdentityPlugin(PluginMetadata):
             ...     print(f"Invalid: {result.error}")
         """
         ...
+
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        """Return workload identity capabilities for composition validation.
+
+        The default is intentionally empty so existing identity plugins remain
+        discoverable until they adopt composition explicitly.
+        """
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(),
+        )
 
     def get_oidc_config(self, realm: str | None = None) -> OIDCConfig:
         """Get OIDC configuration for service integration.

--- a/packages/floe-core/src/floe_core/plugins/secrets.py
+++ b/packages/floe-core/src/floe_core/plugins/secrets.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Any
 
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
 from floe_core.plugin_metadata import PluginMetadata
 
 
@@ -156,6 +157,18 @@ class SecretsPlugin(PluginMetadata):
             {'envFrom': [{'secretRef': {'name': 'db-creds'}}]}
         """
         return {"envFrom": [{"secretRef": {"name": secret_name}}]}
+
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return secret projection capabilities for composition validation.
+
+        The default is intentionally empty so existing secrets plugins remain
+        discoverable until they adopt composition explicitly.
+        """
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(),
+        )
 
     def get_multi_key_secret(self, name: str) -> dict[str, str]:
         """Retrieve all key-value pairs from a multi-key secret.

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -296,6 +296,8 @@ class ResolvedPlugins(BaseModel):
         storage: Resolved storage plugin (optional)
         ingestion: Resolved ingestion plugin (optional)
         semantic: Resolved semantic layer plugin (optional)
+        secrets: Resolved secrets plugin (optional)
+        identity: Resolved identity plugin (optional)
 
     Example:
         >>> plugins = ResolvedPlugins(
@@ -339,6 +341,14 @@ class ResolvedPlugins(BaseModel):
     lineage_backend: PluginRef | None = Field(
         default=None,
         description="Resolved lineage backend plugin (optional, v0.5.0+)",
+    )
+    secrets: PluginRef | None = Field(
+        default=None,
+        description="Resolved secrets plugin (optional)",
+    )
+    identity: PluginRef | None = Field(
+        default=None,
+        description="Resolved identity plugin (optional)",
     )
 
 

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 
 from floe_core.schemas.data_contract import DataContract
 from floe_core.schemas.quality_config import QualityConfig
@@ -55,7 +55,25 @@ _SECRET_VALUE_MARKERS = (
     "secret-value",
     "token",
 )
+_PLUGIN_CONFIG_SECRET_FIELDS = frozenset(
+    {
+        "accesskey",
+        "apikey",
+        "apitoken",
+        "bearertoken",
+        "clientsecret",
+        "clienttoken",
+        "password",
+        "privatekey",
+        "refreshtoken",
+        "secret",
+        "secretaccesskey",
+        "secretkey",
+        "token",
+    }
+)
 _DEFAULT_ADMIN_CREDENTIAL_PATTERN = re.compile(r"(?<![a-z0-9])[a-z0-9_-]*admin[0-9]*(?![a-z0-9])")
+_OMIT_PLUGIN_CONFIG_VALUE = object()
 
 
 def _validate_configmap_name(name: str) -> str:
@@ -140,6 +158,74 @@ def _assert_no_secret_material(value: Any, path: str) -> None:
             "use JSON-compatible dict, list, string, number, boolean, or null values"
         )
         raise ValueError(msg)
+
+
+def _normalize_plugin_config_key(key: object) -> str:
+    """Normalize a plugin config key for credential-field detection."""
+    return re.sub(r"[^a-z0-9]", "", str(key).lower())
+
+
+def _assert_no_plugin_ref_secret_material(value: Any, path: str) -> None:
+    """Reject raw credential fields while allowing secret reference names."""
+    if isinstance(value, SecretStr):
+        msg = (
+            f"{path} looks like raw credential material; use connection_secret_ref "
+            "or provider-owned secret references instead"
+        )
+        raise ValueError(msg)
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if _normalize_plugin_config_key(key) in _PLUGIN_CONFIG_SECRET_FIELDS:
+                msg = (
+                    f"{child_path} looks like raw credential material; use connection_secret_ref "
+                    "or provider-owned secret references instead"
+                )
+                raise ValueError(msg)
+            _assert_no_plugin_ref_secret_material(child, child_path)
+        return
+
+    if isinstance(value, list | tuple | set | frozenset):
+        for index, child in enumerate(value):
+            _assert_no_plugin_ref_secret_material(child, f"{path}[{index}]")
+        return
+
+    if isinstance(value, str | int | float | bool | type(None)):
+        return
+
+    if isinstance(value, Iterable):
+        msg = (
+            f"{path} contains unsupported plugin config type {type(value).__name__}; "
+            "use JSON-compatible dict, list, string, number, boolean, or null values"
+        )
+        raise ValueError(msg)
+
+
+def sanitize_plugin_config_for_artifact(value: Any) -> Any:
+    """Return a JSON-compatible plugin config projection without raw credentials."""
+    if isinstance(value, SecretStr):
+        return _OMIT_PLUGIN_CONFIG_VALUE
+
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, child in value.items():
+            if _normalize_plugin_config_key(key) in _PLUGIN_CONFIG_SECRET_FIELDS:
+                continue
+            sanitized_child = sanitize_plugin_config_for_artifact(child)
+            if sanitized_child is not _OMIT_PLUGIN_CONFIG_VALUE:
+                sanitized[str(key)] = sanitized_child
+        return sanitized
+
+    if isinstance(value, list | tuple | set | frozenset):
+        sanitized_items = []
+        for child in value:
+            sanitized_child = sanitize_plugin_config_for_artifact(child)
+            if sanitized_child is not _OMIT_PLUGIN_CONFIG_VALUE:
+                sanitized_items.append(sanitized_child)
+        return sanitized_items
+
+    return value
 
 
 class CompilationMetadata(BaseModel):
@@ -280,6 +366,13 @@ class PluginRef(BaseModel):
         description="Plugin-specific configuration",
         examples=[{"threads": 4, "memory_limit": "8GB"}],
     )
+
+    @model_validator(mode="after")
+    def validate_secret_free_config(self) -> PluginRef:
+        """Ensure resolved plugin refs do not serialize raw credential material."""
+        if self.config is not None:
+            _assert_no_plugin_ref_secret_material(self.config, f"plugins.{self.type}.config")
+        return self
 
 
 class ResolvedPlugins(BaseModel):

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -495,6 +495,7 @@ class StorageCapabilities(BaseModel):
 
     protocols: list[NonEmptyString] = Field(default_factory=list)
     credential_modes: list[NonEmptyString] = Field(default_factory=list)
+    identity_modes: list[NonEmptyString] = Field(default_factory=list)
     sts_supported: bool = False
     path_style_access: bool = False
 

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -379,16 +379,23 @@ class CredentialRef(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    source: Literal["kubernetes-secret", "environment", "workload-identity", "none"]
+    source: Literal[
+        "kubernetes-secret",
+        "environment",
+        "workload-identity",
+        "external-secret-sync",
+        "csi-secret-volume",
+        "none",
+    ]
     name: NonEmptyString
     key: NonEmptyString | None = None
 
     @model_validator(mode="after")
     def validate_key_for_source(self) -> CredentialRef:
-        """Ensure only Kubernetes Secret credential refs carry key names."""
-        if self.source == "kubernetes-secret":
+        """Ensure only secret-backed credential refs carry key names."""
+        if self.source in {"kubernetes-secret", "external-secret-sync", "csi-secret-volume"}:
             if self.key is None:
-                msg = "kubernetes-secret credential ref requires key"
+                msg = f"{self.source} credential ref requires key"
                 raise ValueError(msg)
             return self
         if self.key is not None:
@@ -402,7 +409,14 @@ class StorageCredentialBinding(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    mode: Literal["kubernetes-secret", "environment", "workload-identity", "none"]
+    mode: Literal[
+        "kubernetes-secret",
+        "environment",
+        "workload-identity",
+        "external-secret-sync",
+        "csi-secret-volume",
+        "none",
+    ]
     secret_ref: KubernetesSecretRef | None = None
     env_refs: dict[str, NonEmptyString] = Field(default_factory=dict)
     service_account_ref: NonEmptyString | None = None
@@ -410,12 +424,12 @@ class StorageCredentialBinding(BaseModel):
     @model_validator(mode="after")
     def validate_mode_sources(self) -> StorageCredentialBinding:
         """Ensure credential source fields match the selected mode."""
-        if self.mode == "kubernetes-secret":
+        if self.mode in {"kubernetes-secret", "external-secret-sync", "csi-secret-volume"}:
             if self.secret_ref is None:
-                msg = "kubernetes-secret credential binding requires secret_ref"
+                msg = f"{self.mode} credential binding requires secret_ref"
                 raise ValueError(msg)
             if self.env_refs or self.service_account_ref is not None:
-                msg = "kubernetes-secret credential binding only accepts secret_ref"
+                msg = f"{self.mode} credential binding only accepts secret_ref"
                 raise ValueError(msg)
             return self
         if self.mode == "environment":
@@ -441,9 +455,9 @@ class StorageCredentialBinding(BaseModel):
 
     def as_credential_ref(self, logical_key: str) -> CredentialRef:
         """Return a consumer credential reference for a logical key."""
-        if self.mode == "kubernetes-secret":
+        if self.mode in {"kubernetes-secret", "external-secret-sync", "csi-secret-volume"}:
             if self.secret_ref is None:
-                msg = "kubernetes-secret credential binding requires secret_ref"
+                msg = f"{self.mode} credential binding requires secret_ref"
                 raise ValueError(msg)
             secret_key = self.secret_ref.keys.get(logical_key)
             if secret_key is None:

--- a/packages/floe-core/src/floe_core/schemas/versions.py
+++ b/packages/floe-core/src/floe_core/schemas/versions.py
@@ -57,7 +57,7 @@ def get_compiled_artifacts_version() -> str:
         >>> from floe_core.schemas.versions import get_compiled_artifacts_version
         >>> version = get_compiled_artifacts_version()
         >>> version
-        '0.4.0'
+        '0.11.0'
     """
     return COMPILED_ARTIFACTS_VERSION
 

--- a/packages/floe-core/src/floe_core/schemas/versions.py
+++ b/packages/floe-core/src/floe_core/schemas/versions.py
@@ -29,7 +29,7 @@ FLOE_VERSION: str = "0.3.0"
 # Increment MAJOR for breaking changes (remove fields, change types)
 # Increment MINOR for backward-compatible additions (new optional fields)
 # Increment PATCH for documentation/metadata only changes
-COMPILED_ARTIFACTS_VERSION: str = "0.12.0"
+COMPILED_ARTIFACTS_VERSION: str = "0.13.0"
 
 # Version history (for documentation and compatibility checks)
 COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
@@ -45,6 +45,7 @@ COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
     "0.10.0": "Add stale_table_recovery_mode to ResolvedGovernance and deployment bindings",
     "0.11.0": "Add secrets and identity to ResolvedPlugins",
     "0.12.0": "Add identity_modes to StorageCapabilities for workload identity composition",
+    "0.13.0": "Add secret projection credential binding modes",
 }
 
 
@@ -58,7 +59,7 @@ def get_compiled_artifacts_version() -> str:
         >>> from floe_core.schemas.versions import get_compiled_artifacts_version
         >>> version = get_compiled_artifacts_version()
         >>> version
-        '0.12.0'
+        '0.13.0'
     """
     return COMPILED_ARTIFACTS_VERSION
 

--- a/packages/floe-core/src/floe_core/schemas/versions.py
+++ b/packages/floe-core/src/floe_core/schemas/versions.py
@@ -29,7 +29,7 @@ FLOE_VERSION: str = "0.3.0"
 # Increment MAJOR for breaking changes (remove fields, change types)
 # Increment MINOR for backward-compatible additions (new optional fields)
 # Increment PATCH for documentation/metadata only changes
-COMPILED_ARTIFACTS_VERSION: str = "0.11.0"
+COMPILED_ARTIFACTS_VERSION: str = "0.12.0"
 
 # Version history (for documentation and compatibility checks)
 COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
@@ -44,6 +44,7 @@ COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
     "0.9.0": "Add default_ttl_hours, snapshot_keep_last to ResolvedGovernance (Issue #165)",
     "0.10.0": "Add stale_table_recovery_mode to ResolvedGovernance and deployment bindings",
     "0.11.0": "Add secrets and identity to ResolvedPlugins",
+    "0.12.0": "Add identity_modes to StorageCapabilities for workload identity composition",
 }
 
 
@@ -57,7 +58,7 @@ def get_compiled_artifacts_version() -> str:
         >>> from floe_core.schemas.versions import get_compiled_artifacts_version
         >>> version = get_compiled_artifacts_version()
         >>> version
-        '0.11.0'
+        '0.12.0'
     """
     return COMPILED_ARTIFACTS_VERSION
 

--- a/packages/floe-core/src/floe_core/schemas/versions.py
+++ b/packages/floe-core/src/floe_core/schemas/versions.py
@@ -29,7 +29,7 @@ FLOE_VERSION: str = "0.3.0"
 # Increment MAJOR for breaking changes (remove fields, change types)
 # Increment MINOR for backward-compatible additions (new optional fields)
 # Increment PATCH for documentation/metadata only changes
-COMPILED_ARTIFACTS_VERSION: str = "0.10.0"
+COMPILED_ARTIFACTS_VERSION: str = "0.11.0"
 
 # Version history (for documentation and compatibility checks)
 COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
@@ -43,6 +43,7 @@ COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
     "0.8.0": "Add lineage_endpoint, lineage_transport to ObservabilityConfig",
     "0.9.0": "Add default_ttl_hours, snapshot_keep_last to ResolvedGovernance (Issue #165)",
     "0.10.0": "Add stale_table_recovery_mode to ResolvedGovernance and deployment bindings",
+    "0.11.0": "Add secrets and identity to ResolvedPlugins",
 }
 
 

--- a/packages/floe-core/tests/unit/compilation/test_resolver.py
+++ b/packages/floe-core/tests/unit/compilation/test_resolver.py
@@ -115,6 +115,47 @@ def test_resolve_plugins_preserves_secrets_and_identity_selections() -> None:
     assert resolved.identity.config == {"realm": "floe"}
 
 
+def test_resolve_plugins_strips_secret_material_from_security_provider_config() -> None:
+    """Security provider configs should project secret-free artifact config."""
+    sensitive_key = "client_" + "secret"
+    manifest = PlatformManifest(
+        api_version="floe.dev/v1",
+        kind="Manifest",
+        metadata=ManifestMetadata(name="platform", version="1.0.0", owner="test@example.com"),
+        plugins=PluginsConfig(
+            compute=PluginSelection(type="duckdb", version="0.9.0"),
+            orchestrator=PluginSelection(type="dagster", version="1.5.0"),
+            secrets=PluginSelection(
+                type="infisical",
+                version="0.1.0",
+                config={
+                    "client_id": "floe-platform",
+                    sensitive_key: "provided-at-runtime",
+                    "secret_path": "/floe/platform",
+                },
+            ),
+            identity=PluginSelection(
+                type="keycloak",
+                version="0.1.0",
+                config={
+                    "realm": "floe",
+                    sensitive_key: "provided-at-runtime",
+                },
+            ),
+        ),
+    )
+
+    resolved = resolve_plugins(manifest)
+
+    assert resolved.secrets is not None
+    assert resolved.secrets.config == {
+        "client_id": "floe-platform",
+        "secret_path": "/floe/platform",
+    }
+    assert resolved.identity is not None
+    assert resolved.identity.config == {"realm": "floe"}
+
+
 class TestResolvePlugins:
     """Tests for resolve_plugins function."""
 

--- a/packages/floe-core/tests/unit/compilation/test_resolver.py
+++ b/packages/floe-core/tests/unit/compilation/test_resolver.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 import pytest
 
+from floe_core.compilation.resolver import resolve_plugins
 from floe_core.schemas.floe_spec import FloeMetadata, FloeSpec, TransformSpec
 from floe_core.schemas.manifest import PlatformManifest
+from floe_core.schemas.metadata import ManifestMetadata
+from floe_core.schemas.plugins import PluginsConfig, PluginSelection
 
 
 @pytest.fixture
@@ -78,6 +81,38 @@ def floe_spec_with_compute_override() -> FloeSpec:
             TransformSpec(name="fct_orders", compute="snowflake"),  # Override
         ],
     )
+
+
+def test_resolve_plugins_preserves_secrets_and_identity_selections() -> None:
+    """Compilation should expose selected security providers in artifacts."""
+    manifest = PlatformManifest(
+        api_version="floe.dev/v1",
+        kind="Manifest",
+        metadata=ManifestMetadata(name="platform", version="1.0.0", owner="test@example.com"),
+        plugins=PluginsConfig(
+            compute=PluginSelection(type="duckdb", version="0.9.0"),
+            orchestrator=PluginSelection(type="dagster", version="1.5.0"),
+            secrets=PluginSelection(
+                type="k8s",
+                version="0.1.0",
+                config={"namespace": "floe-system"},
+            ),
+            identity=PluginSelection(
+                type="keycloak",
+                version="0.1.0",
+                config={"realm": "floe"},
+            ),
+        ),
+    )
+
+    resolved = resolve_plugins(manifest)
+
+    assert resolved.secrets is not None
+    assert resolved.secrets.type == "k8s"
+    assert resolved.secrets.config == {"namespace": "floe-system"}
+    assert resolved.identity is not None
+    assert resolved.identity.type == "keycloak"
+    assert resolved.identity.config == {"realm": "floe"}
 
 
 class TestResolvePlugins:

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -1126,6 +1126,77 @@ def test_compile_validates_selected_workload_identity_mode_not_advertised_altern
     assert "no identity plugin was selected" in error.message
 
 
+def test_compile_rejects_selected_storage_mode_not_declared_by_capabilities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compiler must reject selected storage credential modes not in capabilities."""
+
+    class MismatchedExternalSecretStoragePlugin(ExternalSecretStoragePlugin):
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            binding = super().get_deployment_binding()
+            return binding.model_copy(
+                update={
+                    "capabilities": StorageCapabilities(
+                        protocols=["s3"],
+                        credential_modes=["kubernetes-secret"],
+                        path_style_access=False,
+                    )
+                }
+            )
+
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return MismatchedExternalSecretStoragePlugin()
+            if plugin_type == PluginType.CATALOG:
+                return ExternalSecretCatalogPlugin()
+            if plugin_type == PluginType.SECRETS:
+                return FakeSecretsPlugin()
+            if plugin_type == PluginType.COMPUTE:
+                from floe_compute_duckdb.plugin import DuckDBComputePlugin
+
+                return DuckDBComputePlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+    manifest_path = _external_secret_manifest_path(tmp_path, include_secrets=True)
+
+    with pytest.raises(CompilationException) as exc_info:
+        compile_pipeline(
+            ROOT / "demo" / "customer-360" / "floe.yaml",
+            manifest_path,
+            emit_lineage=False,
+        )
+
+    error = exc_info.value.error
+    assert error.stage == CompilationStage.RESOLVE
+    assert error.code == "E201"
+    assert (
+        "Storage plugin 's3' selected credential mode 'external-secret-sync' "
+        "but declares credential modes ['kubernetes-secret']"
+    ) in error.message
+    assert error.context == {
+        "storage_plugin": "s3",
+        "selected_credential_mode": "external-secret-sync",
+        "declared_credential_modes": ["kubernetes-secret"],
+    }
+
+
 def test_compile_requires_secrets_provider_for_selected_external_secret_sync(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1152,8 +1223,9 @@ def test_compile_requires_secrets_provider_for_selected_external_secret_sync(
                 "severity": "error",
                 "code": "COMPOSITION_SECRET_PROVIDER_MISSING",
                 "message": (
-                    "catalog glue requires secret projection mode external-secret-sync "
-                    "but no secrets plugin was selected"
+                    "catalog glue requires one of secret providers ['infisical'] "
+                    "for secret projection mode external-secret-sync but no secrets "
+                    "plugin was selected"
                 ),
                 "plugins": ["catalog:glue"],
             }

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -548,6 +548,7 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
                 capabilities=StorageCapabilities(
                     protocols=["s3"],
                     credential_modes=["workload-identity"],
+                    identity_modes=["aws-irsa"],
                     sts_supported=True,
                     path_style_access=False,
                 ),
@@ -698,3 +699,154 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
     assert artifacts.deployment is not None
     assert artifacts.deployment.storage is not None
     assert artifacts.deployment.storage.credentials.mode == "workload-identity"
+
+
+def test_storage_only_compile_validates_selected_identity_plugin_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured identity plugin should be ABC-validated even without catalog."""
+
+    class StorageOnlyPlugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "minio"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return StorageDeploymentBinding(
+                provider="minio",
+                protocol="s3-compatible",
+                endpoint=StorageServiceEndpoint(
+                    internal_url="http://minio:9000",
+                    external_url="http://minio:9000",
+                    region="us-east-1",
+                    warehouse_path="s3://warehouse",
+                    path_style_access=True,
+                ),
+                warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
+                credentials=StorageCredentialBinding(
+                    mode="kubernetes-secret",
+                    secret_ref=KubernetesSecretRef(
+                        name="minio-credentials",
+                        namespace="floe-system",
+                        keys={
+                            "accessKeyId": "root-user",
+                            "secretAccessKey": "root-password",  # pragma: allowlist secret
+                        },
+                    ),
+                ),
+                capabilities=StorageCapabilities(
+                    protocols=["s3-compatible"],
+                    credential_modes=["kubernetes-secret"],
+                    path_style_access=True,
+                ),
+                dbt=DbtStorageBinding(
+                    profile_name="floe",
+                    target_name="dev",
+                    schema_name="analytics",
+                ),
+                dagster=DagsterStorageBinding(
+                    resource_key="minio_storage",
+                    asset_io_manager_key="iceberg_io_manager",
+                ),
+            )
+
+    class NotIdentityPlugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "fake-identity"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return "s3://unused"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return StorageOnlyPlugin()
+            if plugin_type == PluginType.IDENTITY:
+                return NotIdentityPlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"].pop("catalog", None)
+    manifest["plugins"]["storage"] = {"type": "minio"}
+    manifest["plugins"]["identity"] = {"type": "fake-identity"}
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    with pytest.raises(CompilationException) as exc_info:
+        compile_pipeline(
+            ROOT / "demo" / "customer-360" / "floe.yaml",
+            manifest_path,
+            emit_lineage=False,
+        )
+
+    error = exc_info.value.error
+    assert error.stage == CompilationStage.RESOLVE
+    assert error.code == "E201"
+    assert "is not an IdentityPlugin" in error.message
+    assert error.context == {"identity_plugin": "fake-identity"}

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -621,7 +621,6 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
                     protocols=["s3"],
                     credential_modes=["workload-identity"],
                     identity_modes=["aws-irsa"],
-                    secret_projection_modes=["external-secret-sync"],
                     providers=["aws"],
                 ),
             )
@@ -700,6 +699,209 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
     assert artifacts.deployment is not None
     assert artifacts.deployment.storage is not None
     assert artifacts.deployment.storage.credentials.mode == "workload-identity"
+
+
+def test_compile_validates_selected_workload_identity_mode_not_advertised_alternatives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compilation must validate the selected storage credential mode."""
+
+    class MixedModeStoragePlugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "s3"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return StorageDeploymentBinding(
+                provider="s3",
+                protocol="s3",
+                endpoint=StorageServiceEndpoint(
+                    internal_url="https://s3.us-east-1.amazonaws.com",
+                    external_url="https://s3.us-east-1.amazonaws.com",
+                    region="us-east-1",
+                    warehouse_path="s3://warehouse",
+                    path_style_access=False,
+                ),
+                warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
+                credentials=StorageCredentialBinding(
+                    mode="workload-identity",
+                    service_account_ref="floe-runtime",
+                ),
+                capabilities=StorageCapabilities(
+                    protocols=["s3"],
+                    credential_modes=["kubernetes-secret", "workload-identity"],
+                    identity_modes=["aws-irsa"],
+                    sts_supported=True,
+                    path_style_access=False,
+                ),
+                dbt=DbtStorageBinding(
+                    profile_name="floe",
+                    target_name="dev",
+                    schema_name="analytics",
+                ),
+                dagster=DagsterStorageBinding(
+                    resource_key="s3_storage",
+                    asset_io_manager_key="iceberg_io_manager",
+                ),
+            )
+
+    class IdentityAwareCatalogPlugin(CatalogPlugin):
+        @property
+        def name(self) -> str:
+            return "glue"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def connect(self, config: dict[str, Any]) -> Any:
+            raise NotImplementedError
+
+        def create_namespace(
+            self,
+            namespace: str,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            return None
+
+        def vend_credentials(self, table_path: str, operations: list[str]) -> dict[str, Any]:
+            return {}
+
+        def list_namespaces(self, parent: str | None = None) -> list[str]:
+            return []
+
+        def delete_namespace(self, namespace: str) -> None:
+            return None
+
+        def create_table(
+            self,
+            identifier: str,
+            schema: dict[str, Any],
+            location: str | None = None,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            return None
+
+        def list_tables(self, namespace: str) -> list[str]:
+            return []
+
+        def drop_table(self, identifier: str, purge: bool = False) -> None:
+            return None
+
+        def get_storage_requirements(self) -> PluginRequirements:
+            return PluginRequirements(
+                plugin_type="catalog",
+                plugin_name="glue",
+                requirements=RequirementSet(
+                    protocols=["s3"],
+                    credential_modes=["kubernetes-secret", "workload-identity"],
+                    identity_modes=["aws-irsa"],
+                    providers=["aws"],
+                ),
+            )
+
+        def build_catalog_deployment(
+            self,
+            storage: StorageDeploymentBinding,
+        ) -> CatalogDeploymentBinding:
+            return CatalogDeploymentBinding(
+                provider="polaris",
+                polaris=PolarisCatalogDeploymentBinding(
+                    storage_type="S3",
+                    default_base_location="s3://warehouse",
+                    allowed_locations=["s3://warehouse"],
+                    endpoint=storage.endpoint.external_url,
+                    endpoint_internal=storage.endpoint.internal_url,
+                    path_style_access=False,
+                    sts_unavailable=False,
+                    credential_refs={
+                        "accessKeyId": CredentialRef(source="none", name="none"),
+                        "secretAccessKey": CredentialRef(source="none", name="none"),
+                    },
+                ),
+            )
+
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return MixedModeStoragePlugin()
+            if plugin_type == PluginType.CATALOG:
+                return IdentityAwareCatalogPlugin()
+            if plugin_type == PluginType.COMPUTE:
+                from floe_compute_duckdb.plugin import DuckDBComputePlugin
+
+                return DuckDBComputePlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["catalog"] = {"type": "glue"}
+    manifest["plugins"].pop("identity", None)
+    manifest["plugins"].pop("secrets", None)
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    with pytest.raises(CompilationException) as exc_info:
+        compile_pipeline(
+            ROOT / "demo" / "customer-360" / "floe.yaml",
+            manifest_path,
+            emit_lineage=False,
+        )
+
+    error = exc_info.value.error
+    assert error.stage == CompilationStage.RESOLVE
+    assert error.code == "COMPOSITION_IDENTITY_PROVIDER_MISSING"
+    assert "identity mode aws-irsa" in error.message
+    assert "no identity plugin was selected" in error.message
 
 
 def test_storage_only_compile_validates_selected_identity_plugin_type(

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -10,9 +10,16 @@ import yaml
 
 from floe_core.compilation.errors import CompilationException
 from floe_core.compilation.stages import CompilationStage, compile_pipeline
-from floe_core.composition.models import PluginRequirements, RequirementSet
+from floe_core.composition.models import (
+    CapabilitySet,
+    PluginCapabilities,
+    PluginRequirements,
+    RequirementSet,
+)
 from floe_core.plugin_errors import PluginConfigurationError
 from floe_core.plugins.catalog import CatalogPlugin
+from floe_core.plugins.identity import IdentityPlugin, TokenValidationResult, UserInfo
+from floe_core.plugins.secrets import SecretsPlugin
 from floe_core.plugins.storage import FileIO, StoragePlugin
 from floe_core.schemas.compiled_artifacts import (
     CatalogDeploymentBinding,
@@ -30,6 +37,84 @@ from floe_core.schemas.compiled_artifacts import (
 
 ROOT = Path(__file__).resolve().parents[5]
 pytestmark = pytest.mark.requirement("AC-4")
+
+
+class FakeSecretsPlugin(SecretsPlugin):
+    """Secrets plugin used to prove compiler composition wiring."""
+
+    @property
+    def name(self) -> str:
+        return "fake-secrets"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def get_secret(self, key: str) -> str | None:
+        return None
+
+    def set_secret(self, key: str, value: str, metadata: dict[str, Any] | None = None) -> None:
+        return None
+
+    def list_secrets(self, prefix: str = "") -> list[str]:
+        return []
+
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["external-secret-sync"],
+                secret_projection_modes=["external-secret-sync"],
+                providers=["infisical"],
+            ),
+        )
+
+
+class FakeIdentityPlugin(IdentityPlugin):
+    """Identity plugin used to prove compiler composition wiring."""
+
+    @property
+    def name(self) -> str:
+        return "fake-identity"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def authenticate(self, credentials: dict[str, Any]) -> str | None:
+        return None
+
+    def get_user_info(self, token: str) -> UserInfo | None:
+        return None
+
+    def validate_token(self, token: str) -> TokenValidationResult:
+        return TokenValidationResult(valid=False)
+
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["workload-identity"],
+                identity_modes=["aws-irsa"],
+                providers=["aws"],
+            ),
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -405,3 +490,211 @@ def test_incompatible_storage_catalog_composition_raises_structured_error(
         "storage_plugin": "minio",
         "catalog_plugin": "polaris",
     }
+
+
+def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compilation should validate non-baseline credential modes with providers."""
+
+    class IdentityStoragePlugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "s3"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return StorageDeploymentBinding(
+                provider="s3",
+                protocol="s3",
+                endpoint=StorageServiceEndpoint(
+                    internal_url="https://s3.us-east-1.amazonaws.com",
+                    external_url="https://s3.us-east-1.amazonaws.com",
+                    region="us-east-1",
+                    warehouse_path="s3://warehouse",
+                    path_style_access=False,
+                ),
+                warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
+                credentials=StorageCredentialBinding(
+                    mode="workload-identity",
+                    service_account_ref="floe-runtime",
+                ),
+                capabilities=StorageCapabilities(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    sts_supported=True,
+                    path_style_access=False,
+                ),
+                dbt=DbtStorageBinding(
+                    profile_name="floe",
+                    target_name="dev",
+                    schema_name="analytics",
+                ),
+                dagster=DagsterStorageBinding(
+                    resource_key="s3_storage",
+                    asset_io_manager_key="iceberg_io_manager",
+                ),
+            )
+
+    class IdentityCatalogPlugin(CatalogPlugin):
+        @property
+        def name(self) -> str:
+            return "glue"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_config_schema(self) -> None:
+            return None
+
+        def connect(self, config: dict[str, Any]) -> Any:
+            raise NotImplementedError
+
+        def create_namespace(
+            self,
+            namespace: str,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            return None
+
+        def vend_credentials(self, table_path: str, operations: list[str]) -> dict[str, Any]:
+            return {}
+
+        def list_namespaces(self, parent: str | None = None) -> list[str]:
+            return []
+
+        def delete_namespace(self, namespace: str) -> None:
+            return None
+
+        def create_table(
+            self,
+            identifier: str,
+            schema: dict[str, Any],
+            location: str | None = None,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            return None
+
+        def list_tables(self, namespace: str) -> list[str]:
+            return []
+
+        def drop_table(self, identifier: str, purge: bool = False) -> None:
+            return None
+
+        def get_storage_requirements(self) -> PluginRequirements:
+            return PluginRequirements(
+                plugin_type="catalog",
+                plugin_name="glue",
+                requirements=RequirementSet(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    identity_modes=["aws-irsa"],
+                    providers=["aws"],
+                ),
+            )
+
+        def build_catalog_deployment(
+            self,
+            storage: StorageDeploymentBinding,
+        ) -> CatalogDeploymentBinding:
+            return CatalogDeploymentBinding(
+                provider="polaris",
+                polaris=PolarisCatalogDeploymentBinding(
+                    storage_type="S3",
+                    default_base_location="s3://warehouse",
+                    allowed_locations=["s3://warehouse"],
+                    endpoint=storage.endpoint.external_url,
+                    endpoint_internal=storage.endpoint.internal_url,
+                    path_style_access=False,
+                    sts_unavailable=False,
+                    credential_refs={
+                        "accessKeyId": CredentialRef(source="none", name="none"),
+                        "secretAccessKey": CredentialRef(source="none", name="none"),
+                    },
+                ),
+            )
+
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return IdentityStoragePlugin()
+            if plugin_type == PluginType.CATALOG:
+                return IdentityCatalogPlugin()
+            if plugin_type == PluginType.SECRETS:
+                return FakeSecretsPlugin()
+            if plugin_type == PluginType.IDENTITY:
+                return FakeIdentityPlugin()
+            if plugin_type == PluginType.COMPUTE:
+                from floe_compute_duckdb.plugin import DuckDBComputePlugin
+
+                return DuckDBComputePlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["catalog"] = {"type": "glue"}
+    manifest["plugins"]["secrets"] = {"type": "fake-secrets"}
+    manifest["plugins"]["identity"] = {"type": "fake-identity"}
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    artifacts = compile_pipeline(
+        ROOT / "demo" / "customer-360" / "floe.yaml",
+        manifest_path,
+        emit_lineage=False,
+    )
+
+    assert artifacts.plugins is not None
+    assert artifacts.plugins.secrets is not None
+    assert artifacts.plugins.secrets.type == "fake-secrets"
+    assert artifacts.plugins.identity is not None
+    assert artifacts.plugins.identity.type == "fake-identity"
+    assert artifacts.deployment is not None
+    assert artifacts.deployment.storage is not None
+    assert artifacts.deployment.storage.credentials.mode == "workload-identity"

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -547,7 +547,7 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
                 ),
                 capabilities=StorageCapabilities(
                     protocols=["s3"],
-                    credential_modes=["workload-identity"],
+                    credential_modes=["workload-identity", "external-secret-sync"],
                     identity_modes=["aws-irsa"],
                     sts_supported=True,
                     path_style_access=False,
@@ -621,6 +621,7 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
                     protocols=["s3"],
                     credential_modes=["workload-identity"],
                     identity_modes=["aws-irsa"],
+                    secret_projection_modes=["external-secret-sync"],
                     providers=["aws"],
                 ),
             )

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -117,6 +117,228 @@ class FakeIdentityPlugin(IdentityPlugin):
         )
 
 
+class ExternalSecretStoragePlugin(StoragePlugin):
+    """Storage fake that selects external-secret-sync credentials."""
+
+    @property
+    def name(self) -> str:
+        return "s3"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def get_pyiceberg_fileio(self) -> FileIO:
+        raise NotImplementedError
+
+    def get_warehouse_uri(self, namespace: str) -> str:
+        return f"s3://warehouse/{namespace}"
+
+    def get_dbt_profile_config(self) -> dict[str, Any]:
+        return {}
+
+    def get_dagster_io_manager_config(self) -> dict[str, Any]:
+        return {}
+
+    def get_helm_values_override(self) -> dict[str, Any]:
+        return {}
+
+    def get_deployment_binding(self) -> StorageDeploymentBinding:
+        return StorageDeploymentBinding.model_construct(
+            provider="s3",
+            protocol="s3",
+            endpoint=StorageServiceEndpoint(
+                internal_url="https://s3.us-east-1.amazonaws.com",
+                external_url="https://s3.us-east-1.amazonaws.com",
+                region="us-east-1",
+                warehouse_path="s3://warehouse",
+                path_style_access=False,
+            ),
+            warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
+            credentials=StorageCredentialBinding.model_construct(
+                mode="external-secret-sync",
+                secret_ref=KubernetesSecretRef(
+                    name="s3-credentials",
+                    namespace="floe-system",
+                    keys={
+                        "accessKeyId": "access-key-id",
+                        "secretAccessKey": "secret-access-key",  # pragma: allowlist secret
+                    },
+                ),
+            ),
+            capabilities=StorageCapabilities(
+                protocols=["s3"],
+                credential_modes=["external-secret-sync"],
+                path_style_access=False,
+            ),
+            dbt=DbtStorageBinding(
+                profile_name="floe",
+                target_name="dev",
+                schema_name="analytics",
+            ),
+            dagster=DagsterStorageBinding(
+                resource_key="s3_storage",
+                asset_io_manager_key="iceberg_io_manager",
+            ),
+        )
+
+
+class ExternalSecretCatalogPlugin(CatalogPlugin):
+    """Catalog fake requiring external-secret-sync projection."""
+
+    @property
+    def name(self) -> str:
+        return "glue"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        return "1.0"
+
+    def get_config_schema(self) -> None:
+        return None
+
+    def connect(self, config: dict[str, Any]) -> Any:
+        raise NotImplementedError
+
+    def create_namespace(
+        self,
+        namespace: str,
+        properties: dict[str, str] | None = None,
+    ) -> None:
+        return None
+
+    def vend_credentials(self, table_path: str, operations: list[str]) -> dict[str, Any]:
+        return {}
+
+    def list_namespaces(self, parent: str | None = None) -> list[str]:
+        return []
+
+    def delete_namespace(self, namespace: str) -> None:
+        return None
+
+    def create_table(
+        self,
+        identifier: str,
+        schema: dict[str, Any],
+        location: str | None = None,
+        properties: dict[str, str] | None = None,
+    ) -> None:
+        return None
+
+    def list_tables(self, namespace: str) -> list[str]:
+        return []
+
+    def drop_table(self, identifier: str, purge: bool = False) -> None:
+        return None
+
+    def get_storage_requirements(self) -> PluginRequirements:
+        return PluginRequirements(
+            plugin_type="catalog",
+            plugin_name="glue",
+            requirements=RequirementSet(
+                protocols=["s3"],
+                credential_modes=["external-secret-sync"],
+                secret_projection_modes=["external-secret-sync"],
+                providers=["infisical"],
+            ),
+        )
+
+    def build_catalog_deployment(
+        self,
+        storage: StorageDeploymentBinding,
+    ) -> CatalogDeploymentBinding:
+        return CatalogDeploymentBinding(
+            provider="polaris",
+            polaris=PolarisCatalogDeploymentBinding(
+                storage_type="S3",
+                default_base_location="s3://warehouse",
+                allowed_locations=["s3://warehouse"],
+                endpoint=storage.endpoint.external_url,
+                endpoint_internal=storage.endpoint.internal_url,
+                path_style_access=False,
+                sts_unavailable=True,
+                credential_refs={
+                    "accessKeyId": CredentialRef(
+                        source="kubernetes-secret",
+                        name="s3-credentials",
+                        key="access-key-id",
+                    ),
+                    "secretAccessKey": CredentialRef(
+                        source="kubernetes-secret",
+                        name="s3-credentials",
+                        key="secret-access-key",
+                    ),
+                },
+            ),
+        )
+
+
+def _install_external_secret_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    include_secrets: bool,
+) -> None:
+    """Install a compiler registry with external-secret-sync storage/catalog fakes."""
+    import floe_core.plugin_registry as plugin_registry
+    from floe_core.plugin_types import PluginType
+
+    class IsolatedRegistry:
+        def discover_all(self) -> None:
+            return None
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            return None
+
+        def get(self, plugin_type: PluginType, name: str) -> Any:
+            if plugin_type == PluginType.STORAGE:
+                return ExternalSecretStoragePlugin()
+            if plugin_type == PluginType.CATALOG:
+                return ExternalSecretCatalogPlugin()
+            if include_secrets and plugin_type == PluginType.SECRETS:
+                return FakeSecretsPlugin()
+            if plugin_type == PluginType.COMPUTE:
+                from floe_compute_duckdb.plugin import DuckDBComputePlugin
+
+                return DuckDBComputePlugin()
+            raise AssertionError(f"unexpected plugin lookup: {plugin_type} {name}")
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
+
+
+def _external_secret_manifest_path(
+    tmp_path: Path,
+    *,
+    include_secrets: bool,
+) -> Path:
+    """Write a manifest selecting external-secret-sync fake storage/catalog plugins."""
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["catalog"] = {"type": "glue"}
+    if include_secrets:
+        manifest["plugins"]["secrets"] = {"type": "fake-secrets"}
+    else:
+        manifest["plugins"].pop("secrets", None)
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    return manifest_path
+
+
 @pytest.fixture(autouse=True)
 def _disable_plugin_instrumentation_audit(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep storage compilation tests focused on deployment binding behavior."""
@@ -902,6 +1124,65 @@ def test_compile_validates_selected_workload_identity_mode_not_advertised_altern
     assert error.code == "COMPOSITION_IDENTITY_PROVIDER_MISSING"
     assert "identity mode aws-irsa" in error.message
     assert "no identity plugin was selected" in error.message
+
+
+def test_compile_requires_secrets_provider_for_selected_external_secret_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External-secret-sync selected mode must require a capable secrets provider."""
+    _install_external_secret_registry(monkeypatch, include_secrets=False)
+    manifest_path = _external_secret_manifest_path(tmp_path, include_secrets=False)
+
+    with pytest.raises(CompilationException) as exc_info:
+        compile_pipeline(
+            ROOT / "demo" / "customer-360" / "floe.yaml",
+            manifest_path,
+            emit_lineage=False,
+        )
+
+    error = exc_info.value.error
+    assert error.stage == CompilationStage.RESOLVE
+    assert error.code == "COMPOSITION_SECRET_PROVIDER_MISSING"
+    assert "secret projection mode external-secret-sync" in error.message
+    assert "no secrets plugin was selected" in error.message
+    assert error.context == {
+        "composition_issues": [
+            {
+                "severity": "error",
+                "code": "COMPOSITION_SECRET_PROVIDER_MISSING",
+                "message": (
+                    "catalog glue requires secret projection mode external-secret-sync "
+                    "but no secrets plugin was selected"
+                ),
+                "plugins": ["catalog:glue"],
+            }
+        ],
+        "storage_plugin": "s3",
+        "catalog_plugin": "glue",
+    }
+
+
+def test_compile_accepts_selected_external_secret_sync_with_capable_secrets_provider(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """External-secret-sync selected mode compiles with matching secrets capabilities."""
+    _install_external_secret_registry(monkeypatch, include_secrets=True)
+    manifest_path = _external_secret_manifest_path(tmp_path, include_secrets=True)
+
+    artifacts = compile_pipeline(
+        ROOT / "demo" / "customer-360" / "floe.yaml",
+        manifest_path,
+        emit_lineage=False,
+    )
+
+    assert artifacts.plugins is not None
+    assert artifacts.plugins.secrets is not None
+    assert artifacts.plugins.secrets.type == "fake-secrets"
+    assert artifacts.deployment is not None
+    assert artifacts.deployment.storage is not None
+    assert artifacts.deployment.storage.credentials.mode == "external-secret-sync"
 
 
 def test_storage_only_compile_validates_selected_identity_plugin_type(

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -122,7 +122,7 @@ class ExternalSecretStoragePlugin(StoragePlugin):
 
     @property
     def name(self) -> str:
-        return "s3"
+        return "aws-object-storage"
 
     @property
     def version(self) -> str:
@@ -329,7 +329,7 @@ def _external_secret_manifest_path(
     """Write a manifest selecting external-secret-sync fake storage/catalog plugins."""
     manifest_path = tmp_path / "manifest.yaml"
     manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
-    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["storage"] = {"type": "aws-object-storage"}
     manifest["plugins"]["catalog"] = {"type": "glue"}
     if include_secrets:
         manifest["plugins"]["secrets"] = {"type": "fake-secrets"}
@@ -723,7 +723,7 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
     class IdentityStoragePlugin(StoragePlugin):
         @property
         def name(self) -> str:
-            return "s3"
+            return "aws-object-storage"
 
         @property
         def version(self) -> str:
@@ -901,7 +901,7 @@ def test_compile_passes_selected_secret_and_identity_capabilities_to_resolver(
     monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
     manifest_path = tmp_path / "manifest.yaml"
     manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
-    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["storage"] = {"type": "aws-object-storage"}
     manifest["plugins"]["catalog"] = {"type": "glue"}
     manifest["plugins"]["secrets"] = {"type": "fake-secrets"}
     manifest["plugins"]["identity"] = {"type": "fake-identity"}
@@ -932,7 +932,7 @@ def test_compile_validates_selected_workload_identity_mode_not_advertised_altern
     class MixedModeStoragePlugin(StoragePlugin):
         @property
         def name(self) -> str:
-            return "s3"
+            return "aws-object-storage"
 
         @property
         def version(self) -> str:
@@ -1106,7 +1106,7 @@ def test_compile_validates_selected_workload_identity_mode_not_advertised_altern
     monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedRegistry)
     manifest_path = tmp_path / "manifest.yaml"
     manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
-    manifest["plugins"]["storage"] = {"type": "s3"}
+    manifest["plugins"]["storage"] = {"type": "aws-object-storage"}
     manifest["plugins"]["catalog"] = {"type": "glue"}
     manifest["plugins"].pop("identity", None)
     manifest["plugins"].pop("secrets", None)
@@ -1187,11 +1187,11 @@ def test_compile_rejects_selected_storage_mode_not_declared_by_capabilities(
     assert error.stage == CompilationStage.RESOLVE
     assert error.code == "E201"
     assert (
-        "Storage plugin 's3' selected credential mode 'external-secret-sync' "
+        "Storage plugin 'aws-object-storage' selected credential mode 'external-secret-sync' "
         "but declares credential modes ['kubernetes-secret']"
     ) in error.message
     assert error.context == {
-        "storage_plugin": "s3",
+        "storage_plugin": "aws-object-storage",
         "selected_credential_mode": "external-secret-sync",
         "declared_credential_modes": ["kubernetes-secret"],
     }
@@ -1230,7 +1230,7 @@ def test_compile_requires_secrets_provider_for_selected_external_secret_sync(
                 "plugins": ["catalog:glue"],
             }
         ],
-        "storage_plugin": "s3",
+        "storage_plugin": "aws-object-storage",
         "catalog_plugin": "glue",
     }
 

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -151,7 +151,7 @@ class ExternalSecretStoragePlugin(StoragePlugin):
         return {}
 
     def get_deployment_binding(self) -> StorageDeploymentBinding:
-        return StorageDeploymentBinding.model_construct(
+        return StorageDeploymentBinding(
             provider="s3",
             protocol="s3",
             endpoint=StorageServiceEndpoint(
@@ -162,7 +162,7 @@ class ExternalSecretStoragePlugin(StoragePlugin):
                 path_style_access=False,
             ),
             warehouse=StorageWarehouse(uri="s3://warehouse", bucket="warehouse"),
-            credentials=StorageCredentialBinding.model_construct(
+            credentials=StorageCredentialBinding(
                 mode="external-secret-sync",
                 secret_ref=KubernetesSecretRef(
                     name="s3-credentials",

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -633,3 +633,50 @@ def test_resolver_rejects_missing_storage_secret_projection_modes() -> None:
             plugins=["storage:s3", "catalog:glue"],
         )
     ]
+
+
+def test_resolver_rejects_workload_identity_without_catalog_identity_modes() -> None:
+    """Generic workload identity requires catalog to name concrete identity modes."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires workload identity but does not declare "
+                "concrete identity modes; storage s3 provides ['aws-irsa']; "
+                "identity aws provides ['aws-irsa']"
+            ),
+            plugins=["storage:s3", "identity:aws", "catalog:glue"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -492,3 +492,98 @@ def test_resolver_accepts_one_matching_identity_mode_from_alternatives() -> None
 
     assert result.valid is True
     assert result.issues == []
+
+
+def test_resolver_rejects_no_matching_secret_projection_alternative() -> None:
+    """Secret projection alternatives must have a storage/catalog match."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="k8s",
+        capabilities=CapabilitySet(
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+            providers=["kubernetes"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of secret projection modes "
+                "['kubernetes-secret']; storage s3 provides ['external-secret-sync']"
+            ),
+            plugins=["storage:s3", "catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_rejects_identity_mode_not_supported_by_storage() -> None:
+    """Identity modes must be compatible across storage, catalog, and identity."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa", "aws-pod-identity"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-pod-identity"],
+            providers=["aws"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of identity modes "
+                "['aws-irsa', 'aws-pod-identity']; storage s3 provides ['aws-irsa']; "
+                "identity aws provides ['aws-pod-identity']"
+            ),
+            plugins=["storage:s3", "identity:aws", "catalog:glue"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -425,3 +425,70 @@ def test_resolver_rejects_unsupported_identity_mode() -> None:
             plugins=["identity:keycloak", "catalog:glue"],
         )
     ]
+
+
+def test_resolver_treats_security_modes_as_alternatives_for_kubernetes_secret_path() -> None:
+    """Kubernetes Secret path should satisfy mixed-mode requirements without identity."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret", "workload-identity"],
+            secret_projection_modes=["kubernetes-secret", "external-secret-sync"],
+            identity_modes=["oidc-federation"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="polaris",
+        requirements=RequirementSet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret", "workload-identity"],
+            secret_projection_modes=["kubernetes-secret", "external-secret-sync"],
+            identity_modes=["oidc-federation"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_accepts_one_matching_identity_mode_from_alternatives() -> None:
+    """One matching identity mode should satisfy an alternative mode list."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa", "aws-pod-identity"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa", "aws-pod-identity"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-pod-identity"],
+            providers=["aws"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -187,3 +187,241 @@ def test_requirement_set_accepts_security_composition_modes() -> None:
     assert requirements.secret_projection_modes == ["external-secret-sync"]
     assert requirements.identity_modes == ["gcp-workload-identity"]
     assert requirements.providers == ["gcp"]
+
+
+def test_resolver_accepts_kubernetes_secret_with_implicit_baseline() -> None:
+    """Existing MinIO and Polaris path must stay valid without secrets plugin."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="polaris",
+        requirements=RequirementSet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_rejects_external_secret_sync_without_secrets_plugin() -> None:
+    """External secret sync requires an explicit secrets provider."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROVIDER_MISSING",
+            message=(
+                "catalog glue requires secret projection mode external-secret-sync "
+                "but no secrets plugin was selected"
+            ),
+            plugins=["catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_accepts_external_secret_sync_with_matching_secrets_plugin() -> None:
+    """External secret sync succeeds when selected secrets plugin supports it."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_rejects_unsupported_secret_projection_mode() -> None:
+    """Selected secrets provider must support the requested projection mode."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="azure-blob",
+        capabilities=CapabilitySet(
+            protocols=["azure-blob"],
+            credential_modes=["csi-secret-volume"],
+            secret_projection_modes=["csi-secret-volume"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="rest",
+        requirements=RequirementSet(
+            protocols=["azure-blob"],
+            credential_modes=["csi-secret-volume"],
+            secret_projection_modes=["csi-secret-volume"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+            message=(
+                "catalog rest requires secret projection mode csi-secret-volume; "
+                "secrets infisical provides ['external-secret-sync']"
+            ),
+            plugins=["secrets:infisical", "catalog:rest"],
+        )
+    ]
+
+
+def test_resolver_rejects_identity_mode_without_identity_plugin() -> None:
+    """Workload identity requires an explicit identity provider."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_PROVIDER_MISSING",
+            message=(
+                "catalog glue requires identity mode aws-irsa but no identity plugin was selected"
+            ),
+            plugins=["catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_rejects_unsupported_identity_mode() -> None:
+    """Selected identity provider must support the requested identity mode."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="keycloak",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["oidc-federation"],
+            providers=["oidc"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires identity mode aws-irsa; "
+                "identity keycloak provides ['oidc-federation']"
+            ),
+            plugins=["identity:keycloak", "catalog:glue"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -262,7 +262,7 @@ def test_resolver_rejects_external_secret_sync_without_secrets_plugin() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["external-secret-sync"],
@@ -300,7 +300,7 @@ def test_resolver_accepts_external_secret_sync_with_matching_secrets_plugin() ->
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["external-secret-sync"],
@@ -337,7 +337,7 @@ def test_resolver_rejects_unsupported_secret_provider() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["external-secret-sync"],
@@ -432,7 +432,7 @@ def test_resolver_rejects_identity_mode_without_identity_plugin() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -471,7 +471,7 @@ def test_resolver_rejects_unsupported_identity_mode() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -520,7 +520,7 @@ def test_resolver_rejects_unsupported_identity_provider() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -598,7 +598,7 @@ def test_resolver_accepts_one_matching_identity_mode_from_alternatives() -> None
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -635,7 +635,7 @@ def test_resolver_rejects_no_matching_secret_projection_alternative() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["external-secret-sync"],
@@ -670,9 +670,10 @@ def test_resolver_rejects_no_matching_secret_projection_alternative() -> None:
             code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
             message=(
                 "catalog glue requires one of secret projection modes "
-                "['kubernetes-secret']; storage s3 provides ['external-secret-sync']"
+                "['kubernetes-secret']; storage aws-object-storage provides "
+                "['external-secret-sync']"
             ),
-            plugins=["storage:s3", "catalog:glue"],
+            plugins=["storage:aws-object-storage", "catalog:glue"],
         )
     ]
 
@@ -682,7 +683,7 @@ def test_resolver_rejects_identity_mode_not_supported_by_storage() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -717,10 +718,11 @@ def test_resolver_rejects_identity_mode_not_supported_by_storage() -> None:
             code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
             message=(
                 "catalog glue requires one of identity modes "
-                "['aws-irsa', 'aws-pod-identity']; storage s3 provides ['aws-irsa']; "
+                "['aws-irsa', 'aws-pod-identity']; storage aws-object-storage provides "
+                "['aws-irsa']; "
                 "identity aws provides ['aws-pod-identity']"
             ),
-            plugins=["storage:s3", "identity:aws", "catalog:glue"],
+            plugins=["storage:aws-object-storage", "identity:aws", "catalog:glue"],
         )
     ]
 
@@ -730,7 +732,7 @@ def test_resolver_rejects_missing_storage_secret_projection_modes() -> None:
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["external-secret-sync"],
@@ -764,9 +766,9 @@ def test_resolver_rejects_missing_storage_secret_projection_modes() -> None:
             code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
             message=(
                 "catalog glue requires one of secret projection modes "
-                "['external-secret-sync']; storage s3 provides []"
+                "['external-secret-sync']; storage aws-object-storage provides []"
             ),
-            plugins=["storage:s3", "catalog:glue"],
+            plugins=["storage:aws-object-storage", "catalog:glue"],
         )
     ]
 
@@ -776,7 +778,7 @@ def test_resolver_rejects_workload_identity_without_catalog_identity_modes() -> 
     resolver = CompositionResolver()
     storage = PluginCapabilities(
         plugin_type="storage",
-        plugin_name="s3",
+        plugin_name="aws-object-storage",
         capabilities=CapabilitySet(
             protocols=["s3"],
             credential_modes=["workload-identity"],
@@ -810,10 +812,10 @@ def test_resolver_rejects_workload_identity_without_catalog_identity_modes() -> 
             code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
             message=(
                 "catalog glue requires workload identity but does not declare "
-                "concrete identity modes; storage s3 provides ['aws-irsa']; "
+                "concrete identity modes; storage aws-object-storage provides ['aws-irsa']; "
                 "identity aws provides ['aws-irsa']"
             ),
-            plugins=["storage:s3", "identity:aws", "catalog:glue"],
+            plugins=["storage:aws-object-storage", "identity:aws", "catalog:glue"],
         )
     ]
 

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -587,3 +587,49 @@ def test_resolver_rejects_identity_mode_not_supported_by_storage() -> None:
             plugins=["storage:s3", "identity:aws", "catalog:glue"],
         )
     ]
+
+
+def test_resolver_rejects_missing_storage_secret_projection_modes() -> None:
+    """Required secret projection modes need matching storage capabilities."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of secret projection modes "
+                "['external-secret-sync']; storage s3 provides []"
+            ),
+            plugins=["storage:s3", "catalog:glue"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -680,3 +680,50 @@ def test_resolver_rejects_workload_identity_without_catalog_identity_modes() -> 
             plugins=["storage:s3", "identity:aws", "catalog:glue"],
         )
     ]
+
+
+def test_resolver_rejects_explicit_secrets_plugin_without_kubernetes_secret_support() -> None:
+    """Explicit secrets plugin must support Kubernetes Secret projection when selected."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="polaris",
+        requirements=RequirementSet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="infisical",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROJECTION_UNSUPPORTED",
+            message=(
+                "catalog polaris requires secret projection mode kubernetes-secret; "
+                "secrets infisical provides ['external-secret-sync']"
+            ),
+            plugins=["secrets:infisical", "catalog:polaris"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -217,6 +217,46 @@ def test_resolver_accepts_kubernetes_secret_with_implicit_baseline() -> None:
     assert result.issues == []
 
 
+def test_resolver_rejects_provider_requirement_without_baseline_secrets_plugin() -> None:
+    """Provider requirements force an explicit secrets plugin even on baseline modes."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="polaris",
+        requirements=RequirementSet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            secret_projection_modes=["kubernetes-secret"],
+            providers=["infisical"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROVIDER_MISSING",
+            message=(
+                "catalog polaris requires one of secret providers ['infisical'] "
+                "for secret projection mode kubernetes-secret but no secrets plugin "
+                "was selected"
+            ),
+            plugins=["catalog:polaris"],
+        )
+    ]
+
+
 def test_resolver_rejects_external_secret_sync_without_secrets_plugin() -> None:
     """External secret sync requires an explicit secrets provider."""
     resolver = CompositionResolver()
@@ -290,6 +330,54 @@ def test_resolver_accepts_external_secret_sync_with_matching_secrets_plugin() ->
 
     assert result.valid is True
     assert result.issues == []
+
+
+def test_resolver_rejects_unsupported_secret_provider() -> None:
+    """Secret provider labels must match when requirements name providers."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["infisical"],
+        ),
+    )
+    secrets = PluginCapabilities(
+        plugin_type="secrets",
+        plugin_name="vault",
+        capabilities=CapabilitySet(
+            credential_modes=["external-secret-sync"],
+            secret_projection_modes=["external-secret-sync"],
+            providers=["vault"],
+        ),
+    )
+
+    result = resolver.validate([storage, secrets], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_SECRET_PROVIDER_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of secret providers ['infisical']; "
+                "secrets vault provides ['vault']"
+            ),
+            plugins=["secrets:vault", "catalog:glue"],
+        )
+    ]
 
 
 def test_resolver_rejects_unsupported_secret_projection_mode() -> None:
@@ -421,6 +509,54 @@ def test_resolver_rejects_unsupported_identity_mode() -> None:
             message=(
                 "catalog glue requires identity mode aws-irsa; "
                 "identity keycloak provides ['oidc-federation']"
+            ),
+            plugins=["identity:keycloak", "catalog:glue"],
+        )
+    ]
+
+
+def test_resolver_rejects_unsupported_identity_provider() -> None:
+    """Identity provider labels must match when requirements name providers."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["aws"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="keycloak",
+        capabilities=CapabilitySet(
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            providers=["oidc"],
+        ),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_PROVIDER_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of identity providers ['aws']; "
+                "identity keycloak provides ['oidc']"
             ),
             plugins=["identity:keycloak", "catalog:glue"],
         )

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -155,3 +155,35 @@ def test_resolver_rejects_malformed_capability_payload() -> None:
             plugin_name="minio",
             capabilities={"protocols": "s3-compatible"},  # type: ignore[arg-type]
         )
+
+
+def test_capability_set_accepts_security_composition_modes() -> None:
+    """CapabilitySet should carry secret projection and identity capabilities."""
+    capabilities = CapabilitySet(
+        credential_modes=["kubernetes-secret", "workload-identity"],
+        secret_projection_modes=["kubernetes-secret", "external-secret-sync"],
+        identity_modes=["aws-irsa", "oidc-federation"],
+        providers=["kubernetes", "aws", "oidc"],
+    )
+
+    assert capabilities.secret_projection_modes == [
+        "kubernetes-secret",
+        "external-secret-sync",
+    ]
+    assert capabilities.identity_modes == ["aws-irsa", "oidc-federation"]
+    assert capabilities.providers == ["kubernetes", "aws", "oidc"]
+
+
+def test_requirement_set_accepts_security_composition_modes() -> None:
+    """RequirementSet should describe required secret and identity modes."""
+    requirements = RequirementSet(
+        credential_modes=["external-secret-sync"],
+        secret_projection_modes=["external-secret-sync"],
+        identity_modes=["gcp-workload-identity"],
+        providers=["gcp"],
+    )
+
+    assert requirements.credential_modes == ["external-secret-sync"]
+    assert requirements.secret_projection_modes == ["external-secret-sync"]
+    assert requirements.identity_modes == ["gcp-workload-identity"]
+    assert requirements.providers == ["gcp"]

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -982,6 +982,8 @@ class TestStorageCredentialBinding:
         "binding_kwargs",
         [
             {"mode": "kubernetes-secret"},
+            {"mode": "external-secret-sync"},
+            {"mode": "csi-secret-volume"},
             {"mode": "environment"},
             {"mode": "environment", "env_refs": {}},
             {"mode": "workload-identity"},
@@ -1036,6 +1038,38 @@ class TestStorageCredentialBinding:
                 "env_refs": {"accessKeyId": "AWS_ACCESS_KEY_ID"},
                 "service_account_ref": "storage-service-account",
             },
+            {
+                "mode": "external-secret-sync",
+                "secret_ref": KubernetesSecretRef(
+                    name="storage-credentials",
+                    namespace="floe-system",
+                ),
+                "env_refs": {"accessKeyId": "AWS_ACCESS_KEY_ID"},
+            },
+            {
+                "mode": "external-secret-sync",
+                "secret_ref": KubernetesSecretRef(
+                    name="storage-credentials",
+                    namespace="floe-system",
+                ),
+                "service_account_ref": "storage-service-account",
+            },
+            {
+                "mode": "csi-secret-volume",
+                "secret_ref": KubernetesSecretRef(
+                    name="storage-credentials",
+                    namespace="floe-system",
+                ),
+                "env_refs": {"accessKeyId": "AWS_ACCESS_KEY_ID"},
+            },
+            {
+                "mode": "csi-secret-volume",
+                "secret_ref": KubernetesSecretRef(
+                    name="storage-credentials",
+                    namespace="floe-system",
+                ),
+                "service_account_ref": "storage-service-account",
+            },
         ],
     )
     def test_mode_inconsistent_credential_bindings_are_rejected(
@@ -1081,6 +1115,8 @@ class TestStorageCredentialBinding:
                 name="storage-service-account",
                 key="accessKeyId",
             ),
+            lambda: CredentialRef(source="external-secret-sync", name="storage-credentials"),
+            lambda: CredentialRef(source="csi-secret-volume", name="storage-credentials"),
             lambda: CredentialRef(source="none", name="none", key="accessKeyId"),
         ],
     )
@@ -1102,6 +1138,26 @@ class TestStorageCredentialBinding:
         assert ref.source == "environment"
         assert ref.name == "AWS_ACCESS_KEY_ID"
         assert ref.key is None
+
+    @pytest.mark.parametrize("mode", ["external-secret-sync", "csi-secret-volume"])
+    def test_secret_projection_credential_ref_uses_configured_secret_key(
+        self,
+        mode: str,
+    ) -> None:
+        binding = StorageCredentialBinding(
+            mode=mode,
+            secret_ref=KubernetesSecretRef(
+                name="storage-credentials",
+                namespace="floe-system",
+                keys={"accessKeyId": "root-user"},
+            ),
+        )
+
+        ref = binding.as_credential_ref("accessKeyId")
+
+        assert ref.source == mode
+        assert ref.name == "storage-credentials"
+        assert ref.key == "root-user"
 
     def test_environment_credential_ref_raises_for_missing_logical_key(self) -> None:
         binding = StorageCredentialBinding(
@@ -1716,40 +1772,40 @@ class TestGovernanceLifecycleFields:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Tests for AC-6: version bump to 0.12.0 with history entry."""
+    """Tests for AC-6: version bump to 0.13.0 with history entry."""
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_version_is_0_12_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.12.0'."""
-        assert COMPILED_ARTIFACTS_VERSION == "0.12.0", (
-            f"Expected version '0.12.0', got '{COMPILED_ARTIFACTS_VERSION}'"
+    def test_compiled_artifacts_version_is_0_13_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.13.0'."""
+        assert COMPILED_ARTIFACTS_VERSION == "0.13.0", (
+            f"Expected version '0.13.0', got '{COMPILED_ARTIFACTS_VERSION}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_contains_0_12_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.12.0' entry."""
-        assert "0.12.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
-            f"Version '0.12.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
+    def test_version_history_contains_0_13_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.13.0' entry."""
+        assert "0.13.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
+            f"Version '0.13.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_0_12_0_references_storage_identity_modes(self) -> None:
-        """Test that the 0.12.0 history entry mentions contract additions."""
-        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.12.0", "")
+    def test_version_history_0_13_0_references_secret_projection_modes(self) -> None:
+        """Test that the 0.13.0 history entry mentions contract additions."""
+        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.13.0", "")
         entry_lower = entry.lower()
-        assert "identity_modes" in entry_lower, (
-            f"Version 0.12.0 history entry does not reference identity_modes: '{entry}'"
+        assert "secret projection" in entry_lower, (
+            f"Version 0.13.0 history entry does not reference secret projection: '{entry}'"
         )
-        assert "storagecapabilities" in entry_lower, (
-            f"Version 0.12.0 history entry does not reference StorageCapabilities: '{entry}'"
+        assert "credential binding" in entry_lower, (
+            f"Version 0.13.0 history entry does not reference credential binding: '{entry}'"
         )
-        assert "workload identity" in entry_lower, (
-            f"Version 0.12.0 history entry does not reference workload identity: '{entry}'"
+        assert "modes" in entry_lower, (
+            f"Version 0.13.0 history entry does not reference modes: '{entry}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_default_version_is_0_12_0(self) -> None:
-        """Test that CompiledArtifacts().version defaults to '0.12.0'."""
+    def test_compiled_artifacts_default_version_is_0_13_0(self) -> None:
+        """Test that CompiledArtifacts().version defaults to '0.13.0'."""
         artifacts = CompiledArtifacts(
             metadata=CompilationMetadata(
                 compiled_at=datetime.now(),
@@ -1778,7 +1834,7 @@ class TestCompiledArtifactsVersionBump:
                 lineage_namespace="test",
             ),
         )
-        assert artifacts.version == "0.12.0"
+        assert artifacts.version == "0.13.0"
 
 
 class TestGovernanceBackwardCompatibility:

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -159,6 +159,21 @@ class TestPluginRef:
         assert ref.version == "0.9.0"
         assert ref.config == {"threads": 4, "memory_limit": "8GB"}
 
+    @pytest.mark.requirement("PCU-005")
+    def test_plugin_ref_rejects_raw_secret_config_fields(self) -> None:
+        """Plugin refs must not serialize raw credential-bearing config fields."""
+        sensitive_key = "client_" + "secret"
+
+        with pytest.raises(ValidationError, match="plugins.keycloak.config.client_secret"):
+            PluginRef(
+                type="keycloak",
+                version="0.1.0",
+                config={
+                    "realm": "floe",
+                    sensitive_key: "provided-at-runtime",
+                },
+            )
+
     @pytest.mark.requirement("2B-FR-007")
     def test_invalid_version_not_semver(self) -> None:
         """Test that non-semver version is rejected."""

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -755,6 +755,7 @@ class TestStorageDeploymentBinding:
         assert payload["capabilities"] == {
             "protocols": ["s3-compatible"],
             "credential_modes": ["kubernetes-secret"],
+            "identity_modes": [],
             "sts_supported": False,
             "path_style_access": True,
         }
@@ -766,6 +767,16 @@ class TestStorageDeploymentBinding:
         assert payload["runtime"]["pyiceberg_properties"] == {
             "s3.endpoint": "http://floe-platform-minio:9000"
         }
+
+    def test_storage_capabilities_accept_identity_modes(self) -> None:
+        """StorageCapabilities should expose concrete workload identity modes."""
+        capabilities = StorageCapabilities(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        )
+
+        assert capabilities.identity_modes == ["aws-irsa"]
 
     @pytest.mark.parametrize(
         ("field_name", "fragment"),

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1705,37 +1705,40 @@ class TestGovernanceLifecycleFields:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Tests for AC-6: version bump to 0.10.0 with history entry."""
+    """Tests for AC-6: version bump to 0.11.0 with history entry."""
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_version_is_0_10_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.10.0'."""
-        assert COMPILED_ARTIFACTS_VERSION == "0.10.0", (
-            f"Expected version '0.10.0', got '{COMPILED_ARTIFACTS_VERSION}'"
+    def test_compiled_artifacts_version_is_0_11_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.11.0'."""
+        assert COMPILED_ARTIFACTS_VERSION == "0.11.0", (
+            f"Expected version '0.11.0', got '{COMPILED_ARTIFACTS_VERSION}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_contains_0_10_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.10.0' entry."""
-        assert "0.10.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
-            f"Version '0.10.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
+    def test_version_history_contains_0_11_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.11.0' entry."""
+        assert "0.11.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
+            f"Version '0.11.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_0_10_0_references_stale_table_recovery(self) -> None:
-        """Test that the 0.10.0 history entry mentions contract additions."""
-        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.10.0", "")
+    def test_version_history_0_11_0_references_security_plugin_refs(self) -> None:
+        """Test that the 0.11.0 history entry mentions contract additions."""
+        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.11.0", "")
         entry_lower = entry.lower()
-        assert "stale" in entry_lower and "recovery" in entry_lower, (
-            f"Version 0.10.0 history entry does not reference stale table recovery: '{entry}'"
+        assert "secrets" in entry_lower, (
+            f"Version 0.11.0 history entry does not reference secrets: '{entry}'"
         )
-        assert "deployment" in entry_lower, (
-            f"Version 0.10.0 history entry does not reference deployment bindings: '{entry}'"
+        assert "identity" in entry_lower, (
+            f"Version 0.11.0 history entry does not reference identity: '{entry}'"
+        )
+        assert "resolvedplugins" in entry_lower, (
+            f"Version 0.11.0 history entry does not reference ResolvedPlugins: '{entry}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_default_version_is_0_10_0(self) -> None:
-        """Test that CompiledArtifacts().version defaults to '0.10.0'."""
+    def test_compiled_artifacts_default_version_is_0_11_0(self) -> None:
+        """Test that CompiledArtifacts().version defaults to '0.11.0'."""
         artifacts = CompiledArtifacts(
             metadata=CompilationMetadata(
                 compiled_at=datetime.now(),
@@ -1764,7 +1767,7 @@ class TestCompiledArtifactsVersionBump:
                 lineage_namespace="test",
             ),
         )
-        assert artifacts.version == "0.10.0"
+        assert artifacts.version == "0.11.0"
 
 
 class TestGovernanceBackwardCompatibility:

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -211,6 +211,31 @@ class TestResolvedPlugins:
         assert plugins.catalog is not None
         assert plugins.catalog.type == "polaris"
 
+    @pytest.mark.requirement("PCU-005")
+    def test_valid_resolved_plugins_includes_secrets_and_identity(self) -> None:
+        """ResolvedPlugins should expose selected security providers."""
+        plugins = ResolvedPlugins(
+            compute=PluginRef(type="duckdb", version="0.9.0"),
+            orchestrator=PluginRef(type="dagster", version="1.5.0"),
+            secrets=PluginRef(
+                type="k8s",
+                version="0.1.0",
+                config={"namespace": "floe-system"},
+            ),
+            identity=PluginRef(
+                type="keycloak",
+                version="0.1.0",
+                config={"realm": "floe"},
+            ),
+        )
+
+        assert plugins.secrets is not None
+        assert plugins.secrets.type == "k8s"
+        assert plugins.secrets.config == {"namespace": "floe-system"}
+        assert plugins.identity is not None
+        assert plugins.identity.type == "keycloak"
+        assert plugins.identity.config == {"realm": "floe"}
+
     @pytest.mark.requirement("2B-FR-007")
     def test_missing_compute_rejected(self) -> None:
         """Test that missing required compute plugin is rejected."""

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1716,40 +1716,40 @@ class TestGovernanceLifecycleFields:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Tests for AC-6: version bump to 0.11.0 with history entry."""
+    """Tests for AC-6: version bump to 0.12.0 with history entry."""
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_version_is_0_11_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.11.0'."""
-        assert COMPILED_ARTIFACTS_VERSION == "0.11.0", (
-            f"Expected version '0.11.0', got '{COMPILED_ARTIFACTS_VERSION}'"
+    def test_compiled_artifacts_version_is_0_12_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.12.0'."""
+        assert COMPILED_ARTIFACTS_VERSION == "0.12.0", (
+            f"Expected version '0.12.0', got '{COMPILED_ARTIFACTS_VERSION}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_contains_0_11_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.11.0' entry."""
-        assert "0.11.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
-            f"Version '0.11.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
+    def test_version_history_contains_0_12_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.12.0' entry."""
+        assert "0.12.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
+            f"Version '0.12.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_0_11_0_references_security_plugin_refs(self) -> None:
-        """Test that the 0.11.0 history entry mentions contract additions."""
-        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.11.0", "")
+    def test_version_history_0_12_0_references_storage_identity_modes(self) -> None:
+        """Test that the 0.12.0 history entry mentions contract additions."""
+        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.12.0", "")
         entry_lower = entry.lower()
-        assert "secrets" in entry_lower, (
-            f"Version 0.11.0 history entry does not reference secrets: '{entry}'"
+        assert "identity_modes" in entry_lower, (
+            f"Version 0.12.0 history entry does not reference identity_modes: '{entry}'"
         )
-        assert "identity" in entry_lower, (
-            f"Version 0.11.0 history entry does not reference identity: '{entry}'"
+        assert "storagecapabilities" in entry_lower, (
+            f"Version 0.12.0 history entry does not reference StorageCapabilities: '{entry}'"
         )
-        assert "resolvedplugins" in entry_lower, (
-            f"Version 0.11.0 history entry does not reference ResolvedPlugins: '{entry}'"
+        assert "workload identity" in entry_lower, (
+            f"Version 0.12.0 history entry does not reference workload identity: '{entry}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_default_version_is_0_11_0(self) -> None:
-        """Test that CompiledArtifacts().version defaults to '0.11.0'."""
+    def test_compiled_artifacts_default_version_is_0_12_0(self) -> None:
+        """Test that CompiledArtifacts().version defaults to '0.12.0'."""
         artifacts = CompiledArtifacts(
             metadata=CompilationMetadata(
                 compiled_at=datetime.now(),
@@ -1778,7 +1778,7 @@ class TestCompiledArtifactsVersionBump:
                 lineage_namespace="test",
             ),
         )
-        assert artifacts.version == "0.11.0"
+        assert artifacts.version == "0.12.0"
 
 
 class TestGovernanceBackwardCompatibility:

--- a/plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py
+++ b/plugins/floe-identity-keycloak/src/floe_identity_keycloak/plugin.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
 from floe_core.plugin_metadata import HealthState, HealthStatus
 from floe_core.plugins.identity import (
     IdentityPlugin,
@@ -86,6 +87,18 @@ class KeycloakIdentityPlugin(IdentityPlugin):
             Tracer name string following OTel naming conventions.
         """
         return TRACER_NAME
+
+    def get_identity_capabilities(self) -> PluginCapabilities:
+        """Return OIDC federation capabilities for workload identity checks."""
+        return PluginCapabilities(
+            plugin_type="identity",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["workload-identity"],
+                identity_modes=["oidc-federation"],
+                providers=["oidc"],
+            ),
+        )
 
     def __init__(self, config: KeycloakIdentityConfig) -> None:
         """Initialize KeycloakIdentityPlugin.

--- a/plugins/floe-identity-keycloak/tests/unit/test_init.py
+++ b/plugins/floe-identity-keycloak/tests/unit/test_init.py
@@ -98,6 +98,7 @@ class TestLazyImports:
 
         assert capabilities.plugin_type == "identity"
         assert capabilities.plugin_name == "keycloak"
+        assert capabilities.capabilities.credential_modes == ["workload-identity"]
         assert capabilities.capabilities.identity_modes == ["oidc-federation"]
         assert capabilities.capabilities.providers == ["oidc"]
 

--- a/plugins/floe-identity-keycloak/tests/unit/test_init.py
+++ b/plugins/floe-identity-keycloak/tests/unit/test_init.py
@@ -78,6 +78,29 @@ class TestLazyImports:
 
         assert "NonExistentAttribute" in str(exc_info.value)
 
+    @pytest.mark.requirement("PCU-005")
+    def test_keycloak_identity_capabilities(self) -> None:
+        """Keycloak plugin should declare OIDC federation support."""
+        from pydantic import SecretStr
+
+        from floe_identity_keycloak import KeycloakIdentityConfig, KeycloakIdentityPlugin
+
+        plugin = KeycloakIdentityPlugin(
+            KeycloakIdentityConfig(
+                server_url="https://keycloak.example.com",
+                realm="floe",
+                client_id="floe-client",
+                client_secret=SecretStr("not-a-real-secret"),
+            )
+        )
+
+        capabilities = plugin.get_identity_capabilities()
+
+        assert capabilities.plugin_type == "identity"
+        assert capabilities.plugin_name == "keycloak"
+        assert capabilities.capabilities.identity_modes == ["oidc-federation"]
+        assert capabilities.capabilities.providers == ["oidc"]
+
 
 class TestModuleAttributes:
     """Tests for module-level attributes."""

--- a/plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py
+++ b/plugins/floe-secrets-infisical/src/floe_secrets_infisical/plugin.py
@@ -30,6 +30,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from floe_core.audit import AuditLogger, AuditOperation
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
 from floe_core.plugin_metadata import HealthState, HealthStatus
 from floe_core.plugins.secrets import SecretsPlugin
 
@@ -149,6 +150,18 @@ class InfisicalSecretsPlugin(SecretsPlugin):
             InfisicalSecretsConfig Pydantic model class.
         """
         return InfisicalSecretsConfig
+
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return Infisical external secret sync capabilities."""
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["external-secret-sync", "kubernetes-secret"],
+                secret_projection_modes=["external-secret-sync", "kubernetes-secret"],
+                providers=["infisical", "kubernetes"],
+            ),
+        )
 
     # =========================================================================
     # Lifecycle Methods

--- a/plugins/floe-secrets-infisical/tests/unit/test_plugin.py
+++ b/plugins/floe-secrets-infisical/tests/unit/test_plugin.py
@@ -108,6 +108,22 @@ class TestInfisicalSecretsPluginMetadata:
         assert plugin.floe_api_version is not None
         assert plugin.floe_api_version == "1.0"
 
+    @pytest.mark.requirement("PCU-005")
+    def test_secret_capabilities(
+        self,
+        plugin: InfisicalSecretsPlugin,
+    ) -> None:
+        """Infisical plugin should declare external secret sync support."""
+        capabilities = plugin.get_secret_capabilities()
+
+        assert capabilities.plugin_type == "secrets"
+        assert capabilities.plugin_name == "infisical"
+        assert capabilities.capabilities.secret_projection_modes == [
+            "external-secret-sync",
+            "kubernetes-secret",
+        ]
+        assert capabilities.capabilities.providers == ["infisical", "kubernetes"]
+
 
 class TestInfisicalSecretsPluginGetSecret:
     """Test InfisicalSecretsPlugin.get_secret() method."""

--- a/plugins/floe-secrets-infisical/tests/unit/test_plugin.py
+++ b/plugins/floe-secrets-infisical/tests/unit/test_plugin.py
@@ -111,13 +111,21 @@ class TestInfisicalSecretsPluginMetadata:
     @pytest.mark.requirement("PCU-005")
     def test_secret_capabilities(
         self,
-        plugin: InfisicalSecretsPlugin,
+        mock_infisical_config: InfisicalSecretsConfig,
     ) -> None:
-        """Infisical plugin should declare external secret sync support."""
+        """Infisical plugin should declare external secret sync support without startup."""
+        plugin = InfisicalSecretsPlugin(config=mock_infisical_config)
+
         capabilities = plugin.get_secret_capabilities()
 
+        assert plugin._client is None
+        assert plugin._authenticated is False
         assert capabilities.plugin_type == "secrets"
         assert capabilities.plugin_name == "infisical"
+        assert capabilities.capabilities.credential_modes == [
+            "external-secret-sync",
+            "kubernetes-secret",
+        ]
         assert capabilities.capabilities.secret_projection_modes == [
             "external-secret-sync",
             "kubernetes-secret",

--- a/plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py
+++ b/plugins/floe-secrets-k8s/src/floe_secrets_k8s/plugin.py
@@ -23,6 +23,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from floe_core.audit import AuditLogger, AuditOperation
+from floe_core.composition.models import CapabilitySet, PluginCapabilities
 from floe_core.plugin_metadata import HealthState, HealthStatus
 from floe_core.plugins.secrets import SecretsPlugin
 
@@ -127,6 +128,18 @@ class K8sSecretsPlugin(SecretsPlugin):
     def get_config_schema(self) -> type[BaseModel]:
         """Return the configuration schema."""
         return K8sSecretsConfig
+
+    def get_secret_capabilities(self) -> PluginCapabilities:
+        """Return Kubernetes Secret projection capabilities."""
+        return PluginCapabilities(
+            plugin_type="secrets",
+            plugin_name=self.name,
+            capabilities=CapabilitySet(
+                credential_modes=["kubernetes-secret"],
+                secret_projection_modes=["kubernetes-secret"],
+                providers=["kubernetes"],
+            ),
+        )
 
     # =========================================================================
     # Lifecycle Methods

--- a/plugins/floe-secrets-k8s/tests/unit/test_plugin.py
+++ b/plugins/floe-secrets-k8s/tests/unit/test_plugin.py
@@ -79,6 +79,18 @@ class TestK8sSecretsPluginMetadata:
         plugin = K8sSecretsPlugin()
         assert plugin.get_config_schema() is K8sSecretsConfig
 
+    @pytest.mark.requirement("PCU-005")
+    def test_secret_capabilities(self) -> None:
+        """K8s secrets plugin should declare Kubernetes Secret projection."""
+        plugin = K8sSecretsPlugin()
+
+        capabilities = plugin.get_secret_capabilities()
+
+        assert capabilities.plugin_type == "secrets"
+        assert capabilities.plugin_name == "k8s"
+        assert capabilities.capabilities.secret_projection_modes == ["kubernetes-secret"]
+        assert capabilities.capabilities.providers == ["kubernetes"]
+
 
 class TestK8sSecretsPluginLifecycle:
     """Test plugin lifecycle methods."""

--- a/plugins/floe-secrets-k8s/tests/unit/test_plugin.py
+++ b/plugins/floe-secrets-k8s/tests/unit/test_plugin.py
@@ -88,6 +88,7 @@ class TestK8sSecretsPluginMetadata:
 
         assert capabilities.plugin_type == "secrets"
         assert capabilities.plugin_name == "k8s"
+        assert capabilities.capabilities.credential_modes == ["kubernetes-secret"]
         assert capabilities.capabilities.secret_projection_modes == ["kubernetes-secret"]
         assert capabilities.capabilities.providers == ["kubernetes"]
 

--- a/testing/fixtures/golden/oci_pull/pull_plugins_config.json
+++ b/testing/fixtures/golden/oci_pull/pull_plugins_config.json
@@ -1,8 +1,8 @@
 {
   "name": "pull_plugins_config",
   "function_name": "",
-  "captured_at": "2026-02-15T08:45:26.797030+00:00",
-  "checksum": "8e24706edf348ce9",
+  "captured_at": "2026-05-07T08:51:37.563663+00:00",
+  "checksum": "f7a30dc3ccc1523a",
   "output": {
     "plugins": {
       "compute": {
@@ -19,7 +19,9 @@
       "storage": null,
       "ingestion": null,
       "semantic": null,
-      "lineage_backend": null
+      "lineage_backend": null,
+      "secrets": null,
+      "identity": null
     },
     "dbt_profiles": {
       "golden_profile": {

--- a/testing/fixtures/golden/oci_pull/pull_success_artifact_structure.json
+++ b/testing/fixtures/golden/oci_pull/pull_success_artifact_structure.json
@@ -1,13 +1,13 @@
 {
   "name": "pull_success_artifact_structure",
   "function_name": "",
-  "captured_at": "2026-02-15T08:45:26.776153+00:00",
-  "checksum": "abf20ea57e1e7b7d",
+  "captured_at": "2026-05-07T08:51:37.561192+00:00",
+  "checksum": "b325f7a58703142e",
   "output": {
-    "version": "0.8.0",
+    "version": "0.13.0",
     "metadata": {
       "compiled_at": "2026-01-15 10:30:00+00:00",
-      "floe_version": "0.8.0",
+      "floe_version": "0.13.0",
       "source_hash": "sha256:golden123abc",
       "product_name": "golden-product",
       "product_version": "1.0.0"
@@ -73,8 +73,11 @@
       "storage": null,
       "ingestion": null,
       "semantic": null,
-      "lineage_backend": null
+      "lineage_backend": null,
+      "secrets": null,
+      "identity": null
     },
+    "deployment": null,
     "transforms": {
       "models": [
         {
@@ -107,7 +110,6 @@
         }
       }
     },
-    "deployment": null,
     "governance": null,
     "enforcement_result": null,
     "data_contracts": [],

--- a/tests/contract/test_resolved_governance_contract.py
+++ b/tests/contract/test_resolved_governance_contract.py
@@ -6,12 +6,12 @@ to ensure GovernanceConfig scalar fields stay synchronized with ResolvedGovernan
 
 Task: T5
 Acceptance Criteria:
-    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.10.0"
+    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.11.0"
     - AC-7: Old JSON without lifecycle fields deserializes correctly
     - AC-9: ResolvedGovernance has all lifecycle fields; drift detection
 
 Contract Guarantees:
-1. COMPILED_ARTIFACTS_VERSION == "0.10.0" (contract-level assertion)
+1. COMPILED_ARTIFACTS_VERSION == "0.11.0" (contract-level assertion)
 2. CompiledArtifacts JSON without default_ttl_hours/snapshot_keep_last -> both None
 3. ResolvedGovernance contains every scalar field from GovernanceConfig
 4. Adding a new scalar field to GovernanceConfig without mirroring in
@@ -208,25 +208,25 @@ def _make_minimal_artifacts_dict() -> dict[str, Any]:
 # ===========================================================================
 
 
-class TestCompiledArtifactsVersionContract:
-    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.10.0."""
+class TestCompiledArtifactsVersionBump:
+    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.11.0."""
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_compiled_artifacts_version_is_0_10_0(self) -> None:
-        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.10.0'.
+    def test_compiled_artifacts_version_is_0_11_0(self) -> None:
+        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.11.0'.
 
         This is a contract-level assertion that locks the version constant.
         If the version changes, this test must be updated deliberately --
         never silently.
         """
-        assert COMPILED_ARTIFACTS_VERSION == "0.10.0", (
+        assert COMPILED_ARTIFACTS_VERSION == "0.11.0", (
             f"COMPILED_ARTIFACTS_VERSION is {COMPILED_ARTIFACTS_VERSION!r}, "
-            "expected '0.10.0'. If this is intentional, update this contract test."
+            "expected '0.11.0'. If this is intentional, update this contract test."
         )
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_default_version_on_new_artifacts_is_0_10_0(self) -> None:
-        """AC-6: A new CompiledArtifacts instance defaults to version '0.10.0'.
+    def test_default_version_on_new_artifacts_is_0_11_0(self) -> None:
+        """AC-6: A new CompiledArtifacts instance defaults to version '0.11.0'.
 
         Ensures the constant is actually wired into the schema default,
         not just defined but unused.
@@ -247,7 +247,7 @@ class TestCompiledArtifactsVersionContract:
             inheritance_chain=[],
             observability=_make_observability(),
         )
-        assert artifacts.version == "0.10.0"
+        assert artifacts.version == "0.11.0"
 
 
 # ===========================================================================

--- a/tests/contract/test_resolved_governance_contract.py
+++ b/tests/contract/test_resolved_governance_contract.py
@@ -6,12 +6,12 @@ to ensure GovernanceConfig scalar fields stay synchronized with ResolvedGovernan
 
 Task: T5
 Acceptance Criteria:
-    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.12.0"
+    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.13.0"
     - AC-7: Old JSON without lifecycle fields deserializes correctly
     - AC-9: ResolvedGovernance has all lifecycle fields; drift detection
 
 Contract Guarantees:
-1. COMPILED_ARTIFACTS_VERSION == "0.12.0" (contract-level assertion)
+1. COMPILED_ARTIFACTS_VERSION == "0.13.0" (contract-level assertion)
 2. CompiledArtifacts JSON without default_ttl_hours/snapshot_keep_last -> both None
 3. ResolvedGovernance contains every scalar field from GovernanceConfig
 4. Adding a new scalar field to GovernanceConfig without mirroring in
@@ -209,24 +209,24 @@ def _make_minimal_artifacts_dict() -> dict[str, Any]:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.12.0."""
+    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.13.0."""
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_compiled_artifacts_version_is_0_12_0(self) -> None:
-        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.12.0'.
+    def test_compiled_artifacts_version_is_0_13_0(self) -> None:
+        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.13.0'.
 
         This is a contract-level assertion that locks the version constant.
         If the version changes, this test must be updated deliberately --
         never silently.
         """
-        assert COMPILED_ARTIFACTS_VERSION == "0.12.0", (
+        assert COMPILED_ARTIFACTS_VERSION == "0.13.0", (
             f"COMPILED_ARTIFACTS_VERSION is {COMPILED_ARTIFACTS_VERSION!r}, "
-            "expected '0.12.0'. If this is intentional, update this contract test."
+            "expected '0.13.0'. If this is intentional, update this contract test."
         )
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_default_version_on_new_artifacts_is_0_12_0(self) -> None:
-        """AC-6: A new CompiledArtifacts instance defaults to version '0.12.0'.
+    def test_default_version_on_new_artifacts_is_0_13_0(self) -> None:
+        """AC-6: A new CompiledArtifacts instance defaults to version '0.13.0'.
 
         Ensures the constant is actually wired into the schema default,
         not just defined but unused.
@@ -247,7 +247,7 @@ class TestCompiledArtifactsVersionBump:
             inheritance_chain=[],
             observability=_make_observability(),
         )
-        assert artifacts.version == "0.12.0"
+        assert artifacts.version == "0.13.0"
 
 
 # ===========================================================================

--- a/tests/contract/test_resolved_governance_contract.py
+++ b/tests/contract/test_resolved_governance_contract.py
@@ -6,12 +6,12 @@ to ensure GovernanceConfig scalar fields stay synchronized with ResolvedGovernan
 
 Task: T5
 Acceptance Criteria:
-    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.11.0"
+    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.12.0"
     - AC-7: Old JSON without lifecycle fields deserializes correctly
     - AC-9: ResolvedGovernance has all lifecycle fields; drift detection
 
 Contract Guarantees:
-1. COMPILED_ARTIFACTS_VERSION == "0.11.0" (contract-level assertion)
+1. COMPILED_ARTIFACTS_VERSION == "0.12.0" (contract-level assertion)
 2. CompiledArtifacts JSON without default_ttl_hours/snapshot_keep_last -> both None
 3. ResolvedGovernance contains every scalar field from GovernanceConfig
 4. Adding a new scalar field to GovernanceConfig without mirroring in
@@ -209,24 +209,24 @@ def _make_minimal_artifacts_dict() -> dict[str, Any]:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.11.0."""
+    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.12.0."""
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_compiled_artifacts_version_is_0_11_0(self) -> None:
-        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.11.0'.
+    def test_compiled_artifacts_version_is_0_12_0(self) -> None:
+        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.12.0'.
 
         This is a contract-level assertion that locks the version constant.
         If the version changes, this test must be updated deliberately --
         never silently.
         """
-        assert COMPILED_ARTIFACTS_VERSION == "0.11.0", (
+        assert COMPILED_ARTIFACTS_VERSION == "0.12.0", (
             f"COMPILED_ARTIFACTS_VERSION is {COMPILED_ARTIFACTS_VERSION!r}, "
-            "expected '0.11.0'. If this is intentional, update this contract test."
+            "expected '0.12.0'. If this is intentional, update this contract test."
         )
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_default_version_on_new_artifacts_is_0_11_0(self) -> None:
-        """AC-6: A new CompiledArtifacts instance defaults to version '0.11.0'.
+    def test_default_version_on_new_artifacts_is_0_12_0(self) -> None:
+        """AC-6: A new CompiledArtifacts instance defaults to version '0.12.0'.
 
         Ensures the constant is actually wired into the schema default,
         not just defined but unused.
@@ -247,7 +247,7 @@ class TestCompiledArtifactsVersionBump:
             inheritance_chain=[],
             observability=_make_observability(),
         )
-        assert artifacts.version == "0.11.0"
+        assert artifacts.version == "0.12.0"
 
 
 # ===========================================================================

--- a/tests/contract/test_storage_binding_security.py
+++ b/tests/contract/test_storage_binding_security.py
@@ -44,6 +44,12 @@ def test_compiled_demo_storage_binding_does_not_contain_secret_values() -> None:
 def test_compiled_artifact_does_not_contain_minio_secret_values() -> None:
     """Full compiled artifact must not contain raw MinIO credential values."""
     artifacts = _compile_demo_artifacts()
+
+    assert artifacts.plugins is not None
+    assert artifacts.plugins.storage is not None
+    assert artifacts.plugins.storage.config is not None
+    assert "credential_secret_name" in artifacts.plugins.storage.config
+
     payload = artifacts.model_dump_json()
 
     for forbidden in FORBIDDEN_STORAGE_SECRET_VALUES:


### PR DESCRIPTION
## Summary
- add identity and secrets plugin refs plus capability contracts to compiled artifacts
- validate storage, catalog, secrets, and identity composition for credential modes, secret projection modes, identity modes, and provider compatibility
- keep compiled plugin refs secret-free while preserving runtime config for plugin setup
- update docs and contract coverage for the identity/secret composition layer

## Validation
- make lint
- make typecheck
- uv run pytest tests/contract -q: 972 passed, 1 xfailed
- uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py -q: 34 passed
- pre-push hook passed: lint, format, mypy, dbt version requirements, bandit, uv-secure, unit tests + coverage, contract tests, no hardcoded sleep, requirement traceability, docs validation, helm lint

## Security Notes
- CompiledArtifacts plugin refs now reject and sanitize credential-bearing config keys, so secret values and identity credentials are not projected into artifacts.
- This PR intentionally keeps the plugin abstraction scope bounded. Follow-up hardening should remove demo placeholder identity/secret literals from source manifests, add full E2E coverage using the identity/security plugins, and add automated security/pen-test style gates.