### PR TITLE
Add AWS provider compatibility test account setup

### DIFF
--- a/.codex/skills/floe-aws-provider-testing/SKILL.md
+++ b/.codex/skills/floe-aws-provider-testing/SKILL.md
@@ -42,6 +42,7 @@ export FLOE_AWS_TEST_BUCKET=<bucket>
 export FLOE_AWS_TEST_PREFIX=<s3-run-prefix>
 export FLOE_AWS_GLUE_DATABASE_PREFIX=<glue-database-prefix>
 export FLOE_AWS_BUDGET_NAME=<budget-name>
+export FLOE_AWS_BUDGET_EMAIL=<budget-email>
 export FLOE_AWS_PROVIDER_TEST_POLICY_ARN=<provider-test-policy-arn>
 ```
 

--- a/.codex/skills/floe-aws-provider-testing/SKILL.md
+++ b/.codex/skills/floe-aws-provider-testing/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: floe-aws-provider-testing
+description: Use when setting up, validating, running, or cleaning up Floe AWS provider testing through infra/aws-provider-tests. Applies to AWS S3 plus AWS Glue provider compatibility work, OpenTofu scaffold operations, AWS readiness checks, and cleanup evidence.
+---
+
+# Floe AWS Provider Testing
+
+Use this skill for Floe AWS provider test-account setup and cleanup.
+
+## Preconditions
+
+- Work from `/Users/dmccarthy/Projects/floe` unless the user gives another Floe checkout.
+- Read `docs/contributing/aws-provider-testing.md`.
+- Use `infra/aws-provider-tests` for OpenTofu.
+- Confirm the AWS account is a sandbox or approved test account.
+- Confirm region, owner, budget email, and AWS profile.
+- Do not use production data.
+- Do not create EKS, NAT Gateway, Glue jobs, Glue crawlers, Lake Formation, S3 Tables, or always-on EC2 unless the user explicitly approves a separate design.
+
+## Setup Workflow
+
+1. Run `aws sts get-caller-identity --profile <profile>` and confirm the account with the user-provided target.
+2. Copy `infra/aws-provider-tests/terraform.tfvars.example` to `infra/aws-provider-tests/terraform.tfvars` if no local tfvars exists.
+3. Fill only non-secret values: region, owner, budget email, and tags.
+4. Run:
+
+```bash
+cd infra/aws-provider-tests
+AWS_PROFILE=<profile> tofu init
+AWS_PROFILE=<profile> tofu fmt -check
+AWS_PROFILE=<profile> tofu validate
+AWS_PROFILE=<profile> tofu plan -out tfplan
+```
+
+5. Review the plan for allowed resource classes only: S3, IAM policy/user attachment if enabled, Budget.
+6. Run `AWS_PROFILE=<profile> tofu apply tfplan` only after the plan is acceptable.
+7. Export the non-secret outputs needed by validation:
+
+```bash
+export FLOE_AWS_REGION=<region>
+export FLOE_AWS_TEST_BUCKET=<bucket>
+export FLOE_AWS_TEST_PREFIX=runs/
+export FLOE_AWS_GLUE_DATABASE_PREFIX=floe_provider_
+```
+
+8. Run `scripts/aws-provider-test-readiness.sh`.
+
+## Cleanup Workflow
+
+For a live provider run, set the current run ID:
+
+```bash
+export FLOE_PROVIDER_SPIKE_RUN=floe-provider-YYYYMMDDTHHMMSSZ
+```
+
+Then run:
+
+```bash
+scripts/aws-provider-test-cleanup.sh
+```
+
+If the whole scaffold is no longer needed:
+
+```bash
+cd infra/aws-provider-tests
+AWS_PROFILE=<profile> tofu destroy
+```
+
+After cleanup, report S3, Glue, and any optional DevPod/EC2 inventory separately.
+
+## Failure Classification
+
+- Product failure: Floe resolver, binding, runtime translator, renderer, or plugin behavior is wrong.
+- Provider failure: AWS auth, S3, Glue, IAM, region, endpoint, or API behavior rejects the test.
+- Infrastructure failure: OpenTofu, DevPod, Kind, network, or CLI setup fails before product validation.
+- Cleanup failure: current-run AWS resources remain after cleanup.

--- a/.codex/skills/floe-aws-provider-testing/SKILL.md
+++ b/.codex/skills/floe-aws-provider-testing/SKILL.md
@@ -9,7 +9,7 @@ Use this skill for Floe AWS provider test-account setup and cleanup.
 
 ## Preconditions
 
-- Work from `/Users/dmccarthy/Projects/floe` unless the user gives another Floe checkout.
+- Work from the repository root unless the user gives another Floe checkout.
 - Read `docs/contributing/aws-provider-testing.md`.
 - Use `infra/aws-provider-tests` for OpenTofu.
 - Confirm the AWS account is a sandbox or approved test account.

--- a/.codex/skills/floe-aws-provider-testing/SKILL.md
+++ b/.codex/skills/floe-aws-provider-testing/SKILL.md
@@ -39,8 +39,10 @@ AWS_PROFILE=<profile> tofu plan -out tfplan
 ```bash
 export FLOE_AWS_REGION=<region>
 export FLOE_AWS_TEST_BUCKET=<bucket>
-export FLOE_AWS_TEST_PREFIX=runs/
-export FLOE_AWS_GLUE_DATABASE_PREFIX=floe_provider_
+export FLOE_AWS_TEST_PREFIX=<s3-run-prefix>
+export FLOE_AWS_GLUE_DATABASE_PREFIX=<glue-database-prefix>
+export FLOE_AWS_BUDGET_NAME=<budget-name>
+export FLOE_AWS_PROVIDER_TEST_POLICY_ARN=<provider-test-policy-arn>
 ```
 
 8. Run `scripts/aws-provider-test-readiness.sh`.

--- a/.gitignore
+++ b/.gitignore
@@ -104,11 +104,16 @@ charts/**/charts/
 *.tgz
 !charts/floe-platform/flux-artifacts/*.tgz
 
-# Terraform
+# Terraform / OpenTofu
 .terraform/
 *.tfstate
 *.tfstate.*
 .terraform.lock.hcl
+!infra/aws-provider-tests/.terraform.lock.hcl
+*.tfvars
+!*.tfvars.example
+tfplan
+*.tfplan
 
 # Secrets (NEVER commit)
 *.pem

--- a/devtools/agent-memory/uv.lock
+++ b/devtools/agent-memory/uv.lock
@@ -3961,11 +3961,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]

--- a/docs/contributing/aws-provider-testing.md
+++ b/docs/contributing/aws-provider-testing.md
@@ -57,8 +57,9 @@ Run readiness checks and report the AWS account ID, region, bucket, Glue databas
 
 ## Clean Account Check
 
-After exporting the OpenTofu `recommended_environment` outputs and setting the
-current `FLOE_PROVIDER_SPIKE_RUN`, ask the agent to verify:
+After exporting all OpenTofu `recommended_environment` outputs, including the
+test prefix, Glue prefix, budget name, and provider-test policy ARN, set the
+current `FLOE_PROVIDER_SPIKE_RUN` and ask the agent to verify:
 
 ```bash
 aws sts get-caller-identity

--- a/docs/contributing/aws-provider-testing.md
+++ b/docs/contributing/aws-provider-testing.md
@@ -1,0 +1,68 @@
+# AWS Provider Testing
+
+Use this guide when you want an AI agent to set up the AWS side of Floe
+provider compatibility testing.
+
+This is not a product deployment guide. The default setup creates no EKS
+cluster, no NAT Gateway, no Glue jobs, no Glue crawlers, and no always-on EC2.
+
+## What A Human Must Provide
+
+Before asking an agent to set up AWS provider tests, have these ready:
+
+| Requirement | Why it matters |
+| --- | --- |
+| AWS sandbox account | Tests create and delete S3 and Glue resources. Do not use production. |
+| Approved AWS region | Keeps bucket, Glue, and cost evidence consistent. |
+| AWS CLI profile or SSO session | Lets the agent run OpenTofu and AWS CLI checks. |
+| Permission to manage IAM, S3, Glue, and Budgets | The scaffold creates the scoped test resources and cost alarm. |
+| Budget alert email | OpenTofu creates a low monthly AWS Budget. |
+| Owner name/tag | Every created resource is tagged for accountability. |
+
+Do not provide raw access keys in chat. Use a local AWS profile or SSO session
+that the agent can use from the repository workspace.
+
+## What The Agent Will Create
+
+The agent applies `infra/aws-provider-tests/` with OpenTofu. The scaffold
+creates:
+
+- one reusable S3 bucket for provider-test data;
+- S3 public access block, encryption, and lifecycle expiry for `runs/`;
+- scoped IAM policy resources for S3 and Glue provider tests;
+- a low monthly AWS Budget;
+- non-secret outputs used by Floe provider validation.
+
+## What The Agent Must Not Create By Default
+
+- EKS clusters
+- NAT Gateways
+- always-on EC2 instances
+- Glue jobs or crawlers
+- Lake Formation resources
+- S3 Tables resources
+- AWS access keys stored in OpenTofu state
+
+## Handoff Prompt
+
+Use this prompt when asking an agent to set up the environment:
+
+~~~text
+Set up the Floe AWS provider testing environment from /Users/dmccarthy/Projects/floe.
+Use AWS profile <profile-name>, region <region>, owner <owner>, and budget email <email>.
+Use OpenTofu under infra/aws-provider-tests.
+Do not create EKS, NAT Gateway, Glue jobs, Glue crawlers, Lake Formation, S3 Tables, or always-on EC2.
+Run readiness checks and report the AWS account ID, region, bucket, Glue database prefix, and cleanup status.
+~~~
+
+## Clean Account Check
+
+After a run, ask the agent to verify:
+
+```bash
+aws sts get-caller-identity
+scripts/aws-provider-test-cleanup.sh
+```
+
+The final report must say whether current-run S3 prefixes and Glue databases
+were removed.

--- a/docs/contributing/aws-provider-testing.md
+++ b/docs/contributing/aws-provider-testing.md
@@ -48,7 +48,7 @@ creates:
 Use this prompt when asking an agent to set up the environment:
 
 ~~~text
-Set up the Floe AWS provider testing environment from /Users/dmccarthy/Projects/floe.
+Set up the Floe AWS provider testing environment from <path-to-floe-checkout>.
 Use AWS profile <profile-name>, region <region>, owner <owner>, and budget email <email>.
 Use OpenTofu under infra/aws-provider-tests.
 Do not create EKS, NAT Gateway, Glue jobs, Glue crawlers, Lake Formation, S3 Tables, or always-on EC2.

--- a/docs/contributing/aws-provider-testing.md
+++ b/docs/contributing/aws-provider-testing.md
@@ -57,11 +57,12 @@ Run readiness checks and report the AWS account ID, region, bucket, Glue databas
 
 ## Clean Account Check
 
-After a run, ask the agent to verify:
+After exporting the OpenTofu `recommended_environment` outputs and setting the
+current `FLOE_PROVIDER_SPIKE_RUN`, ask the agent to verify:
 
 ```bash
 aws sts get-caller-identity
-scripts/aws-provider-test-cleanup.sh
+FLOE_PROVIDER_SPIKE_RUN=floe-provider-YYYYMMDDTHHMMSSZ scripts/aws-provider-test-cleanup.sh
 ```
 
 The final report must say whether current-run S3 prefixes and Glue databases

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -21,6 +21,7 @@ uv run pytest testing/ci/tests/test_validate_docs_navigation.py -q
 - [Remote DevPod workspace](devpod-hetzner.md) for heavyweight validation.
 - [Contributor testing](testing.md) for unit, integration, E2E, docs, and release-validation checks.
 - [Contributor troubleshooting](troubleshooting.md) for remote validation, tunnel, demo, lineage, trace, and stale-image failures.
+- [AWS provider testing](aws-provider-testing.md) for the human prerequisites needed before an agent provisions the AWS test environment.
 - [Documentation standards](documentation-standards.md) for keeping docs aligned with behavior.
 
 Contributor workflows can use repo-local `make` targets and DevPod. Platform Engineer and Data Engineer docs should describe product workflows that do not require contributor infrastructure.

--- a/docs/superpowers/plans/2026-05-11-provider-compatibility-spike.md
+++ b/docs/superpowers/plans/2026-05-11-provider-compatibility-spike.md
@@ -1,0 +1,714 @@
+# Provider Compatibility Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce the provider compatibility spike artifacts that validate whether Floe's merged binding/composition model generalizes beyond the MinIO plus Polaris baseline.
+
+**Architecture:** This plan is documentation-and-evidence first. It maps the implemented model, builds a provider compatibility matrix, classifies gaps, defines a live-service validation runbook, and produces a final recommendation without implementing production provider plugins.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, uv, pytest, ripgrep, Markdown validation scripts, DevPod/Hetzner remote validation, optional AWS CLI or SDK evidence for the later live lane.
+
+---
+
+## Scope Boundary
+
+This plan implements the spike artifacts only. It does not implement AWS S3,
+AWS Glue, Nessie, GCS, Azure, Hive, or new production plugin code.
+
+The plan may run read-only code searches and existing tests. It may create or
+edit Markdown evidence artifacts under `docs/validation/` and should update no
+production source files unless a validation command exposes a blocker that the
+user explicitly asks to fix.
+
+The preferred live proof remains AWS S3 plus AWS Glue, but this plan only
+defines the executable live runbook and readiness gate. Actual live AWS
+execution requires explicit credentials and cleanup confirmation before a later
+implementation session runs it.
+
+## File Map
+
+Create these evidence artifacts:
+
+- `docs/validation/2026-05-11-provider-compatibility-system-map.md`
+  - Owns the implemented-system map and source evidence from `main`.
+- `docs/validation/2026-05-11-provider-compatibility-matrix.md`
+  - Owns provider-by-provider compatibility decisions.
+- `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md`
+  - Owns gap classification and next implementation recommendations.
+- `docs/validation/2026-05-11-provider-compatibility-live-runbook.md`
+  - Owns AWS S3 plus Glue and Nessie plus MinIO live validation runbooks.
+- `docs/validation/2026-05-11-provider-compatibility-final-recommendation.md`
+  - Owns the final recommendation and first follow-up implementation unit.
+
+Read these source and docs surfaces:
+
+- `docs/superpowers/specs/2026-05-11-provider-compatibility-spike-design.md`
+- `docs/validation/2026-05-09-post-composition-plugin-matrix.md`
+- `docs/validation/2026-05-09-post-composition-compatibility-ledger.md`
+- `docs/validation/2026-05-09-post-composition-runtime-validation.md`
+- `docs/architecture/plugin-composition-uplift-tracker.md`
+- `packages/floe-core/src/floe_core/composition/models.py`
+- `packages/floe-core/src/floe_core/composition/resolver.py`
+- `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+- `packages/floe-core/src/floe_core/runtime_catalog_connection.py`
+- `packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py`
+- `plugins/floe-storage-minio/src/floe_storage_minio/plugin.py`
+- `plugins/floe-catalog-polaris/src/floe_catalog_polaris/plugin.py`
+- `plugins/floe-ingestion-dlt/src/floe_ingestion_dlt/plugin.py`
+- `plugins/floe-compute-duckdb/src/floe_compute_duckdb/plugin.py`
+- `plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/`
+- `packages/floe-core/src/floe_core/cli/helm/generate.py`
+
+## Task 1: Preflight And Implemented-System Evidence
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-05-11-provider-compatibility-spike-design.md`
+- Read: `packages/floe-core/src/floe_core/composition/models.py`
+- Read: `packages/floe-core/src/floe_core/composition/resolver.py`
+- Read: `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+- Read: `packages/floe-core/src/floe_core/runtime_catalog_connection.py`
+- Read: `packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py`
+- Create: `docs/validation/2026-05-11-provider-compatibility-system-map.md`
+
+- [ ] **Step 1: Confirm trunk state**
+
+Run:
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+git log --oneline -5
+```
+
+Expected:
+
+- Branch is `main`.
+- Worktree is clean before edits.
+- Recent history includes `docs: add provider compatibility spike design`.
+
+- [ ] **Step 2: Capture composition and binding source map**
+
+Run:
+
+```bash
+rg -n "class (CapabilitySet|RequirementSet|PluginCapabilities|PluginRequirements|CompositionIssue|CompositionValidationResult)|class (StorageDeploymentBinding|CatalogDeploymentBinding|IngestionDeploymentBinding|RuntimeCatalogConnection|CredentialRef|DeploymentConfig)|def build_runtime_catalog_connection|def runtime_catalog_connection_to_pyiceberg_config" \
+  packages/floe-core/src/floe_core/composition \
+  packages/floe-core/src/floe_core/schemas/compiled_artifacts.py \
+  packages/floe-core/src/floe_core/runtime_catalog_connection.py \
+  packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py
+```
+
+Expected:
+
+- Output identifies all current composition and typed binding symbols.
+- `RuntimeCatalogConnection` exists in `compiled_artifacts.py`.
+- Runtime catalog derivation and PyIceberg translation functions exist.
+
+- [ ] **Step 3: Capture provider implementation source map**
+
+Run:
+
+```bash
+rg -n "def get_deployment_binding|def get_storage_requirements|def build_catalog_deployment|def get_composition_requirements|def build_deployment_binding|def augment_dbt_profile|RuntimeCatalogConnection|build_runtime_catalog_connection|runtime_catalog_connection_to_pyiceberg_config" \
+  plugins/floe-storage-minio/src \
+  plugins/floe-catalog-polaris/src \
+  plugins/floe-ingestion-dlt/src \
+  plugins/floe-compute-duckdb/src \
+  plugins/floe-orchestrator-dagster/src \
+  packages/floe-core/src/floe_core/cli/helm/generate.py
+```
+
+Expected:
+
+- Output shows MinIO emits storage binding.
+- Output shows Polaris declares requirements and emits catalog binding.
+- Output shows dlt declares requirements and emits ingestion binding.
+- Output shows DuckDB augments dbt profiles from deployment bindings.
+- Output shows Dagster and Iceberg consume runtime catalog connection.
+- Output shows Helm rendering uses deployment bindings.
+
+- [ ] **Step 4: Create the system-map artifact**
+
+Create `docs/validation/2026-05-11-provider-compatibility-system-map.md` with this structure and fill it from Steps 1-3:
+
+```markdown
+# Provider Compatibility Implemented-System Map
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Branch: `main`
+Purpose: Source map for the provider compatibility spike.
+
+## Current Head
+
+| Item | Evidence |
+| --- | --- |
+| Branch | `main` |
+| HEAD | Record the exact SHA printed by `git rev-parse HEAD` in Step 1 |
+| Recent commits | Record the five commit subjects printed by `git log --oneline -5` in Step 1 |
+
+## Composition Contracts
+
+| Contract | Source | Role |
+| --- | --- | --- |
+| `CapabilitySet` | `packages/floe-core/src/floe_core/composition/models.py` | Provider capability declaration |
+| `RequirementSet` | `packages/floe-core/src/floe_core/composition/models.py` | Provider requirement declaration |
+| `CompositionResolver` | `packages/floe-core/src/floe_core/composition/resolver.py` | Compatibility validation |
+| `COMPOSITION_*` diagnostics | `packages/floe-core/src/floe_core/composition/error_codes.py` | Operator-facing composition failures |
+
+## Typed Bindings
+
+| Binding | Source | Role |
+| --- | --- | --- |
+| `StorageDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free storage deployment state |
+| `CatalogDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free catalog deployment state |
+| `IngestionDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free ingestion runtime state |
+| `RuntimeCatalogConnection` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Neutral Iceberg runtime catalog projection |
+| `CredentialRef` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free credential reference |
+
+## Current Provider Consumers
+
+| Consumer | Source | Current behavior |
+| --- | --- | --- |
+| MinIO storage | `plugins/floe-storage-minio/src/floe_storage_minio/plugin.py` | Emits `StorageDeploymentBinding` |
+| Polaris catalog | `plugins/floe-catalog-polaris/src/floe_catalog_polaris/plugin.py` | Declares storage requirements and emits `CatalogDeploymentBinding` |
+| dlt ingestion | `plugins/floe-ingestion-dlt/src/floe_ingestion_dlt/plugin.py` | Declares storage/catalog requirements and emits `IngestionDeploymentBinding` |
+| DuckDB compute | `plugins/floe-compute-duckdb/src/floe_compute_duckdb/plugin.py` | Augments dbt profile from deployment bindings |
+| Dagster runtime | `plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/` | Consumes `RuntimeCatalogConnection` |
+| Helm renderer | `packages/floe-core/src/floe_core/cli/helm/generate.py` | Renders from deployment bindings |
+
+## Baseline Conclusion
+
+MinIO plus Polaris is the control path. New provider compatibility must either reuse the current neutral contracts or justify a new capability, binding, runtime translator, or renderer dimension.
+```
+
+- [ ] **Step 5: Commit the system-map artifact**
+
+Run:
+
+```bash
+git add docs/validation/2026-05-11-provider-compatibility-system-map.md
+git commit -m "docs: map provider compatibility baseline"
+```
+
+Expected: commit succeeds and hooks pass.
+
+## Task 2: Provider Compatibility Matrix
+
+**Files:**
+- Read: `docs/validation/2026-05-11-provider-compatibility-system-map.md`
+- Read: `docs/validation/2026-05-09-post-composition-plugin-matrix.md`
+- Read: `docs/architecture/plugin-composition-uplift-tracker.md`
+- Create: `docs/validation/2026-05-11-provider-compatibility-matrix.md`
+
+- [ ] **Step 1: Inventory existing plugin entry points**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import tomllib
+
+for path in sorted(Path("plugins").glob("*/pyproject.toml")):
+    data = tomllib.loads(path.read_text())
+    entry_points = data.get("project", {}).get("entry-points", {})
+    floe_groups = {
+        group: sorted(entries)
+        for group, entries in entry_points.items()
+        if group.startswith("floe.")
+    }
+    if floe_groups:
+        print(path.parent.name)
+        for group, names in floe_groups.items():
+            print(f"  {group}: {', '.join(names)}")
+PY
+```
+
+Expected:
+
+- Output includes `floe-storage-minio`, `floe-catalog-polaris`, `floe-ingestion-dlt`, `floe-compute-duckdb`, `floe-orchestrator-dagster`, and the security/observability plugin families.
+- Output does not include AWS S3, AWS Glue, Nessie, GCS, Azure, or Hive provider plugins.
+
+- [ ] **Step 2: Create the matrix artifact**
+
+Create `docs/validation/2026-05-11-provider-compatibility-matrix.md` with this structure:
+
+```markdown
+# Provider Compatibility Matrix
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Provider-by-provider assessment against the merged binding/composition model.
+
+## Level Definitions
+
+| Level | Meaning | Evidence required |
+| --- | --- | --- |
+| 0 | Discoverable plugin only | Entry point, metadata, config schema |
+| 1 | Declares capabilities and requirements | `PluginCapabilities`, `PluginRequirements`, resolver tests |
+| 2 | Emits or consumes typed bindings | Contract model, schema tests, secret-free artifacts |
+| 3 | Runtime/deployment translated and validated | Resolver tests, binding output, renderer/runtime translation, E2E or live proof where applicable |
+
+## Matrix
+
+| Provider combination | Storage protocol | Catalog protocol | Credential mode | Identity mode | Endpoint shape | Warehouse ownership | Server-side storage access | Current expressibility | Required model change | Target level | Live proof |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| MinIO + Polaris | `s3-compatible` | Iceberg REST via Polaris | Kubernetes Secret | none | explicit internal/external endpoint, path-style | storage binding plus Polaris warehouse | yes, via referenced MinIO credentials | Expressed today | none | Level 3 | Existing DevPod/Hetzner E2E control path |
+| AWS S3 + AWS Glue | `s3` | Glue Catalog | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | regional AWS endpoints, optional custom endpoint for tests | S3 bucket/prefix plus Glue database/table metadata | yes, through AWS IAM | Partially expressible conceptually; provider plugins absent | native S3 storage plugin, Glue catalog binding, AWS identity/credential requirements, PyIceberg Glue translation proof | Level 3 target after implementation | Preferred live proof |
+| AWS S3 + Iceberg REST or Polaris | `s3` | Iceberg REST | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | AWS S3 regional endpoint plus REST catalog URI | storage owns bucket/prefix, catalog owns warehouse reference | depends on catalog deployment | Partially expressible conceptually; native S3 plugin absent | native S3 storage binding plus catalog-specific requirements | Level 2 or 3 depending on live catalog | Optional second proof |
+| MinIO + Nessie | `s3-compatible` | Nessie Iceberg catalog | Kubernetes Secret | none | MinIO path-style endpoint plus Nessie REST endpoint | storage bucket/prefix plus Nessie catalog branch/namespace | yes, if Nessie service accesses storage | MinIO side expressed; Nessie provider absent | Nessie catalog plugin and typed catalog binding | Level 3 fallback target | Fallback live proof |
+| AWS S3 + Nessie | `s3` | Nessie Iceberg catalog | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | AWS S3 endpoint plus Nessie REST endpoint | S3 bucket/prefix plus Nessie branch/namespace | yes, if Nessie service accesses storage | Not implemented | native S3 storage plugin, Nessie catalog plugin, identity/credential binding proof | Level 3 second-wave target | Deferred live proof |
+| GCS + future catalog | `gcs` | provider-specific | workload identity or secret-backed service account | GCP Workload Identity or service account reference | GCS bucket URI and regional/multi-region behavior | GCS bucket/prefix plus catalog metadata | provider-dependent | Not implemented | GCS storage capability, credential mode, runtime translator pressure test | Level 1 or 2 design target | No first live proof |
+| Azure Blob or ADLS + future catalog | `abfs` or provider-specific | provider-specific | workload identity or secret-backed identity | Azure Workload Identity or managed identity | account/container/path endpoint | container/path plus catalog metadata | provider-dependent | Not implemented | Azure storage capability, identity mode, runtime translator pressure test | Level 1 or 2 design target | No first live proof |
+| Hive catalog | object-store dependent | Hive metastore | provider-dependent | provider-dependent | metastore URI plus object-store endpoint | storage path plus Hive metadata | yes | Not implemented and no concrete alpha trigger | defer until deployment path exists | Level 0 deferred | No live proof |
+
+## Entry Point Evidence
+
+Record the Step 1 entry point inventory summary here. Use it to prove which providers exist today and which are future provider paths.
+
+## Matrix Conclusion
+
+AWS S3 plus Glue is the preferred first live target because it stresses native cloud storage, managed catalog semantics, IAM, and PyIceberg runtime translation. Nessie plus MinIO is the fallback because it validates catalog variation without cloud-provider setup.
+```
+
+- [ ] **Step 3: Search for provider-specific assumptions**
+
+Run:
+
+```bash
+rg -n '"minio"|polaris|s3-compatible|path-style|path_style|Glue|glue|Nessie|nessie|GCS|Azure|ADLS|abfs|s3.endpoint|warehouse' \
+  packages plugins tests docs/contracts docs/architecture \
+  -g '*.py' -g '*.md' -g '*.yaml' -g '*.yml' -g '*.json'
+```
+
+Expected:
+
+- Output identifies current MinIO/Polaris assumptions.
+- Output does not show production AWS Glue or Nessie provider implementations.
+- Add a short "Provider-specific assumption search" section to the matrix artifact with the main findings.
+
+- [ ] **Step 4: Commit the provider matrix**
+
+Run:
+
+```bash
+git add docs/validation/2026-05-11-provider-compatibility-matrix.md
+git commit -m "docs: add provider compatibility matrix"
+```
+
+Expected: commit succeeds and hooks pass.
+
+## Task 3: Gap Classification Ledger
+
+**Files:**
+- Read: `docs/validation/2026-05-11-provider-compatibility-matrix.md`
+- Read: `docs/validation/2026-05-09-post-composition-compatibility-ledger.md`
+- Create: `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md`
+
+- [ ] **Step 1: Search for compatibility helpers and runtime rediscovery paths**
+
+Run:
+
+```bash
+rg -n "get_pyiceberg_catalog_config|get_helm_values_override|artifacts\\.plugins\\.(storage|catalog)\\.config|runtime_catalog_connection|RuntimeCatalogConnection|build_runtime_catalog_connection|runtime_catalog_connection_to_pyiceberg_config" \
+  packages plugins tests docs \
+  -g '*.py' -g '*.md'
+```
+
+Expected:
+
+- Output shows first-party runtime paths now prefer `RuntimeCatalogConnection`.
+- Deprecated helpers may still exist as compatibility surfaces, but should not be recommended as new provider contracts.
+
+- [ ] **Step 2: Search for secret-sensitive binding fields**
+
+Run:
+
+```bash
+rg -n "CredentialRef|StorageCredentialBinding|SecretReference|SecretStr|access_key|secret_key|client_secret|token|password|AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY" \
+  packages/floe-core/src/floe_core/schemas \
+  packages/floe-core/src/floe_core/composition \
+  plugins/floe-storage-minio/src \
+  plugins/floe-catalog-polaris/src \
+  plugins/floe-ingestion-dlt/src \
+  tests/contract \
+  -g '*.py'
+```
+
+Expected:
+
+- Output shows compiled artifact credential material represented by references or env names.
+- Output should not justify adding raw credential values to `CompiledArtifacts`.
+
+- [ ] **Step 3: Create the gap ledger artifact**
+
+Create `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md` with this structure:
+
+```markdown
+# Provider Compatibility Gap Ledger
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Classify provider compatibility gaps before implementation.
+
+## Gap Categories
+
+| Category | Meaning |
+| --- | --- |
+| No change | Current model already expresses the provider path |
+| Capability-only gap | Resolver needs another compatibility dimension |
+| Typed binding gap | Current bindings cannot carry required secret-free state |
+| Provider plugin gap | Model is sufficient, but provider plugin does not exist |
+| Runtime translator gap | Binding exists, but runtime library translation is missing |
+| Renderer gap | Deployment output cannot be generated from bindings yet |
+| Live validation gap | Real service proof is missing |
+| Out of scope | Provider path lacks a concrete composition trigger |
+
+## Gaps
+
+| Gap | Provider path | Category | Evidence | Recommended next action |
+| --- | --- | --- | --- | --- |
+| Native AWS S3 storage provider absent | AWS S3 + Glue; AWS S3 + Nessie | Provider plugin gap | Entry point inventory has no `floe-storage-aws-s3` plugin | Design native S3 storage plugin after matrix approval |
+| AWS credential and identity modes need proof against resolver | AWS S3 + Glue | Capability-only gap | Current composition model includes credential and identity modes but AWS provider declarations do not exist | Define AWS provider requirements and resolver tests in the first implementation unit |
+| Glue catalog binding absent | AWS S3 + Glue | Provider plugin gap and typed binding gap | Entry point inventory has no Glue catalog plugin and current catalog binding has Polaris-specific provider detail only | Design Glue catalog provider-owned binding before implementation |
+| PyIceberg Glue translation not proven from `RuntimeCatalogConnection` | AWS S3 + Glue | Runtime translator gap | Current runtime translator handles generic URI/warehouse/S3 properties, not proven Glue catalog properties | Add translator proof or a Glue-specific runtime projection in a follow-up spec |
+| Nessie catalog provider absent | MinIO + Nessie; AWS S3 + Nessie | Provider plugin gap and typed binding gap | Entry point inventory has no Nessie catalog plugin | Design Nessie catalog binding if selected as fallback live proof |
+| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap and typed binding pressure test | No current provider plugin or runtime translation evidence | Keep as design pressure tests, not first implementation |
+| Hive lacks concrete alpha path | Hive | Out of scope | No current deployment trigger in the approved spike | Defer until a product path exists |
+
+## Compatibility Helper Decision
+
+Do not use deprecated helper APIs as new provider contracts. New provider work must flow through capabilities, requirements, typed bindings, resolver validation, and runtime/renderer translators.
+
+## Secret-Free Decision
+
+Provider compatibility is invalid if it requires raw access keys, secret keys, tokens, client secrets, passwords, or bearer tokens inside `CompiledArtifacts`.
+
+## First Follow-Up Recommendation
+
+Recommend one implementation unit and one live validation lane based on the matrix:
+
+- Primary path: AWS S3 plus AWS Glue provider compatibility design if AWS credentials and cleanup controls are available.
+- Fallback path: Nessie plus MinIO provider compatibility design if AWS access is unavailable.
+```
+
+- [ ] **Step 4: Commit the gap ledger**
+
+Run:
+
+```bash
+git add docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
+git commit -m "docs: classify provider compatibility gaps"
+```
+
+Expected: commit succeeds and hooks pass.
+
+## Task 4: Live Validation Runbook
+
+**Files:**
+- Read: `scripts/devpod-test.sh`
+- Read: `docs/validation/2026-05-09-post-composition-runtime-validation.md`
+- Read: `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md`
+- Create: `docs/validation/2026-05-11-provider-compatibility-live-runbook.md`
+
+- [ ] **Step 1: Capture DevPod remote lane command shape**
+
+Run:
+
+```bash
+rg -n "DEVPOD_WORKSPACE|DEVPOD_REMOTE_E2E_MAKE_TARGET|DEVPOD_REMOTE_E2E_TIMEOUT|devpod list|Hetzner|hcloud|servers|volumes|ssh_keys|load_balancers|floating_ips" \
+  scripts/devpod-test.sh docs/validation/2026-05-09-post-composition-runtime-validation.md
+```
+
+Expected:
+
+- Output identifies the remote validation command pattern.
+- Output identifies direct Hetzner inventory requirements.
+
+- [ ] **Step 2: Create the live validation runbook**
+
+Create `docs/validation/2026-05-11-provider-compatibility-live-runbook.md` with this structure:
+
+```markdown
+# Provider Compatibility Live Validation Runbook
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Executable live-service validation plan for the provider compatibility spike.
+
+## Preconditions
+
+- Run from `main`.
+- Worktree is clean before validation.
+- DevPod is installed and has the Hetzner provider initialized.
+- `.env` contains `DEVPOD_HETZNER_TOKEN` or the environment contains `HCLOUD_TOKEN`.
+- AWS live proof requires explicit user approval that AWS credentials are available and scoped for the test.
+- Do not run live AWS cleanup commands against shared resources unless the resource names match the current run prefix.
+
+## Failure Classification
+
+| Classification | Meaning |
+| --- | --- |
+| Product failure | Floe resolver, binding, runtime translation, renderer, or plugin behavior is wrong |
+| Provider failure | AWS, Glue, S3, Nessie, or catalog provider rejects auth, permissions, region, endpoint, warehouse, or API usage |
+| Infrastructure failure | DevPod, Hetzner, Kind, Flux, network, or provisioning fails before product validation |
+| Cleanup failure | Billable or test resources remain after the run |
+| Tooling warning | Non-fatal wrapper or tunnel behavior occurs after artifacts and cleanup prove the result |
+
+## Preferred Lane: AWS S3 Plus AWS Glue
+
+### Resource Naming
+
+Use a unique run prefix:
+
+```bash
+export FLOE_PROVIDER_SPIKE_RUN="floe-provider-$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+All AWS resources created for the proof must include `${FLOE_PROVIDER_SPIKE_RUN}` in the name or tags.
+
+### Readiness Checks
+
+```bash
+git status --short --branch
+devpod list
+aws sts get-caller-identity
+aws s3api list-buckets --query 'Buckets[].Name' --output text
+aws glue get-databases --max-results 1
+```
+
+Expected:
+
+- Git branch is `main`.
+- DevPod list is empty or has no current-run workspace.
+- AWS caller identity succeeds.
+- S3 and Glue list commands succeed with the intended test account.
+
+### Product Validation Shape
+
+The live proof should preserve these artifacts:
+
+- Compiled artifact JSON.
+- Resolver decision output.
+- Runtime catalog connection projection.
+- PyIceberg or runtime config derived from bindings.
+- Live create/list/read/write output.
+- Secret scan output for artifacts and logs.
+
+### AWS Cleanup
+
+Cleanup must verify these resource classes:
+
+```bash
+aws glue get-databases
+aws glue get-tables --database-name "${FLOE_PROVIDER_SPIKE_RUN}"
+aws s3api list-objects-v2 --bucket "${FLOE_PROVIDER_SPIKE_RUN}" --max-items 10
+aws s3api head-bucket --bucket "${FLOE_PROVIDER_SPIKE_RUN}"
+aws iam list-roles --query "Roles[?contains(RoleName, '${FLOE_PROVIDER_SPIKE_RUN}')].RoleName"
+aws iam list-policies --scope Local --query "Policies[?contains(PolicyName, '${FLOE_PROVIDER_SPIKE_RUN}')].Arn"
+```
+
+Expected after cleanup:
+
+- Glue database and tables created for the run are absent.
+- S3 bucket or prefix created for the run is absent or empty and retained only if explicitly approved.
+- IAM roles and policies created for the run are absent.
+- Any external reusable credential or role is named in the final evidence and not deleted by the runbook.
+
+## Fallback Lane: Nessie Plus MinIO
+
+Use this lane when AWS access is unavailable or not safe for the first proof.
+
+Expected proof:
+
+- Nessie catalog service is deployed in the remote validation environment.
+- MinIO remains the storage provider.
+- Resolver accepts MinIO plus Nessie only when catalog requirements match storage capabilities.
+- Runtime catalog connection is derived from deployment bindings.
+- Iceberg table create/list/read/write succeeds.
+- DevPod and Hetzner resources are directly inventoried after cleanup.
+
+## DevPod And Hetzner Cleanup
+
+Use the existing remote lane shape:
+
+```bash
+DEVPOD_WORKSPACE="${FLOE_PROVIDER_SPIKE_RUN}" DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full make devpod-test
+devpod list
+```
+
+Direct Hetzner inventory must check these resource classes for the current run prefix:
+
+```bash
+servers
+volumes
+ssh_keys
+load_balancers
+floating_ips
+```
+
+Final evidence must state whether each class has no current-run resources remaining.
+```
+
+- [ ] **Step 3: Commit the live runbook**
+
+Run:
+
+```bash
+git add docs/validation/2026-05-11-provider-compatibility-live-runbook.md
+git commit -m "docs: add provider compatibility live runbook"
+```
+
+Expected: commit succeeds and hooks pass.
+
+## Task 5: Final Recommendation And Verification
+
+**Files:**
+- Read: `docs/validation/2026-05-11-provider-compatibility-system-map.md`
+- Read: `docs/validation/2026-05-11-provider-compatibility-matrix.md`
+- Read: `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md`
+- Read: `docs/validation/2026-05-11-provider-compatibility-live-runbook.md`
+- Create: `docs/validation/2026-05-11-provider-compatibility-final-recommendation.md`
+
+- [ ] **Step 1: Create the final recommendation artifact**
+
+Create `docs/validation/2026-05-11-provider-compatibility-final-recommendation.md` with this structure:
+
+```markdown
+# Provider Compatibility Final Recommendation
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Closeout recommendation for the provider compatibility spike.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+| --- | --- |
+| `docs/validation/2026-05-11-provider-compatibility-system-map.md` | Implemented model and source map |
+| `docs/validation/2026-05-11-provider-compatibility-matrix.md` | Provider matrix and Level decisions |
+| `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md` | Gap classification and next action |
+| `docs/validation/2026-05-11-provider-compatibility-live-runbook.md` | Live AWS/Glue and Nessie/MinIO validation plan |
+
+## Recommendation
+
+Proceed with AWS S3 plus AWS Glue as the first provider compatibility implementation design if AWS credentials and cleanup controls are available. Otherwise proceed with Nessie plus MinIO as the first live proof while keeping AWS S3 plus Glue as the primary provider matrix target.
+
+## First Implementation Unit
+
+Recommended first implementation unit:
+
+- Design native AWS S3 storage binding and AWS Glue catalog binding against the current composition model.
+- Add resolver tests for AWS credential and identity modes.
+- Add secret-free compiled artifact tests.
+- Add runtime translator proof for PyIceberg Glue config derived from typed bindings.
+- Keep live AWS validation behind the runbook readiness gate.
+
+## Fallback Implementation Unit
+
+Recommended fallback implementation unit:
+
+- Design Nessie catalog binding that composes with existing MinIO storage binding.
+- Add resolver tests for MinIO plus Nessie compatibility.
+- Add runtime translator proof for Nessie Iceberg catalog config.
+- Use the fallback live lane to validate catalog variation without AWS resources.
+
+## Explicit Deferrals
+
+- GCS and Azure remain design pressure tests until a concrete provider path exists.
+- Hive remains deferred until a concrete deployment path exists.
+- Deprecated compatibility helpers are not new provider contracts.
+- Raw credentials in `CompiledArtifacts` remain forbidden.
+
+## Closeout Status
+
+The spike is complete when this document references all evidence artifacts and the worktree is clean after the final commit.
+```
+
+- [ ] **Step 2: Run Markdown and content validation**
+
+Run:
+
+```bash
+uv run python testing/ci/validate-docs-navigation.py
+uv run python testing/ci/validate-docs-content.py
+git diff --check
+```
+
+Expected:
+
+- Docs navigation validation passes.
+- Docs content validation passes.
+- `git diff --check` prints no whitespace errors.
+
+- [ ] **Step 3: Search for plan red flags in generated artifacts**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+terms = [
+    "T" + "BD",
+    "TO" + "DO",
+    "FIX" + "ME",
+    "raw access" + " key",
+    "raw secret" + " key",
+    "hardcoded credential",
+]
+failed = False
+for path in sorted(Path("docs/validation").glob("2026-05-11-provider-compatibility-*.md")):
+    text = path.read_text()
+    for line_no, line in enumerate(text.splitlines(), 1):
+        for term in terms:
+            if term in line:
+                print(f"{path}:{line_no}: {term}: {line}")
+                failed = True
+if failed:
+    raise SystemExit(1)
+PY
+```
+
+Expected:
+
+- No output for incomplete-work markers.
+- If `raw access key`, `raw secret key`, or `hardcoded credential` appears, it appears only in a rule forbidding those patterns.
+
+- [ ] **Step 4: Commit final recommendation**
+
+Run:
+
+```bash
+git add docs/validation/2026-05-11-provider-compatibility-final-recommendation.md
+git commit -m "docs: recommend provider compatibility path"
+```
+
+Expected: commit succeeds and hooks pass.
+
+- [ ] **Step 5: Final closeout check**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -8
+```
+
+Expected:
+
+- Worktree is clean.
+- Recent commits include the system map, matrix, gap ledger, live runbook, and final recommendation commits.
+
+## Post-Plan Execution Notes
+
+Use `superpowers:subagent-driven-development` for execution. Good task splits:
+
+- Worker 1: Task 1 system map.
+- Worker 2: Task 2 provider matrix.
+- Worker 3: Task 3 gap ledger.
+- Worker 4: Task 4 live runbook.
+- Parent session: Task 5 final recommendation and validation, integrating prior artifacts.
+
+Do not dispatch workers to modify the same evidence file concurrently.

--- a/docs/superpowers/plans/2026-05-12-aws-provider-test-account.md
+++ b/docs/superpowers/plans/2026-05-12-aws-provider-test-account.md
@@ -1,0 +1,1055 @@
+# AWS Provider Test Account Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a repeatable, low-cost AWS provider testing setup for Floe using OpenTofu, a minimal human handoff guide, and a reusable Codex skill.
+
+**Architecture:** Keep the human-facing guide small and make automation the source of truth. OpenTofu owns AWS setup, shell helpers own readiness/cleanup checks, and the Codex skill owns the repeatable agent workflow. The default path provisions no always-on compute and does not replace the existing Hetzner DevPod control lane.
+
+**Tech Stack:** OpenTofu, AWS provider, AWS CLI, Bash, Markdown docs, Codex skill format, existing Floe docs validators and pre-commit hooks.
+
+---
+
+## Scope And File Map
+
+Create:
+
+- `infra/aws-provider-tests/versions.tf` - OpenTofu and AWS provider requirements.
+- `infra/aws-provider-tests/variables.tf` - configurable inputs with safe defaults and validation.
+- `infra/aws-provider-tests/locals.tf` - normalized names and common tags.
+- `infra/aws-provider-tests/main.tf` - S3 bucket, encryption, public access block, lifecycle, and budget resources.
+- `infra/aws-provider-tests/iam.tf` - scoped IAM policy/role and optional disabled-by-default access-key user.
+- `infra/aws-provider-tests/outputs.tf` - environment hints for agents and contributors.
+- `infra/aws-provider-tests/terraform.tfvars.example` - copyable non-secret example values.
+- `infra/aws-provider-tests/README.md` - short IaC owner notes for agents.
+- `scripts/aws-provider-test-readiness.sh` - AWS account, S3, Glue, Budget, and IAM readiness checks.
+- `scripts/aws-provider-test-cleanup.sh` - current-run S3/Glue cleanup plus post-cleanup inventory.
+- `docs/contributing/aws-provider-testing.md` - human-only prerequisite and handoff guide.
+- `.codex/skills/floe-aws-provider-testing/SKILL.md` - reusable agent workflow skill.
+
+Modify:
+
+- `.gitignore` - allow committing `infra/aws-provider-tests/.terraform.lock.hcl` while keeping state and local tfvars ignored.
+- `docs/contributing/index.md` - link the AWS provider testing guide.
+
+Do not create:
+
+- EKS resources.
+- NAT Gateways.
+- Glue jobs or crawlers.
+- Lake Formation or S3 Tables resources.
+- Long-running EC2 resources.
+- Real AWS credentials, tfstate, or local-only tfvars in git.
+
+## Task 1: Add OpenTofu Scaffold
+
+**Files:**
+
+- Create: `infra/aws-provider-tests/versions.tf`
+- Create: `infra/aws-provider-tests/variables.tf`
+- Create: `infra/aws-provider-tests/locals.tf`
+- Create: `infra/aws-provider-tests/main.tf`
+- Create: `infra/aws-provider-tests/iam.tf`
+- Create: `infra/aws-provider-tests/outputs.tf`
+- Create: `infra/aws-provider-tests/terraform.tfvars.example`
+- Create: `infra/aws-provider-tests/README.md`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create the OpenTofu directory**
+
+Run:
+
+```bash
+mkdir -p infra/aws-provider-tests
+```
+
+Expected: directory exists and contains no files yet.
+
+- [ ] **Step 2: Add provider requirements**
+
+Create `infra/aws-provider-tests/versions.tf`:
+
+```hcl
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+```
+
+- [ ] **Step 3: Add variables with validation**
+
+Create `infra/aws-provider-tests/variables.tf`:
+
+```hcl
+variable "aws_region" {
+  description = "AWS region used for Floe provider compatibility testing."
+  type        = string
+  default     = "ap-southeast-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.aws_region))
+    error_message = "aws_region must be an AWS region identifier such as ap-southeast-2."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix for AWS resources created by this scaffold."
+  type        = string
+  default     = "floe-provider-tests"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{2,40}$", var.name_prefix))
+    error_message = "name_prefix must be lowercase, start with a letter, and contain only letters, numbers, and hyphens."
+  }
+}
+
+variable "owner" {
+  description = "Human owner for cost and cleanup accountability."
+  type        = string
+}
+
+variable "budget_email" {
+  description = "Email address that receives AWS Budget alerts."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", var.budget_email))
+    error_message = "budget_email must be an email address."
+  }
+}
+
+variable "monthly_budget_limit_usd" {
+  description = "Monthly AWS Budget threshold in USD."
+  type        = number
+  default     = 25
+
+  validation {
+    condition     = var.monthly_budget_limit_usd > 0 && var.monthly_budget_limit_usd <= 100
+    error_message = "monthly_budget_limit_usd must be greater than 0 and no more than 100 for this test scaffold."
+  }
+}
+
+variable "s3_bucket_name" {
+  description = "Optional explicit S3 bucket name. Leave null to derive one from account, region, and prefix."
+  type        = string
+  default     = null
+}
+
+variable "s3_run_prefix" {
+  description = "S3 prefix under which per-run test artifacts are written."
+  type        = string
+  default     = "runs/"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9/_-]*/$", var.s3_run_prefix))
+    error_message = "s3_run_prefix must be a relative S3 prefix ending with /."
+  }
+}
+
+variable "run_data_retention_days" {
+  description = "Number of days before S3 run data expires."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.run_data_retention_days >= 1 && var.run_data_retention_days <= 30
+    error_message = "run_data_retention_days must be between 1 and 30."
+  }
+}
+
+variable "glue_database_prefix" {
+  description = "Prefix allowed for Glue databases created by provider tests."
+  type        = string
+  default     = "floe_provider_"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]{2,40}_$", var.glue_database_prefix))
+    error_message = "glue_database_prefix must be lowercase snake_case and end with an underscore."
+  }
+}
+
+variable "enable_access_key_user" {
+  description = "Create a disabled-by-default IAM user/access key path for environments that cannot assume roles."
+  type        = bool
+  default     = false
+}
+
+variable "enable_aws_devpod_permissions" {
+  description = "Include EC2 permissions needed by a future AWS DevPod target."
+  type        = bool
+  default     = false
+}
+
+variable "common_tags" {
+  description = "Additional tags applied to supported AWS resources."
+  type        = map(string)
+  default     = {}
+}
+```
+
+- [ ] **Step 4: Add locals**
+
+Create `infra/aws-provider-tests/locals.tf`:
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  derived_bucket_name = lower("${var.name_prefix}-${local.account_id}-${var.aws_region}")
+  bucket_name         = coalesce(var.s3_bucket_name, local.derived_bucket_name)
+
+  common_tags = merge(
+    {
+      Project   = "floe"
+      Purpose   = "provider-compatibility"
+      ManagedBy = "opentofu"
+      Owner     = var.owner
+    },
+    var.common_tags,
+  )
+}
+```
+
+- [ ] **Step 5: Add S3 and Budget resources**
+
+Create `infra/aws-provider-tests/main.tf`:
+
+```hcl
+resource "aws_s3_bucket" "provider_tests" {
+  bucket = local.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  rule {
+    id     = "expire-provider-test-runs"
+    status = "Enabled"
+
+    filter {
+      prefix = var.s3_run_prefix
+    }
+
+    expiration {
+      days = var.run_data_retention_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+resource "aws_budgets_budget" "provider_tests" {
+  name         = "${var.name_prefix}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_limit_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.budget_email]
+  }
+}
+```
+
+- [ ] **Step 6: Add scoped IAM resources**
+
+Create `infra/aws-provider-tests/iam.tf`:
+
+```hcl
+data "aws_iam_policy_document" "provider_test_permissions" {
+  statement {
+    sid = "ReadCallerIdentity"
+
+    actions = [
+      "sts:GetCallerIdentity",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ListProviderTestBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.provider_tests.arn,
+    ]
+  }
+
+  statement {
+    sid = "ManageProviderTestObjects"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.provider_tests.arn}/${var.s3_run_prefix}*",
+    ]
+  }
+
+  statement {
+    sid = "ManageFloeGlueDatabases"
+
+    actions = [
+      "glue:CreateDatabase",
+      "glue:DeleteDatabase",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:UpdateDatabase",
+    ]
+
+    resources = [
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
+    ]
+  }
+
+  statement {
+    sid = "ManageFloeGlueTables"
+
+    actions = [
+      "glue:BatchDeleteTable",
+      "glue:CreateTable",
+      "glue:DeleteTable",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:UpdateTable",
+    ]
+
+    resources = [
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*",
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_aws_devpod_permissions ? [1] : []
+
+    content {
+      sid = "OptionalAwsDevPodEc2Inventory"
+
+      actions = [
+        "ec2:DescribeInstances",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+      ]
+
+      resources = ["*"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "provider_test_permissions" {
+  name        = "${var.name_prefix}-permissions"
+  description = "Scoped permissions for Floe AWS provider compatibility tests."
+  policy      = data.aws_iam_policy_document.provider_test_permissions.json
+}
+
+resource "aws_iam_user" "provider_test" {
+  count = var.enable_access_key_user ? 1 : 0
+  name  = "${var.name_prefix}-user"
+}
+
+resource "aws_iam_user_policy_attachment" "provider_test" {
+  count      = var.enable_access_key_user ? 1 : 0
+  user       = aws_iam_user.provider_test[0].name
+  policy_arn = aws_iam_policy.provider_test_permissions.arn
+}
+```
+
+Do not create an access key resource in the first implementation. If a user path needs access keys later, add it behind a separate approval because Terraform state would contain the secret access key.
+
+- [ ] **Step 7: Add outputs**
+
+Create `infra/aws-provider-tests/outputs.tf`:
+
+```hcl
+output "aws_account_id" {
+  description = "AWS account ID where provider-test resources were created."
+  value       = local.account_id
+}
+
+output "aws_region" {
+  description = "AWS region for provider-test resources."
+  value       = var.aws_region
+}
+
+output "s3_bucket_name" {
+  description = "Reusable S3 bucket for Floe provider compatibility tests."
+  value       = aws_s3_bucket.provider_tests.bucket
+}
+
+output "s3_run_prefix" {
+  description = "Prefix for per-run S3 data."
+  value       = var.s3_run_prefix
+}
+
+output "glue_database_prefix" {
+  description = "Allowed Glue database prefix for provider tests."
+  value       = var.glue_database_prefix
+}
+
+output "provider_test_policy_arn" {
+  description = "IAM policy ARN for Floe AWS provider tests."
+  value       = aws_iam_policy.provider_test_permissions.arn
+}
+
+output "recommended_environment" {
+  description = "Non-secret environment exports for Floe AWS provider validation."
+  value = {
+    FLOE_AWS_REGION               = var.aws_region
+    FLOE_AWS_TEST_BUCKET          = aws_s3_bucket.provider_tests.bucket
+    FLOE_AWS_TEST_PREFIX          = var.s3_run_prefix
+    FLOE_AWS_GLUE_DATABASE_PREFIX = var.glue_database_prefix
+  }
+}
+```
+
+- [ ] **Step 8: Add example tfvars**
+
+Create `infra/aws-provider-tests/terraform.tfvars.example`:
+
+```hcl
+aws_region               = "ap-southeast-2"
+name_prefix              = "floe-provider-tests"
+owner                    = "your-name"
+budget_email             = "you@example.com"
+monthly_budget_limit_usd = 25
+run_data_retention_days  = 3
+glue_database_prefix     = "floe_provider_"
+
+common_tags = {
+  Environment = "test"
+  CostCenter  = "floe-provider-tests"
+}
+```
+
+- [ ] **Step 9: Add IaC README**
+
+Create `infra/aws-provider-tests/README.md`:
+
+~~~markdown
+# Floe AWS Provider Test Account
+
+This OpenTofu scaffold prepares low-cost AWS resources for Floe provider
+compatibility validation.
+
+It creates S3, IAM, and Budget resources only. It does not create EKS, EC2,
+NAT Gateways, Glue jobs, Glue crawlers, Lake Formation resources, or S3 Tables.
+
+## Human prerequisites
+
+Read `docs/contributing/aws-provider-testing.md` before applying this scaffold.
+
+## Agent workflow
+
+```bash
+cd infra/aws-provider-tests
+cp terraform.tfvars.example terraform.tfvars
+tofu init
+tofu fmt -check
+tofu validate
+tofu plan -out tfplan
+tofu apply tfplan
+```
+
+Do not commit `terraform.tfvars`, `tfplan`, `.terraform/`, or state files.
+~~~
+
+- [ ] **Step 10: Allow committing the OpenTofu lock file for this scaffold**
+
+Modify the Terraform section in `.gitignore`:
+
+```gitignore
+# Terraform / OpenTofu
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+!infra/aws-provider-tests/.terraform.lock.hcl
+*.tfvars
+!*.tfvars.example
+tfplan
+*.tfplan
+```
+
+- [ ] **Step 11: Format and validate OpenTofu files**
+
+Run:
+
+```bash
+tofu fmt -check infra/aws-provider-tests
+tofu init -backend=false -chdir=infra/aws-provider-tests
+tofu validate -chdir=infra/aws-provider-tests
+```
+
+Expected:
+
+- `tofu fmt -check` exits `0`.
+- `tofu init -backend=false` installs provider metadata locally.
+- `tofu validate` reports success.
+
+If `tofu` is not installed, record `SKIP: tofu CLI unavailable` in the task notes and continue to docs/secret validation. Do not replace OpenTofu with Terraform.
+
+- [ ] **Step 12: Commit OpenTofu scaffold**
+
+Run:
+
+```bash
+git add .gitignore infra/aws-provider-tests
+git commit -m "infra: add AWS provider test scaffold"
+```
+
+## Task 2: Add AWS Readiness And Cleanup Helpers
+
+**Files:**
+
+- Create: `scripts/aws-provider-test-readiness.sh`
+- Create: `scripts/aws-provider-test-cleanup.sh`
+
+- [ ] **Step 1: Add readiness helper**
+
+Create `scripts/aws-provider-test-readiness.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+    echo "[aws-provider-readiness] $*" >&2
+}
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        echo "[aws-provider-readiness] ERROR: ${name} is required" >&2
+        exit 1
+    fi
+}
+
+require_env FLOE_AWS_REGION
+require_env FLOE_AWS_TEST_BUCKET
+require_env FLOE_AWS_GLUE_DATABASE_PREFIX
+
+aws_args=(--region "${FLOE_AWS_REGION}")
+
+log "Checking AWS caller identity"
+aws sts get-caller-identity "${aws_args[@]}"
+
+log "Checking S3 bucket access: ${FLOE_AWS_TEST_BUCKET}"
+aws s3api get-bucket-location \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    "${aws_args[@]}"
+
+log "Checking S3 list access"
+aws s3api list-objects-v2 \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    --prefix "${FLOE_AWS_TEST_PREFIX:-runs/}" \
+    --max-items 1 \
+    "${aws_args[@]}" >/dev/null
+
+probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
+
+cleanup_probe() {
+    aws glue delete-database \
+        --database-name "${probe_db}" \
+        "${aws_args[@]}" >/dev/null 2>&1 || true
+}
+trap cleanup_probe EXIT
+
+log "Checking Glue create/get/delete access with ${probe_db}"
+aws glue create-database \
+    --database-input "{\"Name\":\"${probe_db}\"}" \
+    "${aws_args[@]}" >/dev/null
+aws glue get-database \
+    --name "${probe_db}" \
+    "${aws_args[@]}" >/dev/null
+aws glue delete-database \
+    --database-name "${probe_db}" \
+    "${aws_args[@]}" >/dev/null
+
+log "Readiness checks passed"
+```
+
+- [ ] **Step 2: Add cleanup helper**
+
+Create `scripts/aws-provider-test-cleanup.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+    echo "[aws-provider-cleanup] $*" >&2
+}
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        echo "[aws-provider-cleanup] ERROR: ${name} is required" >&2
+        exit 1
+    fi
+}
+
+require_env FLOE_AWS_REGION
+require_env FLOE_AWS_TEST_BUCKET
+require_env FLOE_AWS_GLUE_DATABASE_PREFIX
+require_env FLOE_PROVIDER_SPIKE_RUN
+
+aws_args=(--region "${FLOE_AWS_REGION}")
+run_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}${FLOE_PROVIDER_SPIKE_RUN}/"
+run_database="${FLOE_AWS_GLUE_DATABASE_PREFIX}${FLOE_PROVIDER_SPIKE_RUN//-/_}"
+
+log "Cleaning S3 run prefix s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}"
+aws s3 rm "s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}" --recursive "${aws_args[@]}" || true
+
+log "Deleting Glue tables in ${run_database} if the database exists"
+if aws glue get-database --name "${run_database}" "${aws_args[@]}" >/dev/null 2>&1; then
+    table_names="$(
+        aws glue get-tables \
+            --database-name "${run_database}" \
+            --query 'TableList[].Name' \
+            --output text \
+            "${aws_args[@]}"
+    )"
+    for table_name in ${table_names}; do
+        aws glue delete-table \
+            --database-name "${run_database}" \
+            --name "${table_name}" \
+            "${aws_args[@]}" >/dev/null || true
+    done
+    aws glue delete-database \
+        --database-name "${run_database}" \
+        "${aws_args[@]}" >/dev/null || true
+fi
+
+log "Post-cleanup S3 inventory"
+aws s3api list-objects-v2 \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    --prefix "${run_prefix}" \
+    --max-items 10 \
+    "${aws_args[@]}"
+
+log "Post-cleanup Glue inventory"
+aws glue get-database \
+    --name "${run_database}" \
+    "${aws_args[@]}" >/dev/null 2>&1 && {
+        echo "[aws-provider-cleanup] ERROR: Glue database still exists: ${run_database}" >&2
+        exit 1
+    }
+
+log "Cleanup checks passed"
+```
+
+- [ ] **Step 3: Make helpers executable and lint shell syntax**
+
+Run:
+
+```bash
+chmod +x scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh
+bash -n scripts/aws-provider-test-readiness.sh
+bash -n scripts/aws-provider-test-cleanup.sh
+```
+
+Expected: both `bash -n` commands exit `0`.
+
+- [ ] **Step 4: Commit helpers**
+
+Run:
+
+```bash
+git add scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh
+git commit -m "tools: add AWS provider test helpers"
+```
+
+## Task 3: Add Minimal Human Guide
+
+**Files:**
+
+- Create: `docs/contributing/aws-provider-testing.md`
+- Modify: `docs/contributing/index.md`
+
+- [ ] **Step 1: Add contributor guide**
+
+Create `docs/contributing/aws-provider-testing.md`:
+
+```markdown
+# AWS Provider Testing
+
+Use this guide when you want an AI agent to set up the AWS side of Floe
+provider compatibility testing.
+
+This is not a product deployment guide. The default setup creates no EKS
+cluster, no NAT Gateway, no Glue jobs, no Glue crawlers, and no always-on EC2.
+
+## What A Human Must Provide
+
+Before asking an agent to set up AWS provider tests, have these ready:
+
+| Requirement | Why it matters |
+| --- | --- |
+| AWS sandbox account | Tests create and delete S3 and Glue resources. Do not use production. |
+| Approved AWS region | Keeps bucket, Glue, and cost evidence consistent. |
+| AWS CLI profile or SSO session | Lets the agent run OpenTofu and AWS CLI checks. |
+| Permission to manage IAM, S3, Glue, and Budgets | The scaffold creates the scoped test resources and cost alarm. |
+| Budget alert email | OpenTofu creates a low monthly AWS Budget. |
+| Owner name/tag | Every created resource is tagged for accountability. |
+
+Do not provide raw access keys in chat. Use a local AWS profile or SSO session
+that the agent can use from the repository workspace.
+
+## What The Agent Will Create
+
+The agent applies `infra/aws-provider-tests/` with OpenTofu. The scaffold
+creates:
+
+- one reusable S3 bucket for provider-test data;
+- S3 public access block, encryption, and lifecycle expiry for `runs/`;
+- scoped IAM policy resources for S3 and Glue provider tests;
+- a low monthly AWS Budget;
+- non-secret outputs used by Floe provider validation.
+
+## What The Agent Must Not Create By Default
+
+- EKS clusters
+- NAT Gateways
+- always-on EC2 instances
+- Glue jobs or crawlers
+- Lake Formation resources
+- S3 Tables resources
+- AWS access keys stored in OpenTofu state
+
+## Handoff Prompt
+
+Use this prompt when asking an agent to set up the environment:
+
+```text
+Set up the Floe AWS provider testing environment from /Users/dmccarthy/Projects/floe.
+Use AWS profile <profile-name>, region <region>, owner <owner>, and budget email <email>.
+Use OpenTofu under infra/aws-provider-tests.
+Do not create EKS, NAT Gateway, Glue jobs, Glue crawlers, Lake Formation, S3 Tables, or always-on EC2.
+Run readiness checks and report the AWS account ID, region, bucket, Glue database prefix, and cleanup status.
+```
+
+## Clean Account Check
+
+After a run, ask the agent to verify:
+
+```bash
+aws sts get-caller-identity
+scripts/aws-provider-test-cleanup.sh
+```
+
+The final report must say whether current-run S3 prefixes and Glue databases
+were removed.
+```
+
+- [ ] **Step 2: Link the guide from contributor index**
+
+Modify the Contributor Workflows list in `docs/contributing/index.md` to include:
+
+```markdown
+- [AWS provider testing](aws-provider-testing.md) for the human prerequisites needed before an agent provisions the AWS test environment.
+```
+
+- [ ] **Step 3: Run docs validators**
+
+Run:
+
+```bash
+uv run python testing/ci/validate-docs-navigation.py
+uv run python testing/ci/validate-docs-content.py
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Commit guide**
+
+Run:
+
+```bash
+git add docs/contributing/aws-provider-testing.md docs/contributing/index.md
+git commit -m "docs: add AWS provider testing handoff guide"
+```
+
+## Task 4: Add Reusable Codex Skill
+
+**Files:**
+
+- Create: `.codex/skills/floe-aws-provider-testing/SKILL.md`
+
+- [ ] **Step 1: Create skill directory**
+
+Run:
+
+```bash
+mkdir -p .codex/skills/floe-aws-provider-testing
+```
+
+- [ ] **Step 2: Add skill instructions**
+
+Create `.codex/skills/floe-aws-provider-testing/SKILL.md`:
+
+```markdown
+---
+name: floe-aws-provider-testing
+description: Use when setting up, validating, running, or cleaning up Floe AWS provider testing through infra/aws-provider-tests. Applies to AWS S3 plus AWS Glue provider compatibility work, OpenTofu scaffold operations, AWS readiness checks, and cleanup evidence.
+---
+
+# Floe AWS Provider Testing
+
+Use this skill for Floe AWS provider test-account setup and cleanup.
+
+## Preconditions
+
+- Work from `/Users/dmccarthy/Projects/floe` unless the user gives another Floe checkout.
+- Read `docs/contributing/aws-provider-testing.md`.
+- Use `infra/aws-provider-tests` for OpenTofu.
+- Confirm the AWS account is a sandbox or approved test account.
+- Confirm region, owner, budget email, and AWS profile.
+- Do not use production data.
+- Do not create EKS, NAT Gateway, Glue jobs, Glue crawlers, Lake Formation, S3 Tables, or always-on EC2 unless the user explicitly approves a separate design.
+
+## Setup Workflow
+
+1. Run `aws sts get-caller-identity --profile <profile>` and confirm the account with the user-provided target.
+2. Copy `infra/aws-provider-tests/terraform.tfvars.example` to `infra/aws-provider-tests/terraform.tfvars` if no local tfvars exists.
+3. Fill only non-secret values: region, owner, budget email, and tags.
+4. Run:
+
+```bash
+cd infra/aws-provider-tests
+AWS_PROFILE=<profile> tofu init
+AWS_PROFILE=<profile> tofu fmt -check
+AWS_PROFILE=<profile> tofu validate
+AWS_PROFILE=<profile> tofu plan -out tfplan
+```
+
+5. Review the plan for allowed resource classes only: S3, IAM policy/user attachment if enabled, Budget.
+6. Run `AWS_PROFILE=<profile> tofu apply tfplan` only after the plan is acceptable.
+7. Export the non-secret outputs needed by validation:
+
+```bash
+export FLOE_AWS_REGION=<region>
+export FLOE_AWS_TEST_BUCKET=<bucket>
+export FLOE_AWS_TEST_PREFIX=runs/
+export FLOE_AWS_GLUE_DATABASE_PREFIX=floe_provider_
+```
+
+8. Run `scripts/aws-provider-test-readiness.sh`.
+
+## Cleanup Workflow
+
+For a live provider run, set the current run ID:
+
+```bash
+export FLOE_PROVIDER_SPIKE_RUN=floe-provider-YYYYMMDDTHHMMSSZ
+```
+
+Then run:
+
+```bash
+scripts/aws-provider-test-cleanup.sh
+```
+
+If the whole scaffold is no longer needed:
+
+```bash
+cd infra/aws-provider-tests
+AWS_PROFILE=<profile> tofu destroy
+```
+
+After cleanup, report S3, Glue, and any optional DevPod/EC2 inventory separately.
+
+## Failure Classification
+
+- Product failure: Floe resolver, binding, runtime translator, renderer, or plugin behavior is wrong.
+- Provider failure: AWS auth, S3, Glue, IAM, region, endpoint, or API behavior rejects the test.
+- Infrastructure failure: OpenTofu, DevPod, Kind, network, or CLI setup fails before product validation.
+- Cleanup failure: current-run AWS resources remain after cleanup.
+```
+
+- [ ] **Step 3: Run skill hygiene checks**
+
+Run:
+
+```bash
+test -f .codex/skills/floe-aws-provider-testing/SKILL.md
+rg -n "AKIA|ASIA|aws_secret_access_key|AWS_SECRET_ACCESS_KEY|secret_access_key|BEGIN [A-Z ]*PRIVATE KEY" .codex/skills/floe-aws-provider-testing/SKILL.md
+```
+
+Expected:
+
+- `test -f` exits `0`.
+- `rg` exits `1` with no matches.
+
+- [ ] **Step 4: Commit skill**
+
+Run:
+
+```bash
+git add .codex/skills/floe-aws-provider-testing/SKILL.md
+git commit -m "docs: add Floe AWS provider testing skill"
+```
+
+## Task 5: Final Validation And Evidence
+
+**Files:**
+
+- Validate all files changed by Tasks 1-4.
+- Optionally create validation note only if a live AWS or OpenTofu command is skipped or fails for environmental reasons.
+
+- [ ] **Step 1: Run static validation**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --check HEAD
+uv run python testing/ci/validate-docs-navigation.py
+uv run python testing/ci/validate-docs-content.py
+bash -n scripts/aws-provider-test-readiness.sh
+bash -n scripts/aws-provider-test-cleanup.sh
+```
+
+Expected:
+
+- Worktree shows only intended changes if any remain uncommitted.
+- `git diff --check HEAD` reports no whitespace errors.
+- Docs validators pass.
+- Bash syntax checks pass.
+
+- [ ] **Step 2: Run OpenTofu validation when the CLI is available**
+
+Run:
+
+```bash
+tofu fmt -check infra/aws-provider-tests
+tofu init -backend=false -chdir=infra/aws-provider-tests
+tofu validate -chdir=infra/aws-provider-tests
+```
+
+Expected: all commands pass.
+
+If `tofu` is unavailable, do not install tooling silently. Report:
+
+```text
+SKIP: OpenTofu validation not run because tofu CLI is unavailable.
+```
+
+- [ ] **Step 3: Run focused secret scan**
+
+Run:
+
+```bash
+rg -n "AKIA|ASIA|aws_secret_access_key|AWS_SECRET_ACCESS_KEY|secret_access_key|BEGIN [A-Z ]*PRIVATE KEY|password\\s*=|token\\s*=|client_secret" \
+  infra/aws-provider-tests \
+  scripts/aws-provider-test-readiness.sh \
+  scripts/aws-provider-test-cleanup.sh \
+  docs/contributing/aws-provider-testing.md \
+  .codex/skills/floe-aws-provider-testing/SKILL.md
+```
+
+Expected: no matches except non-secret explanatory text if explicitly reviewed. Prefer zero matches.
+
+- [ ] **Step 4: Verify commit history and branch state**
+
+Run:
+
+```bash
+git log --oneline -5
+git status --short --branch
+```
+
+Expected:
+
+- Recent commits include the OpenTofu scaffold, helper scripts, guide, and skill.
+- Worktree is clean unless validation artifacts were intentionally left untracked.
+
+## Plan Self-Review
+
+Spec coverage:
+
+- OpenTofu scaffold: Task 1.
+- Minimal human guide: Task 3.
+- Reusable Codex skill: Task 4.
+- AWS readiness and cleanup evidence: Task 2 and Task 5.
+- Cost controls and explicit exclusions: Task 1, Task 3, Task 4.
+- No product provider implementation: out of scope in file map and tasks.
+
+Placeholder scan:
+
+- No placeholder-scan violations remain.
+- Human-provided values appear only in guide/skill prompt examples as `<profile-name>`, `<region>`, `<owner>`, and `<email>`.
+
+Execution note:
+
+- The implementation should not run `tofu apply`, `tofu destroy`, or live AWS cleanup unless the user explicitly provides AWS account/profile details and authorizes live AWS mutation.

--- a/docs/superpowers/specs/2026-05-11-provider-compatibility-spike-design.md
+++ b/docs/superpowers/specs/2026-05-11-provider-compatibility-spike-design.md
@@ -1,0 +1,332 @@
+# Provider Compatibility Spike Design
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Branch: `main`
+Status: Approved design
+
+## Purpose
+
+Validate whether Floe's merged plugin binding and composition model is
+provider-neutral enough to support additional storage and catalog providers
+without weakening the architecture constraints that now protect the alpha
+runtime path.
+
+This is an architecture validation spike, not a provider implementation
+project. It should produce a provider compatibility matrix, classify gaps, and
+define one live-service validation proof. It should not build production AWS,
+Glue, Nessie, GCS, or Azure support as part of the spike itself.
+
+The spike must preserve these rules:
+
+- Capabilities, requirements, typed bindings, and resolver validation own
+  cross-plugin compatibility.
+- Plugins do not know another plugin's concrete implementation details.
+- `CompiledArtifacts` remains secret-free.
+- Runtimes and renderers consume resolved deployment/runtime bindings.
+- Compatibility layers are introduced or retained only when the evidence proves
+  they are needed.
+
+## Success Criteria
+
+The spike is complete when it answers these questions with code and runtime
+evidence references:
+
+1. Which provider combinations are already expressible by the current model?
+2. Which combinations need new capability or requirement dimensions?
+3. Which combinations need new typed deployment or runtime binding fields?
+4. Which combinations need provider plugin implementation but no model change?
+5. Which combinations need runtime or renderer translation work?
+6. Which combinations should remain deferred until a concrete composition path
+   exists?
+7. Which live-service proof should be implemented first?
+
+The first live proof should target AWS S3 plus AWS Glue if credentials and
+cleanup controls are available. Nessie plus MinIO is the fallback because it
+exercises catalog variation while reusing the known storage lane.
+
+## Implemented System Map
+
+The spike starts from the implemented `main` system, not from historical plans.
+
+Current composition contracts:
+
+- `packages/floe-core/src/floe_core/composition/models.py`
+  - `CapabilitySet`
+  - `RequirementSet`
+  - `PluginCapabilities`
+  - `PluginRequirements`
+  - `CompositionIssue`
+  - `CompositionValidationResult`
+- `packages/floe-core/src/floe_core/composition/resolver.py`
+  - Validates storage, catalog, secrets, identity, and ingestion compatibility.
+  - Emits operator-facing `COMPOSITION_*` diagnostics where covered by the
+    public taxonomy.
+
+Current typed deployment and runtime bindings:
+
+- `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+  - `StorageDeploymentBinding`
+  - `CatalogDeploymentBinding`
+  - `IngestionDeploymentBinding`
+  - `RuntimeCatalogConnection`
+  - `CredentialRef`
+  - `StorageCredentialBinding`
+  - `DeploymentConfig`
+- `packages/floe-core/src/floe_core/runtime_catalog_connection.py`
+  - Derives a neutral `RuntimeCatalogConnection` from storage and catalog
+    deployment bindings.
+- `packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py`
+  - Translates `RuntimeCatalogConnection` into PyIceberg connection config.
+
+Current provider implementations and consumers:
+
+- `plugins/floe-storage-minio`
+  - Emits `StorageDeploymentBinding`.
+  - Provides the known-good S3-compatible storage baseline.
+- `plugins/floe-catalog-polaris`
+  - Declares storage requirements.
+  - Translates storage binding into `CatalogDeploymentBinding`.
+- `plugins/floe-compute-duckdb`
+  - Augments dbt profiles from compiled deployment projections.
+- `plugins/floe-ingestion-dlt`
+  - Declares storage/catalog requirements.
+  - Emits `IngestionDeploymentBinding` from composed storage and catalog
+    bindings.
+- `plugins/floe-orchestrator-dagster`
+  - Consumes `RuntimeCatalogConnection` for Dagster/Iceberg runtime paths.
+- `packages/floe-core/src/floe_core/cli/helm/generate.py`
+  - Renders platform Helm values from deployment bindings.
+
+Known-good baseline:
+
+- MinIO plus Polaris is the control path for the spike.
+- The current remote DevPod/Hetzner lane validates the merged runtime path and
+  separates infrastructure failures from product failures.
+
+Known compatibility and cleanup constraints:
+
+- Deprecated helper APIs must not be used as new cross-plugin contracts.
+- Provider-specific fields belong in provider-owned bindings unless they are
+  stable cross-provider concepts.
+- Protocol-level S3-compatible settings must stay distinct from the removed
+  legacy Floe storage plugin type `s3`.
+
+## Provider Matrix
+
+The spike must evaluate providers before implementation. Each row should carry a
+decision, required evidence, and next action.
+
+Initial matrix rows:
+
+| Provider combination | Purpose | Expected disposition |
+| --- | --- | --- |
+| MinIO + Polaris | Known-good baseline | Level 3 control path |
+| AWS S3 + AWS Glue | First preferred live proof | Primary compatibility target |
+| AWS S3 + Polaris or Iceberg REST | Native cloud storage with existing REST catalog style | Matrix target, live proof optional |
+| MinIO + Nessie | Fallback live proof with catalog variation | Fallback compatibility target |
+| AWS S3 + Nessie | Combined native storage and non-AWS catalog variation | Second-wave target |
+| GCS + future catalog | Pressure test for neutral storage concepts | Design-only unless product trigger exists |
+| Azure Blob or ADLS + future catalog | Pressure test for neutral identity and endpoint concepts | Design-only unless product trigger exists |
+| Hive catalog | Legacy catalog pressure test | Defer unless a concrete deployment path exists |
+
+Each row must record:
+
+- Storage provider.
+- Catalog provider.
+- Runtime consumers.
+- Table format.
+- Deployment ownership.
+- Credential model.
+- Identity model.
+- Endpoint shape.
+- Warehouse ownership.
+- Server-side storage access requirement.
+- Runtime projection needs.
+- Renderer projection needs.
+- Secret-free proof.
+- Live proof requirements.
+- Cleanup requirements.
+
+## Gap Classification
+
+Each provider gap must be classified into exactly one primary category:
+
+| Category | Meaning | Example action |
+| --- | --- | --- |
+| No change | Current model already expresses the provider path | Add or identify validation evidence |
+| Capability-only gap | Resolver needs another compatibility dimension | Add capability and requirement fields |
+| Typed binding gap | Current bindings cannot carry required secret-free state | Add neutral or provider-owned binding fields |
+| Provider plugin gap | Model is sufficient, but provider plugin does not exist | Plan provider implementation separately |
+| Runtime translator gap | Binding exists, but runtime library translation is missing | Add translator tests and implementation plan |
+| Renderer gap | Deployment output cannot be generated from bindings yet | Add renderer contract work |
+| Live validation gap | Static evidence is sufficient for design, but real service proof is missing | Define live lane and resource cleanup |
+| Out of scope | Provider path lacks a concrete composition trigger | Record deferral reason |
+
+Decision rules:
+
+- If a provider requires only different constants or endpoint values, do not add
+  a new abstraction.
+- If two or more providers need the same concept, consider a neutral binding
+  field.
+- If only one provider needs a concept, keep it under that provider's binding.
+- If a provider needs raw credential values in `CompiledArtifacts`, reject the
+  design.
+- If runtime code must rediscover plugin config to execute, the design is
+  incomplete.
+- If one plugin must inspect another plugin's class or config shape, reject the
+  approach.
+
+## Live-Service Validation Plan
+
+The spike should define, but not yet implement, one live-service validation lane.
+
+### Preferred Lane: AWS S3 Plus AWS Glue
+
+This lane proves native cloud storage and managed catalog compatibility.
+
+Required live resources:
+
+- Dedicated S3 bucket or prefixed test warehouse.
+- Glue database/catalog namespace.
+- IAM role, workload identity, or secret-backed credentials scoped to the test.
+- Temporary Iceberg test table or namespace.
+- DevPod/Hetzner workspace for the remote Floe validation environment.
+
+Required product proof:
+
+- Floe compiles a provider selection into secret-free `CompiledArtifacts`.
+- Resolver accepts a valid AWS S3 plus Glue combination.
+- Resolver rejects incompatible credential, identity, or storage access modes.
+- Runtime config is derived from typed bindings.
+- PyIceberg or the selected runtime creates, lists, reads, or writes an Iceberg
+  table through Glue and S3.
+- Logs and artifacts do not contain raw credentials.
+
+Required cleanup proof:
+
+- DevPod workspace is deleted.
+- Hetzner servers, volumes, SSH keys, load balancers, and floating IPs are
+  directly inventoried and removed if current-run resources remain.
+- AWS S3 test objects and buckets or prefixes are deleted.
+- Glue databases, tables, and temporary catalog resources are deleted.
+- IAM test roles, policies, access keys, or session resources are verified
+  removed or confirmed external and reusable.
+
+### Fallback Lane: Nessie Plus MinIO
+
+This lane proves catalog variation while avoiding cloud IAM and AWS billing
+surface area.
+
+Required proof:
+
+- Nessie declares catalog/storage requirements that compose with MinIO.
+- Typed catalog binding captures the Nessie endpoint and Iceberg runtime needs.
+- Runtime config is derived from deployment bindings.
+- Iceberg table create/read/write succeeds against Nessie and MinIO.
+- No raw credentials appear in compiled artifacts or logs.
+- DevPod/Hetzner resources are cleaned up with direct provider inventory.
+
+## Validation Lanes
+
+The spike should define evidence for five validation lanes.
+
+### Static Lane
+
+Required evidence:
+
+- Resolver tests for compatible and incompatible provider combinations.
+- Schema tests for any proposed capability or binding changes.
+- Secret-free contract tests for compiled artifacts.
+- Search evidence that runtime/renderers are not rediscovering plugin config.
+
+### Renderer Lane
+
+Required evidence:
+
+- Generated deployment values are derived from typed bindings.
+- Provider-specific deployment fields live under provider-owned projections.
+- Helm or renderer output references secrets by name/key only.
+- No renderer consults raw plugin config to make compatibility decisions.
+
+### Runtime Lane
+
+Required evidence:
+
+- `RuntimeCatalogConnection` or the relevant typed binding translates to
+  PyIceberg, Dagster, dlt, and dbt inputs where applicable.
+- Missing optional provider fields degrade explicitly rather than falling back
+  to deprecated helper APIs.
+- Runtime translators do not accept raw secret material.
+
+### Live Lane
+
+Required evidence:
+
+- Real provider service calls succeed.
+- The exact runtime artifact used in the live call is preserved.
+- Product failures, provider failures, and infra failures are classified
+  separately.
+- The lane records concrete resource names and cleanup status.
+
+### Cleanup Lane
+
+Required evidence:
+
+- Direct inventory is used for every billable provider involved.
+- Current-run resources are identified by unique run name or prefix.
+- Cleanup is verified after tool-level deletion.
+- Any intentionally retained external resource is named and justified.
+
+## Failure Classification
+
+Live validation must classify failures before recommending fixes.
+
+| Classification | Meaning |
+| --- | --- |
+| Product failure | Floe resolver, binding, runtime translation, renderer, or plugin behavior is wrong |
+| Provider failure | Cloud or catalog provider rejects auth, permissions, region, endpoint, warehouse, or API usage |
+| Infrastructure failure | DevPod, Hetzner, Kind, Flux, network, or provisioning fails before product validation |
+| Cleanup failure | Billable or test resources remain after the run |
+| Tooling warning | Non-fatal wrapper or tunnel behavior occurs after artifacts and cleanup prove the result |
+
+## Security Requirements
+
+The spike must not weaken existing secret handling.
+
+- `CompiledArtifacts` must not contain raw access keys, secret keys, client
+  secrets, OAuth tokens, passwords, or bearer tokens.
+- Credentials must be represented as `CredentialRef`, environment variable
+  names, workload identity references, or provider-managed identity metadata.
+- Live-service logs must be scanned or reviewed for raw credential exposure.
+- Provider cleanup commands must not print secret values.
+- Any proposed AWS lane must prefer temporary or least-privilege credentials.
+
+## Out Of Scope
+
+- Full AWS S3 storage plugin implementation.
+- Full AWS Glue catalog plugin implementation.
+- Full Nessie, GCS, Azure, or Hive support.
+- Compatibility shims without evidence.
+- Removing existing compatibility APIs during the spike design.
+- Mutating retired feature worktrees.
+- Treating historical plans or specs as current behavior.
+- Adding raw secret values to compiled artifacts, generated Helm values, logs,
+  or runtime config.
+
+## Recommended Outcome
+
+Proceed with a contract-first provider compatibility spike:
+
+1. Complete the provider matrix against the implemented binding/composition
+   model.
+2. Classify each gap with the gap taxonomy above.
+3. Recommend the first implementation unit.
+4. Define the first live validation lane.
+5. Use AWS S3 plus AWS Glue as the preferred live target if credentials and
+   cleanup guardrails are available.
+6. Use Nessie plus MinIO as the fallback live target if AWS access is not
+   available or not safe to use for the first proof.
+
+The next step after this spec is an implementation plan for the spike artifacts:
+the matrix document, evidence-gathering commands, and live validation runbook.

--- a/docs/superpowers/specs/2026-05-12-aws-provider-test-account-design.md
+++ b/docs/superpowers/specs/2026-05-12-aws-provider-test-account-design.md
@@ -1,0 +1,295 @@
+# AWS Provider Test Account Design
+
+## Goal
+
+Create a repeatable, low-cost AWS test-account setup for Floe provider
+compatibility validation. The setup must let an AI agent provision and validate
+the AWS testing environment with minimal human setup, while keeping the human
+guide focused on the AWS account prerequisites that cannot safely be automated
+from inside the repository.
+
+This design supports the deferred AWS S3 plus AWS Glue provider compatibility
+path identified by the provider spike. It does not implement the AWS storage or
+Glue catalog plugins. It prepares the account, IAM, cost controls, IaC, and
+agent workflow needed to run those tests once the provider implementation
+exists.
+
+## Current Context
+
+Floe already has a remote validation lane based on DevPod plus Hetzner. That
+lane remains the control path for heavyweight contributor validation. The
+provider compatibility spike recommends AWS S3 plus AWS Glue as the first
+native cloud provider proof, with Nessie plus MinIO as a fallback when AWS
+access is unavailable.
+
+The current repository has no AWS DevPod target and no repo-owned AWS
+OpenTofu scaffold for provider testing. Existing AWS references are mostly
+architecture docs, provider-matrix docs, and future plugin references.
+
+## Principles
+
+- Keep provider contracts composable: capabilities, requirements, typed
+  bindings, and resolver validation own cross-plugin compatibility.
+- Keep `CompiledArtifacts` secret-free.
+- Keep Helm/renderers and runtime code consuming resolved deployment bindings,
+  not rediscovering AWS config.
+- Prefer temporary or scoped credentials over long-lived access keys.
+- Make AWS setup repeatable through OpenTofu, not console instructions.
+- Make cleanup evidence mandatory for every live run.
+- Keep the default cost profile close to zero when no validation is running.
+- Separate product failures, provider failures, infrastructure failures, and
+  cleanup failures in all runbooks.
+
+## Recommended Approach
+
+Use a repo-owned OpenTofu scaffold plus a short human guide and a reusable
+Codex skill.
+
+The human guide explains only what a person must prepare before an agent can
+act: an AWS account, budget recipient, admin or bootstrap credentials, region
+choice, and any organization-specific guardrails. The OpenTofu scaffold owns
+test bucket, IAM, budgets, lifecycle policy, and outputs. The Codex skill owns
+the repeatable agent procedure for applying, validating, using, and destroying
+the environment.
+
+This is stronger than a guide-only design because it avoids copy/paste drift.
+It is smaller than a full AWS platform migration because EKS, NAT Gateways,
+Glue jobs, crawlers, and long-running EC2 are not required for the first
+provider proof.
+
+## Deliverables
+
+### 1. Human Setup Guide
+
+Path:
+
+- `docs/contributing/aws-provider-testing.md`
+
+The guide should cover:
+
+- Purpose of the AWS test account.
+- Required human-owned prerequisites:
+  - AWS account or sandbox account available for destructive testing.
+  - Permission to create IAM roles, S3 buckets, Glue databases, and Budgets.
+  - Approved AWS region.
+  - Budget alert email address.
+  - Local AWS CLI authentication path for the agent, such as SSO profile or
+    administrator bootstrap profile.
+  - Confirmation that no production or customer data will be used.
+- What the agent will create with OpenTofu.
+- What the agent must never create by default.
+- How contributors hand an AWS profile and variables to the agent.
+- How to verify the account is clean after a run.
+
+The guide should not be a long manual console walkthrough. Its job is to make
+the human-agent handoff clear and safe.
+
+### 2. OpenTofu Scaffold
+
+Path:
+
+- `infra/aws-provider-tests/`
+
+The scaffold should create the minimum AWS resources needed for live provider
+tests:
+
+- Reusable S3 test bucket.
+- Public access block for the bucket.
+- Server-side encryption for the bucket.
+- Lifecycle rule for `runs/` prefixes.
+- Abort-incomplete-multipart-upload lifecycle rule.
+- IAM role or policy for provider tests with scoped S3 and Glue access.
+- Optional IAM user/access key only if a role-assumption flow is not practical;
+  this should be disabled by default.
+- AWS Budget with a low configurable monthly threshold.
+- Common resource tags.
+- Outputs for bucket name, region, role ARN, run-prefix convention, Glue
+  database prefix, and recommended environment variables.
+
+The scaffold should not create:
+
+- EKS clusters.
+- NAT Gateways.
+- Always-on EC2 instances.
+- Glue jobs or crawlers.
+- Lake Formation resources.
+- S3 Tables resources.
+- Production deployment resources.
+- Repository-stored secrets.
+
+### 3. AWS DevPod Target
+
+The first implementation should leave AWS DevPod as an optional extension, not
+the default provider-test requirement.
+
+When added, it should provide:
+
+- `.devcontainer/aws/devcontainer.json`.
+- Make/script configuration that can select `DEVPOD_PROVIDER=aws`.
+- Configurable instance type, disk size, region, and tags.
+- Workspace deletion after validation.
+- Direct AWS inventory evidence for EC2 instances, volumes, security groups, and
+  any provider-created SSH keys.
+
+AWS DevPod plus Kind is useful for network locality and EC2 instance-profile
+testing. It is not a substitute for EKS Pod Identity or IRSA validation.
+
+### 4. Reusable Codex Skill
+
+Path:
+
+- `.codex/skills/floe-aws-provider-testing/`
+
+The skill should be concise and procedural. It should trigger when an agent is
+asked to set up, validate, run, or clean up the Floe AWS provider testing
+environment.
+
+The skill should include:
+
+- `SKILL.md` with the core workflow.
+- Optional scripts or references only when they prevent fragile repetition.
+- A strict preflight checklist:
+  - Confirm repository path and branch.
+  - Confirm AWS account ID and region.
+  - Confirm the OpenTofu working directory.
+  - Confirm no production resources are targeted.
+  - Confirm budget and cleanup expectations.
+- Apply workflow:
+  - `tofu init`.
+  - `tofu plan`.
+  - Review resource classes and cost-sensitive resources.
+  - `tofu apply` only when authorized.
+- Validation workflow:
+  - `aws sts get-caller-identity`.
+  - S3 bucket and prefix checks.
+  - Glue database/table permissions checks.
+  - Secret scan for generated local artifacts.
+- Cleanup workflow:
+  - Delete current-run Glue databases and tables.
+  - Empty current-run S3 prefixes.
+  - Run `tofu destroy` when the test account scaffold is no longer needed.
+  - Re-inventory AWS resources after cleanup.
+- Failure classification:
+  - Product failure.
+  - Provider failure.
+  - Infrastructure failure.
+  - Cleanup failure.
+
+The skill should not contain account-specific IDs, credentials, or long
+provider documentation. Detailed AWS reference material should remain in the
+repo guide or linked official docs.
+
+## Configuration Model
+
+The OpenTofu scaffold should be driven by explicit variables:
+
+- `aws_region`
+- `name_prefix`
+- `owner`
+- `budget_email`
+- `monthly_budget_limit_usd`
+- `s3_bucket_name`
+- `s3_run_prefix`
+- `glue_database_prefix`
+- `enable_access_key_user`
+- `enable_aws_devpod_permissions`
+- `common_tags`
+
+Default values should be safe:
+
+- Low monthly budget.
+- Short lifecycle retention for `runs/`.
+- AWS DevPod permissions disabled.
+- Access-key user disabled.
+- No production-like names.
+
+The guide should show a minimal `terraform.tfvars` example and a local-only
+override file pattern. No generated state or secret material should be committed.
+
+## Runtime Data Flow
+
+1. Human creates or selects the AWS sandbox account and authentication method.
+2. Agent runs OpenTofu from `infra/aws-provider-tests/`.
+3. OpenTofu emits the provider-test bucket, IAM role or policy, budget, tags,
+   and environment-variable hints.
+4. Agent exports the generated AWS test configuration.
+5. Floe provider validation creates per-run S3 prefixes and Glue databases.
+6. Validation captures resolver, binding, runtime translation, live read/write,
+   and secret-scan evidence.
+7. Cleanup removes current-run resources and verifies no current-run AWS
+   resources remain.
+
+No AWS credentials flow through `CompiledArtifacts`.
+
+## Evidence Required
+
+Static evidence:
+
+- `tofu fmt -check`
+- `tofu validate`
+- `tofu plan` showing only expected resource classes
+- Markdown docs validation
+- Secret scan over guide, IaC, skill, and generated examples
+
+AWS readiness evidence:
+
+- AWS caller identity and account ID match the approved sandbox.
+- S3 bucket exists with public access blocked.
+- S3 lifecycle rule covers `runs/`.
+- Glue read/create/delete permissions work against the test database prefix.
+- Budget exists with the configured alert email.
+- IAM policy scope is limited to test resources.
+
+Live run evidence:
+
+- Unique run ID.
+- Resolved provider-test environment variables.
+- Compiled artifact secret scan.
+- Runtime catalog/storage config derived from typed bindings.
+- Live S3 write/read/delete result.
+- Live Glue database/table create/list/drop result.
+- Post-run S3 and Glue cleanup inventory.
+
+AWS DevPod evidence, when enabled:
+
+- DevPod provider and workspace identity.
+- EC2 instance type, region, tags, and deletion result.
+- Direct AWS inventory after cleanup for instances, volumes, and security
+  groups matching the run prefix.
+
+## Cost Controls
+
+The default path should incur only negligible ongoing cost:
+
+- S3 storage only for temporary test artifacts.
+- Glue Data Catalog metadata only during test runs.
+- Budget alert always present.
+- Lifecycle rules remove stale `runs/` data.
+- No NAT Gateway.
+- No EKS.
+- No always-on EC2.
+- No Glue jobs or crawlers.
+
+Any optional AWS DevPod run must delete its workspace after validation and
+perform direct AWS inventory before declaring cleanup complete.
+
+## Out Of Scope
+
+- Implementing `floe-storage-aws-s3`.
+- Implementing `floe-catalog-glue`.
+- Migrating Floe product deployment to AWS.
+- Adding EKS, IRSA, or EKS Pod Identity validation.
+- Adding Lake Formation or S3 Tables validation.
+- Replacing the existing Hetzner DevPod lane.
+- Storing AWS secrets in the repository.
+- Running live AWS validation without explicit account and cleanup approval.
+
+## Approval Criteria
+
+This design is ready for implementation planning when the approved plan covers:
+
+- OpenTofu scaffold tasks.
+- Human guide tasks.
+- Codex skill tasks.
+- Validation tasks for docs, OpenTofu, secret scanning, and AWS readiness.
+- Cleanup tasks that directly inventory AWS resources after every live run.

--- a/docs/validation/2026-05-11-provider-compatibility-final-recommendation.md
+++ b/docs/validation/2026-05-11-provider-compatibility-final-recommendation.md
@@ -1,0 +1,75 @@
+# Provider Compatibility Final Recommendation
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Closeout recommendation for the provider compatibility spike.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+| --- | --- |
+| `docs/validation/2026-05-11-provider-compatibility-system-map.md` | Implemented model and source map |
+| `docs/validation/2026-05-11-provider-compatibility-matrix.md` | Provider matrix and Level decisions |
+| `docs/validation/2026-05-11-provider-compatibility-gap-ledger.md` | Gap classification and next action |
+| `docs/validation/2026-05-11-provider-compatibility-live-runbook.md` | Live AWS/Glue and Nessie/MinIO validation plan |
+
+## Recommendation
+
+Proceed with AWS S3 plus AWS Glue as the first provider compatibility
+implementation design if AWS credentials and cleanup controls are available.
+Otherwise proceed with Nessie plus MinIO as the first live proof while keeping
+AWS S3 plus AWS Glue as the primary provider matrix target.
+
+AWS S3 plus Glue is the stronger first target because it stresses the full
+composition model: native cloud storage, managed catalog semantics, IAM,
+credential and identity modes, PyIceberg runtime translation, and external
+provider cleanup. Nessie plus MinIO is the safer fallback because it validates
+catalog variation without adding cloud-provider billing and IAM surface area.
+
+## First Implementation Unit
+
+Recommended first implementation unit:
+
+- Design native AWS S3 storage binding and AWS Glue catalog binding against the
+  current composition model.
+- Add resolver tests for AWS credential and identity modes.
+- Add secret-free compiled artifact tests.
+- Add runtime translator proof for PyIceberg Glue config derived from typed
+  bindings.
+- Keep live AWS validation behind the runbook readiness gate.
+
+The first implementation unit should remain design/test-led. It should not add
+literal AWS credential values to `CompiledArtifacts`, should not introduce a
+compatibility shim around deprecated helper APIs, and should not let runtime
+code rediscover provider config outside typed bindings.
+
+## Fallback Implementation Unit
+
+Recommended fallback implementation unit:
+
+- Design Nessie catalog binding that composes with existing MinIO storage
+  binding.
+- Add resolver tests for MinIO plus Nessie compatibility.
+- Add runtime translator proof for Nessie Iceberg catalog config.
+- Use the fallback live lane to validate catalog variation without AWS
+  resources.
+
+The fallback is appropriate if AWS credentials, IAM scope, or cleanup controls
+are not ready. It should not be treated as proof that native cloud storage is
+complete.
+
+## Explicit Deferrals
+
+- GCS and Azure remain design pressure tests until a concrete provider path
+  exists.
+- Hive remains deferred until a concrete deployment path exists.
+- Deprecated compatibility helpers are not new provider contracts.
+- Raw credentials in `CompiledArtifacts` remain forbidden.
+- Live AWS or DevPod validation has not been run as part of this spike
+  artifact set.
+
+## Closeout Status
+
+The provider compatibility spike artifacts are complete when this document is
+committed after the system map, matrix, gap ledger, and live runbook, and the
+worktree is clean after the final commit.

--- a/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
+++ b/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
@@ -22,11 +22,11 @@ Purpose: Classify provider compatibility gaps before implementation.
 | Gap | Provider path | Category | Evidence | Recommended next action |
 | --- | --- | --- | --- | --- |
 | Native AWS S3 storage provider absent | AWS S3 + Glue; AWS S3 + Nessie | Provider plugin gap | Entry point inventory has no `floe-storage-aws-s3` plugin | Design native S3 storage plugin after matrix approval |
-| AWS credential and identity modes need proof against resolver | AWS S3 + Glue | Capability-only gap | Current composition model includes credential and identity modes but AWS provider declarations do not exist | Define AWS provider requirements and resolver tests in the first implementation unit |
+| AWS credential and identity modes need proof against resolver | AWS S3 + Glue; AWS S3 + Nessie | Capability-only gap | Current composition model includes credential and identity modes but AWS provider declarations do not exist | Define AWS provider requirements and resolver tests in the first implementation unit |
 | Glue catalog binding absent | AWS S3 + Glue | Provider plugin gap and typed binding gap | Entry point inventory has no Glue catalog plugin and current catalog binding has Polaris-specific provider detail only | Design Glue catalog provider-owned binding before implementation |
 | PyIceberg Glue translation not proven from `RuntimeCatalogConnection` | AWS S3 + Glue | Runtime translator gap | Current runtime translator handles generic URI/warehouse/S3 properties, not proven Glue catalog properties | Add translator proof or a Glue-specific runtime projection in a follow-up spec |
 | Nessie catalog provider absent | MinIO + Nessie; AWS S3 + Nessie | Provider plugin gap and typed binding gap | Entry point inventory has no Nessie catalog plugin | Design Nessie catalog binding if selected as fallback live proof |
-| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap and typed binding pressure test | No current provider plugin or runtime translation evidence | Keep as design pressure tests, not first implementation |
+| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap and Typed binding gap | No current provider plugin or runtime translation evidence | Keep as design pressure tests, not first implementation |
 | Hive lacks concrete alpha path | Hive | Out of scope | No current deployment trigger in the approved spike | Defer until a product path exists |
 
 ## Compatibility Helper Decision

--- a/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
+++ b/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
@@ -23,10 +23,10 @@ Purpose: Classify provider compatibility gaps before implementation.
 | --- | --- | --- | --- | --- |
 | Native AWS S3 storage provider absent | AWS S3 + Glue; AWS S3 + Nessie | Provider plugin gap | Entry point inventory has no `floe-storage-aws-s3` plugin | Design native S3 storage plugin after matrix approval |
 | AWS credential and identity modes need proof against resolver | AWS S3 + Glue; AWS S3 + Nessie | Capability-only gap | Current composition model includes credential and identity modes but AWS provider declarations do not exist | Define AWS provider requirements and resolver tests in the first implementation unit |
-| Glue catalog binding absent | AWS S3 + Glue | Provider plugin gap and typed binding gap | Entry point inventory has no Glue catalog plugin and current catalog binding has Polaris-specific provider detail only | Design Glue catalog provider-owned binding before implementation |
+| Glue catalog binding absent | AWS S3 + Glue | Provider plugin gap | Entry point inventory has no Glue catalog plugin; implementation design must also decide whether Glue needs a provider-owned typed binding | Design Glue catalog provider and binding before implementation |
 | PyIceberg Glue translation not proven from `RuntimeCatalogConnection` | AWS S3 + Glue | Runtime translator gap | Current runtime translator handles generic URI/warehouse/S3 properties, not proven Glue catalog properties | Add translator proof or a Glue-specific runtime projection in a follow-up spec |
-| Nessie catalog provider absent | MinIO + Nessie; AWS S3 + Nessie | Provider plugin gap and typed binding gap | Entry point inventory has no Nessie catalog plugin | Design Nessie catalog binding if selected as fallback live proof |
-| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap and Typed binding gap | No current provider plugin or runtime translation evidence | Keep as design pressure tests, not first implementation |
+| Nessie catalog provider absent | MinIO + Nessie; AWS S3 + Nessie | Provider plugin gap | Entry point inventory has no Nessie catalog plugin; implementation design must also decide the Nessie catalog binding shape | Design Nessie catalog provider and binding if selected as fallback live proof |
+| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap | No current provider plugin or runtime translation evidence; use these as pressure tests for future binding fields | Keep as design pressure tests, not first implementation |
 | Hive lacks concrete alpha path | Hive | Out of scope | No current deployment trigger in the approved spike | Defer until a product path exists |
 
 ## Compatibility Helper Decision

--- a/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
+++ b/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
@@ -1,0 +1,45 @@
+# Provider Compatibility Gap Ledger
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Classify provider compatibility gaps before implementation.
+
+## Gap Categories
+
+| Category | Meaning |
+| --- | --- |
+| No change | Current model already expresses the provider path |
+| Capability-only gap | Resolver needs another compatibility dimension |
+| Typed binding gap | Current bindings cannot carry required secret-free state |
+| Provider plugin gap | Model is sufficient, but provider plugin does not exist |
+| Runtime translator gap | Binding exists, but runtime library translation is missing |
+| Renderer gap | Deployment output cannot be generated from bindings yet |
+| Live validation gap | Real service proof is missing |
+| Out of scope | Provider path lacks a concrete composition trigger |
+
+## Gaps
+
+| Gap | Provider path | Category | Evidence | Recommended next action |
+| --- | --- | --- | --- | --- |
+| Native AWS S3 storage provider absent | AWS S3 + Glue; AWS S3 + Nessie | Provider plugin gap | Entry point inventory has no `floe-storage-aws-s3` plugin | Design native S3 storage plugin after matrix approval |
+| AWS credential and identity modes need proof against resolver | AWS S3 + Glue | Capability-only gap | Current composition model includes credential and identity modes but AWS provider declarations do not exist | Define AWS provider requirements and resolver tests in the first implementation unit |
+| Glue catalog binding absent | AWS S3 + Glue | Provider plugin gap and typed binding gap | Entry point inventory has no Glue catalog plugin and current catalog binding has Polaris-specific provider detail only | Design Glue catalog provider-owned binding before implementation |
+| PyIceberg Glue translation not proven from `RuntimeCatalogConnection` | AWS S3 + Glue | Runtime translator gap | Current runtime translator handles generic URI/warehouse/S3 properties, not proven Glue catalog properties | Add translator proof or a Glue-specific runtime projection in a follow-up spec |
+| Nessie catalog provider absent | MinIO + Nessie; AWS S3 + Nessie | Provider plugin gap and typed binding gap | Entry point inventory has no Nessie catalog plugin | Design Nessie catalog binding if selected as fallback live proof |
+| GCS and Azure credential/endpoint models are unproven | GCS; Azure | Capability-only gap and typed binding pressure test | No current provider plugin or runtime translation evidence | Keep as design pressure tests, not first implementation |
+| Hive lacks concrete alpha path | Hive | Out of scope | No current deployment trigger in the approved spike | Defer until a product path exists |
+
+## Compatibility Helper Decision
+
+Do not use deprecated helper APIs as new provider contracts. New provider work must flow through capabilities, requirements, typed bindings, resolver validation, and runtime/renderer translators.
+
+## Secret-Free Decision
+
+Provider compatibility is invalid if it requires raw access keys, secret keys, tokens, client secrets, passwords, or bearer tokens inside `CompiledArtifacts`.
+
+## First Follow-Up Recommendation
+
+Recommend one implementation unit and one live validation lane based on the matrix:
+
+- Primary path: AWS S3 plus AWS Glue provider compatibility design if AWS credentials and cleanup controls are available.
+- Fallback path: Nessie plus MinIO provider compatibility design if AWS access is unavailable.

--- a/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
+++ b/docs/validation/2026-05-11-provider-compatibility-gap-ledger.md
@@ -35,7 +35,8 @@ Do not use deprecated helper APIs as new provider contracts. New provider work m
 
 ## Secret-Free Decision
 
-Provider compatibility is invalid if it requires raw access keys, secret keys, tokens, client secrets, passwords, or bearer tokens inside `CompiledArtifacts`.
+Provider compatibility is invalid if it requires literal credential values,
+tokens, client secrets, passwords, or bearer tokens inside `CompiledArtifacts`.
 
 ## First Follow-Up Recommendation
 

--- a/docs/validation/2026-05-11-provider-compatibility-live-runbook.md
+++ b/docs/validation/2026-05-11-provider-compatibility-live-runbook.md
@@ -108,14 +108,44 @@ devpod list
 Direct Hetzner inventory must check these resource classes for the current run prefix:
 
 ```bash
-servers
-volumes
-ssh_keys
-load_balancers
-floating_ips
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+HCLOUD_INVENTORY_TOKEN="${DEVPOD_HETZNER_TOKEN:-${HCLOUD_TOKEN:-}}"
+if [ -z "${HCLOUD_INVENTORY_TOKEN}" ]; then
+  echo "ERROR: set DEVPOD_HETZNER_TOKEN or HCLOUD_TOKEN before Hetzner inventory" >&2
+  exit 1
+fi
+
+if [ -z "${FLOE_PROVIDER_SPIKE_RUN:-}" ]; then
+  echo "ERROR: set FLOE_PROVIDER_SPIKE_RUN before Hetzner inventory" >&2
+  exit 1
+fi
+
+for resource_class in servers volumes ssh_keys load_balancers floating_ips; do
+  echo "== ${resource_class} matching ${FLOE_PROVIDER_SPIKE_RUN} =="
+  curl -fsS \
+    -H "Authorization: Bearer ${HCLOUD_INVENTORY_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://api.hetzner.cloud/v1/${resource_class}" \
+    | jq -r --arg class "${resource_class}" --arg run "${FLOE_PROVIDER_SPIKE_RUN}" '
+        .[$class]
+        | map(select((.name // "") | contains($run)))
+        | if length == 0 then
+            "no matches"
+          else
+            (["id", "name", "status"] | @tsv),
+            (.[] | [.id, (.name // "-"), (.status // "-")] | @tsv)
+          end
+      '
+done
 ```
 
-Final evidence must state whether each class has no current-run resources remaining.
+Final evidence must state whether each class has no current-run resources remaining. Delete only current-run matches in a later cleanup step using the provider API or `devpod delete`.
 
 ## DevPod Evidence Source
 

--- a/docs/validation/2026-05-11-provider-compatibility-live-runbook.md
+++ b/docs/validation/2026-05-11-provider-compatibility-live-runbook.md
@@ -1,0 +1,122 @@
+# Provider Compatibility Live Validation Runbook
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Executable live-service validation plan for the provider compatibility spike.
+
+## Preconditions
+
+- Run from `main`.
+- Worktree is clean before validation.
+- DevPod is installed and has the Hetzner provider initialized.
+- `.env` contains `DEVPOD_HETZNER_TOKEN` or the environment contains `HCLOUD_TOKEN`.
+- AWS live proof requires explicit user approval that AWS credentials are available and scoped for the test.
+- Do not run live AWS cleanup commands against shared resources unless the resource names match the current run prefix.
+
+## Failure Classification
+
+| Classification | Meaning |
+| --- | --- |
+| Product failure | Floe resolver, binding, runtime translation, renderer, or plugin behavior is wrong |
+| Provider failure | AWS, Glue, S3, Nessie, or catalog provider rejects auth, permissions, region, endpoint, warehouse, or API usage |
+| Infrastructure failure | DevPod, Hetzner, Kind, Flux, network, or provisioning fails before product validation |
+| Cleanup failure | Billable or test resources remain after the run |
+| Tooling warning | Non-fatal wrapper or tunnel behavior occurs after artifacts and cleanup prove the result |
+
+## Preferred Lane: AWS S3 Plus AWS Glue
+
+### Resource Naming
+
+Use a unique run prefix:
+
+```bash
+export FLOE_PROVIDER_SPIKE_RUN="floe-provider-$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+All AWS resources created for the proof must include `${FLOE_PROVIDER_SPIKE_RUN}` in the name or tags.
+
+### Readiness Checks
+
+```bash
+git status --short --branch
+devpod list
+aws sts get-caller-identity
+aws s3api list-buckets --query 'Buckets[].Name' --output text
+aws glue get-databases --max-results 1
+```
+
+Expected:
+
+- Git branch is `main`.
+- DevPod list is empty or has no current-run workspace.
+- AWS caller identity succeeds.
+- S3 and Glue list commands succeed with the intended test account.
+
+### Product Validation Shape
+
+The live proof should preserve these artifacts:
+
+- Compiled artifact JSON.
+- Resolver decision output.
+- Runtime catalog connection projection.
+- PyIceberg or runtime config derived from bindings.
+- Live create/list/read/write output.
+- Secret scan output for artifacts and logs.
+
+### AWS Cleanup
+
+Cleanup must verify these resource classes:
+
+```bash
+aws glue get-databases
+aws glue get-tables --database-name "${FLOE_PROVIDER_SPIKE_RUN}"
+aws s3api list-objects-v2 --bucket "${FLOE_PROVIDER_SPIKE_RUN}" --max-items 10
+aws s3api head-bucket --bucket "${FLOE_PROVIDER_SPIKE_RUN}"
+aws iam list-roles --query "Roles[?contains(RoleName, '${FLOE_PROVIDER_SPIKE_RUN}')].RoleName"
+aws iam list-policies --scope Local --query "Policies[?contains(PolicyName, '${FLOE_PROVIDER_SPIKE_RUN}')].Arn"
+```
+
+Expected after cleanup:
+
+- Glue database and tables created for the run are absent.
+- S3 bucket or prefix created for the run is absent or empty and retained only if explicitly approved.
+- IAM roles and policies created for the run are absent.
+- Any external reusable credential or role is named in the final evidence and not deleted by the runbook.
+
+## Fallback Lane: Nessie Plus MinIO
+
+Use this lane when AWS access is unavailable or not safe for the first proof.
+
+Expected proof:
+
+- Nessie catalog service is deployed in the remote validation environment.
+- MinIO remains the storage provider.
+- Resolver accepts MinIO plus Nessie only when catalog requirements match storage capabilities.
+- Runtime catalog connection is derived from deployment bindings.
+- Iceberg table create/list/read/write succeeds.
+- DevPod and Hetzner resources are directly inventoried after cleanup.
+
+## DevPod And Hetzner Cleanup
+
+Use the existing remote lane shape:
+
+```bash
+DEVPOD_WORKSPACE="${FLOE_PROVIDER_SPIKE_RUN}" DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full make devpod-test
+devpod list
+```
+
+Direct Hetzner inventory must check these resource classes for the current run prefix:
+
+```bash
+servers
+volumes
+ssh_keys
+load_balancers
+floating_ips
+```
+
+Final evidence must state whether each class has no current-run resources remaining.
+
+## DevPod Evidence Source
+
+The existing remote lane wrapper documents `DEVPOD_WORKSPACE`, `DEVPOD_REMOTE_E2E_MAKE_TARGET`, and `DEVPOD_REMOTE_E2E_TIMEOUT` as the controls for workspace naming, remote make target selection, and remote timeout. The 2026-05-09 post-composition validation record shows prior use of `DEVPOD_WORKSPACE=floe-postcomp-audit make devpod-test`, `devpod list`, and direct Hetzner inventory for current-run servers, volumes, and SSH keys.

--- a/docs/validation/2026-05-11-provider-compatibility-matrix.md
+++ b/docs/validation/2026-05-11-provider-compatibility-matrix.md
@@ -1,0 +1,57 @@
+# Provider Compatibility Matrix
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Purpose: Provider-by-provider assessment against the merged binding/composition model.
+
+## Level Definitions
+
+| Level | Meaning | Evidence required |
+| --- | --- | --- |
+| 0 | Discoverable plugin only | Entry point, metadata, config schema |
+| 1 | Declares capabilities and requirements | `PluginCapabilities`, `PluginRequirements`, resolver tests |
+| 2 | Emits or consumes typed bindings | Contract model, schema tests, secret-free artifacts |
+| 3 | Runtime/deployment translated and validated | Resolver tests, binding output, renderer/runtime translation, E2E or live proof where applicable |
+
+## Matrix
+
+| Provider combination | Storage protocol | Catalog protocol | Credential mode | Identity mode | Endpoint shape | Warehouse ownership | Server-side storage access | Current expressibility | Required model change | Target level | Live proof |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| MinIO + Polaris | `s3-compatible` | Iceberg REST via Polaris | Kubernetes Secret | none | explicit internal/external endpoint, path-style | storage binding plus Polaris warehouse | yes, via referenced MinIO credentials | Expressed today | none | Level 3 | Existing DevPod/Hetzner E2E control path |
+| AWS S3 + AWS Glue | `s3` | Glue Catalog | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | regional AWS endpoints, optional custom endpoint for tests | S3 bucket/prefix plus Glue database/table metadata | yes, through AWS IAM | Partially expressible conceptually; provider plugins absent | native S3 storage plugin, Glue catalog binding, AWS identity/credential requirements, PyIceberg Glue translation proof | Level 3 target after implementation | Preferred live proof |
+| AWS S3 + Iceberg REST or Polaris | `s3` | Iceberg REST | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | AWS S3 regional endpoint plus REST catalog URI | storage owns bucket/prefix, catalog owns warehouse reference | depends on catalog deployment | Partially expressible conceptually; native S3 plugin absent | native S3 storage binding plus catalog-specific requirements | Level 2 or 3 depending on live catalog | Optional second proof |
+| MinIO + Nessie | `s3-compatible` | Nessie Iceberg catalog | Kubernetes Secret | none | MinIO path-style endpoint plus Nessie REST endpoint | storage bucket/prefix plus Nessie catalog branch/namespace | yes, if Nessie service accesses storage | MinIO side expressed; Nessie provider absent | Nessie catalog plugin and typed catalog binding | Level 3 fallback target | Fallback live proof |
+| AWS S3 + Nessie | `s3` | Nessie Iceberg catalog | workload identity or secret-backed AWS credentials | IRSA, AWS Pod Identity, or external AWS credentials | AWS S3 endpoint plus Nessie REST endpoint | S3 bucket/prefix plus Nessie branch/namespace | yes, if Nessie service accesses storage | Not implemented | native S3 storage plugin, Nessie catalog plugin, identity/credential binding proof | Level 3 second-wave target | Deferred live proof |
+| GCS + future catalog | `gcs` | provider-specific | workload identity or secret-backed service account | GCP Workload Identity or service account reference | GCS bucket URI and regional/multi-region behavior | GCS bucket/prefix plus catalog metadata | provider-dependent | Not implemented | GCS storage capability, credential mode, runtime translator pressure test | Level 1 or 2 design target | No first live proof |
+| Azure Blob or ADLS + future catalog | `abfs` or provider-specific | provider-specific | workload identity or secret-backed identity | Azure Workload Identity or managed identity | account/container/path endpoint | container/path plus catalog metadata | provider-dependent | Not implemented | Azure storage capability, identity mode, runtime translator pressure test | Level 1 or 2 design target | No first live proof |
+| Hive catalog | object-store dependent | Hive metastore | provider-dependent | provider-dependent | metastore URI plus object-store endpoint | storage path plus Hive metadata | yes | Not implemented and no concrete alpha trigger | defer until deployment path exists | Level 0 deferred | No live proof |
+
+## Entry Point Evidence
+
+The entry point inventory found first-party plugins for alert channels, Polaris catalog, DuckDB compute, dbt Core/Fusion, Keycloak identity, dlt ingestion, Marquez lineage, Kubernetes network security, Dagster orchestrator, dbt/GX quality, Kubernetes RBAC, Infisical/Kubernetes secrets, Cube semantic layer, MinIO storage, and console/Jaeger telemetry.
+
+Storage/catalog evidence is limited to:
+
+| Plugin package | Entry point group | Entry point names |
+| --- | --- | --- |
+| `floe-storage-minio` | `floe.storage` | `minio` |
+| `floe-catalog-polaris` | `floe.catalogs` | `polaris` |
+
+The inventory did not include entry points for AWS S3, AWS Glue, Nessie, GCS, Azure, ADLS, or Hive provider plugins. The `plugins/` directory likewise contains `floe-storage-minio` and `floe-catalog-polaris`, with no first-party `floe-storage-s3`, `floe-catalog-glue`, `floe-catalog-nessie`, `floe-storage-gcs`, `floe-storage-azure`, or `floe-catalog-hive` package.
+
+## Provider-Specific Assumption Search
+
+The provider-specific search found the current implemented assumptions concentrated around the MinIO + Polaris control path:
+
+- `plugins/floe-storage-minio/src/floe_storage_minio/plugin.py` emits `provider="minio"`, `protocol="s3-compatible"`, `s3.endpoint`, `s3.path-style-access`, bucket/warehouse bindings, dbt profile fragments, and Helm value fragments.
+- `plugins/floe-storage-minio/src/floe_storage_minio/config.py` documents `path_style_access` as required for MinIO and LocalStack.
+- `plugins/floe-catalog-polaris/src/floe_catalog_polaris/plugin.py` declares storage requirements for `s3-compatible` and `s3`, supports path-style access, builds Polaris deployment bindings from storage warehouse state, and re-applies client-side `s3.endpoint` to loaded PyIceberg tables.
+- `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`, `packages/floe-core/tests/unit/composition/test_resolver.py`, `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`, and `packages/floe-core/tests/unit/test_runtime_catalog_connection.py` assert MinIO/Polaris protocol compatibility, path-style access, secret-free bindings, and runtime catalog projection.
+- `tests/e2e/conftest.py`, `tests/e2e/dbt_utils.py`, and current E2E suites default runtime catalog access to Polaris plus MinIO endpoints and `s3.path-style-access=true`.
+- Architecture docs name future Glue, Hive, Nessie, GCS, and Azure paths, but targeted implementation search found those names only in docs and examples, not as production provider plugin packages or entry points.
+
+The search therefore supports treating MinIO + Polaris as the only Level 3 provider combination today, with AWS Glue, Nessie, GCS, Azure/ADLS, and Hive as future provider paths requiring new plugin and binding work.
+
+## Matrix Conclusion
+
+AWS S3 plus Glue is the preferred first live target because it stresses native cloud storage, managed catalog semantics, IAM, and PyIceberg runtime translation. Nessie plus MinIO is the fallback because it validates catalog variation without cloud-provider setup.

--- a/docs/validation/2026-05-11-provider-compatibility-system-map.md
+++ b/docs/validation/2026-05-11-provider-compatibility-system-map.md
@@ -5,13 +5,13 @@ Repo: `/Users/dmccarthy/Projects/floe`
 Branch: `main`
 Purpose: Source map for the provider compatibility spike.
 
-## Current Head
+## Baseline Head
 
 | Item | Evidence |
 | --- | --- |
 | Branch | `main` |
-| HEAD | `901cfbb404e8b5ccc140de1a63e7d42e80257fa6` |
-| Recent commits | `901cfbb4 docs: plan provider compatibility spike`<br>`7347e8cb docs: add provider compatibility spike design`<br>`d97785cd [codex] Binding-first Dagster Iceberg runtime (#328)`<br>`50670b79 [codex] Post-composition cleanup roadmap (#327)`<br>`d9e3582a Stabilize dlt ingestion through composability layers (#326)` |
+| Baseline HEAD before this artifact | `901cfbb404e8b5ccc140de1a63e7d42e80257fa6` |
+| Five recent commits captured before this artifact | `901cfbb4 docs: plan provider compatibility spike`<br>`7347e8cb docs: add provider compatibility spike design`<br>`d97785cd [codex] Binding-first Dagster Iceberg runtime (#328)`<br>`50670b79 [codex] Post-composition cleanup roadmap (#327)`<br>`d9e3582a Stabilize dlt ingestion through composability layers (#326)` |
 
 ## Composition Contracts
 

--- a/docs/validation/2026-05-11-provider-compatibility-system-map.md
+++ b/docs/validation/2026-05-11-provider-compatibility-system-map.md
@@ -1,0 +1,48 @@
+# Provider Compatibility Implemented-System Map
+
+Date: 2026-05-11
+Repo: `/Users/dmccarthy/Projects/floe`
+Branch: `main`
+Purpose: Source map for the provider compatibility spike.
+
+## Current Head
+
+| Item | Evidence |
+| --- | --- |
+| Branch | `main` |
+| HEAD | `901cfbb404e8b5ccc140de1a63e7d42e80257fa6` |
+| Recent commits | `901cfbb4 docs: plan provider compatibility spike`<br>`7347e8cb docs: add provider compatibility spike design`<br>`d97785cd [codex] Binding-first Dagster Iceberg runtime (#328)`<br>`50670b79 [codex] Post-composition cleanup roadmap (#327)`<br>`d9e3582a Stabilize dlt ingestion through composability layers (#326)` |
+
+## Composition Contracts
+
+| Contract | Source | Role |
+| --- | --- | --- |
+| `CapabilitySet` | `packages/floe-core/src/floe_core/composition/models.py` | Provider capability declaration |
+| `RequirementSet` | `packages/floe-core/src/floe_core/composition/models.py` | Provider requirement declaration |
+| `CompositionResolver` | `packages/floe-core/src/floe_core/composition/resolver.py` | Compatibility validation |
+| `COMPOSITION_*` diagnostics | `packages/floe-core/src/floe_core/composition/error_codes.py` | Operator-facing composition failures |
+
+## Typed Bindings
+
+| Binding | Source | Role |
+| --- | --- | --- |
+| `StorageDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free storage deployment state |
+| `CatalogDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free catalog deployment state |
+| `IngestionDeploymentBinding` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free ingestion runtime state |
+| `RuntimeCatalogConnection` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Neutral Iceberg runtime catalog projection |
+| `CredentialRef` | `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py` | Secret-free credential reference |
+
+## Current Provider Consumers
+
+| Consumer | Source | Current behavior |
+| --- | --- | --- |
+| MinIO storage | `plugins/floe-storage-minio/src/floe_storage_minio/plugin.py` | Emits `StorageDeploymentBinding` |
+| Polaris catalog | `plugins/floe-catalog-polaris/src/floe_catalog_polaris/plugin.py` | Declares storage requirements and emits `CatalogDeploymentBinding` |
+| dlt ingestion | `plugins/floe-ingestion-dlt/src/floe_ingestion_dlt/plugin.py` | Declares storage/catalog requirements and emits `IngestionDeploymentBinding` |
+| DuckDB compute | `plugins/floe-compute-duckdb/src/floe_compute_duckdb/plugin.py` | Augments dbt profile from deployment bindings |
+| Dagster runtime | `plugins/floe-orchestrator-dagster/src/floe_orchestrator_dagster/` | Consumes `RuntimeCatalogConnection` |
+| Helm renderer | `packages/floe-core/src/floe_core/cli/helm/generate.py` | Renders from deployment bindings |
+
+## Baseline Conclusion
+
+MinIO plus Polaris is the control path. New provider compatibility must either reuse the current neutral contracts or justify a new capability, binding, runtime translator, or renderer dimension.

--- a/infra/aws-provider-tests/.terraform.lock.hcl
+++ b/infra/aws-provider-tests/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = ">= 5.0.0, < 7.0.0"
+  hashes = [
+    "h1:nnkrhJv02OdUdVsoKca2veqHX06nCnheOJOx57YvL0s=",
+    "zh:2a61db8c7ab08a4df5302cbd36b6a5e4915d29270d2d0ade4baf2bd541d0ca04",
+    "zh:3b6fc9bcdec7c1ae2acfce7a258c32196f3218e9ed4089237b02ec31d7c97964",
+    "zh:3d50690ee83c7203b3aea6319c3b1c131354bd2ee027e56dc94b547e346f9c26",
+    "zh:46a49494db3589b6941f4405b7508d02381e6666d75c600f8b5656816aea9c9b",
+    "zh:51d334a594e167001b8ad4842d650495fe0118bcff7371c85256a10ac413dee3",
+    "zh:591fcf5e50ce0ef8caa666cc1534bb3e338ff71279e8ad162aa2a81c87598618",
+    "zh:5f470c6880033f27aff77fa1d9c54ab32c7daae3f617d10fed393325f317bdea",
+    "zh:8fec40a1433179b51a533adf473c494d8dd580b994f11c3a1590f85554c61391",
+    "zh:bcd6c7990a946f70ecb009b3516f32ab718827f019a8822b6b464df04e31e8b7",
+    "zh:be940702e9f97b75e3830e2453a219a8e4379b85a4e8881b4277ec28c4b0f99d",
+    "zh:c212e2628c98a69cd83e5e4a09cce34c984e5130045fe64848af6aad12201bbb",
+    "zh:d26e946c0835d8034708843a35471625c2dc54a359a6f25290150daf7daf3b30",
+    "zh:d3965e6b0202204ef4d80d58bb870abb1c944025cac3e6b423bc4492d6cd9365",
+    "zh:e2a71e1d0ec03f920a5a962871d9270af3a066ff0c0c55ee48f97c544fbfe93a",
+    "zh:f472d8603f14d6e34627d00d3368f1304821d4f2ce4334a155ff75877a1b5364",
+  ]
+}

--- a/infra/aws-provider-tests/.terraform.lock.hcl
+++ b/infra/aws-provider-tests/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.44.0"
-  constraints = ">= 5.0.0, < 7.0.0"
+  constraints = "~> 6.0"
   hashes = [
     "h1:nnkrhJv02OdUdVsoKca2veqHX06nCnheOJOx57YvL0s=",
     "zh:2a61db8c7ab08a4df5302cbd36b6a5e4915d29270d2d0ade4baf2bd541d0ca04",

--- a/infra/aws-provider-tests/README.md
+++ b/infra/aws-provider-tests/README.md
@@ -1,0 +1,21 @@
+# AWS Provider Test Account Scaffold
+
+This OpenTofu scaffold prepares low-cost AWS resources for Floe provider compatibility validation. It creates S3, IAM, and Budget resources only.
+
+It does not create EKS, EC2, NAT Gateways, Glue jobs, Glue crawlers, Lake Formation, or S3 Tables.
+
+Before using this scaffold, read the human prerequisite guidance in `docs/contributing/aws-provider-testing.md`.
+
+## Agent Workflow
+
+```bash
+cd infra/aws-provider-tests
+cp terraform.tfvars.example terraform.tfvars
+tofu init
+tofu fmt -check
+tofu validate
+tofu plan -out tfplan
+tofu apply tfplan
+```
+
+Do not commit `terraform.tfvars`, `tfplan`, `.terraform/`, or state files.

--- a/infra/aws-provider-tests/iam.tf
+++ b/infra/aws-provider-tests/iam.tf
@@ -1,0 +1,111 @@
+data "aws_iam_policy_document" "provider_test_permissions" {
+  statement {
+    sid = "ReadCallerIdentity"
+
+    actions = [
+      "sts:GetCallerIdentity",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ReadProviderTestBucket"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.provider_tests.arn,
+    ]
+  }
+
+  statement {
+    sid = "ManageProviderTestRunObjects"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.provider_tests.arn}/${var.s3_run_prefix}*",
+    ]
+  }
+
+  statement {
+    sid = "ManageProviderTestGlueDatabases"
+
+    actions = [
+      "glue:CreateDatabase",
+      "glue:DeleteDatabase",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:UpdateDatabase",
+    ]
+
+    resources = [
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
+    ]
+  }
+
+  statement {
+    sid = "ManageProviderTestGlueTables"
+
+    actions = [
+      "glue:BatchDeleteTable",
+      "glue:CreateTable",
+      "glue:DeleteTable",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:UpdateTable",
+    ]
+
+    resources = [
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*",
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_aws_devpod_permissions ? [1] : []
+
+    content {
+      sid = "ReadAwsDevpodEc2Inventory"
+
+      actions = [
+        "ec2:DescribeInstances",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+      ]
+
+      resources = ["*"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "provider_test_permissions" {
+  name   = "${var.name_prefix}-permissions"
+  policy = data.aws_iam_policy_document.provider_test_permissions.json
+}
+
+resource "aws_iam_user" "provider_test" {
+  count = var.enable_access_key_user ? 1 : 0
+
+  name = "${var.name_prefix}-user"
+}
+
+resource "aws_iam_user_policy_attachment" "provider_test" {
+  count = var.enable_access_key_user ? 1 : 0
+
+  policy_arn = aws_iam_policy.provider_test_permissions.arn
+  user       = aws_iam_user.provider_test[0].name
+}

--- a/infra/aws-provider-tests/locals.tf
+++ b/infra/aws-provider-tests/locals.tf
@@ -1,0 +1,18 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  derived_bucket_name = lower("${var.name_prefix}-${local.account_id}-${var.aws_region}")
+  bucket_name         = coalesce(var.s3_bucket_name, local.derived_bucket_name)
+
+  common_tags = merge(
+    {
+      Project   = "floe"
+      Purpose   = "provider-compatibility"
+      ManagedBy = "opentofu"
+      Owner     = var.owner
+    },
+    var.common_tags,
+  )
+}

--- a/infra/aws-provider-tests/main.tf
+++ b/infra/aws-provider-tests/main.tf
@@ -1,0 +1,75 @@
+resource "aws_s3_bucket" "provider_tests" {
+  bucket = local.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "provider_tests" {
+  bucket = aws_s3_bucket.provider_tests.id
+
+  rule {
+    id     = "expire-provider-test-runs"
+    status = "Enabled"
+
+    filter {
+      prefix = var.s3_run_prefix
+    }
+
+    expiration {
+      days = var.run_data_retention_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}
+
+resource "aws_budgets_budget" "provider_tests" {
+  name         = "${var.name_prefix}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = var.monthly_budget_limit_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.budget_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.budget_email]
+  }
+}

--- a/infra/aws-provider-tests/outputs.tf
+++ b/infra/aws-provider-tests/outputs.tf
@@ -33,6 +33,11 @@ output "budget_name" {
   value       = aws_budgets_budget.provider_tests.name
 }
 
+output "budget_email" {
+  description = "AWS Budget subscriber email used for provider compatibility test cost alerts."
+  value       = var.budget_email
+}
+
 output "recommended_environment" {
   description = "Environment variables recommended for Floe AWS provider compatibility tests."
   value = {
@@ -41,6 +46,7 @@ output "recommended_environment" {
     FLOE_AWS_TEST_PREFIX              = var.s3_run_prefix
     FLOE_AWS_GLUE_DATABASE_PREFIX     = var.glue_database_prefix
     FLOE_AWS_BUDGET_NAME              = aws_budgets_budget.provider_tests.name
+    FLOE_AWS_BUDGET_EMAIL             = var.budget_email
     FLOE_AWS_PROVIDER_TEST_POLICY_ARN = aws_iam_policy.provider_test_permissions.arn
   }
 }

--- a/infra/aws-provider-tests/outputs.tf
+++ b/infra/aws-provider-tests/outputs.tf
@@ -1,0 +1,39 @@
+output "aws_account_id" {
+  description = "AWS account ID used by this provider test scaffold."
+  value       = local.account_id
+}
+
+output "aws_region" {
+  description = "AWS region used by this provider test scaffold."
+  value       = var.aws_region
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket for provider compatibility test run data."
+  value       = aws_s3_bucket.provider_tests.bucket
+}
+
+output "s3_run_prefix" {
+  description = "S3 prefix for provider compatibility test run data."
+  value       = var.s3_run_prefix
+}
+
+output "glue_database_prefix" {
+  description = "Glue database prefix permitted for provider compatibility tests."
+  value       = var.glue_database_prefix
+}
+
+output "provider_test_policy_arn" {
+  description = "IAM policy ARN containing provider compatibility test permissions."
+  value       = aws_iam_policy.provider_test_permissions.arn
+}
+
+output "recommended_environment" {
+  description = "Environment variables recommended for Floe AWS provider compatibility tests."
+  value = {
+    FLOE_AWS_REGION               = var.aws_region
+    FLOE_AWS_TEST_BUCKET          = aws_s3_bucket.provider_tests.bucket
+    FLOE_AWS_TEST_PREFIX          = var.s3_run_prefix
+    FLOE_AWS_GLUE_DATABASE_PREFIX = var.glue_database_prefix
+  }
+}

--- a/infra/aws-provider-tests/outputs.tf
+++ b/infra/aws-provider-tests/outputs.tf
@@ -36,6 +36,7 @@ output "budget_name" {
 output "budget_email" {
   description = "AWS Budget subscriber email used for provider compatibility test cost alerts."
   value       = var.budget_email
+  sensitive   = true
 }
 
 output "recommended_environment" {
@@ -49,4 +50,5 @@ output "recommended_environment" {
     FLOE_AWS_BUDGET_EMAIL             = var.budget_email
     FLOE_AWS_PROVIDER_TEST_POLICY_ARN = aws_iam_policy.provider_test_permissions.arn
   }
+  sensitive = true
 }

--- a/infra/aws-provider-tests/outputs.tf
+++ b/infra/aws-provider-tests/outputs.tf
@@ -28,12 +28,19 @@ output "provider_test_policy_arn" {
   value       = aws_iam_policy.provider_test_permissions.arn
 }
 
+output "budget_name" {
+  description = "AWS Budget name used for provider compatibility test cost controls."
+  value       = aws_budgets_budget.provider_tests.name
+}
+
 output "recommended_environment" {
   description = "Environment variables recommended for Floe AWS provider compatibility tests."
   value = {
-    FLOE_AWS_REGION               = var.aws_region
-    FLOE_AWS_TEST_BUCKET          = aws_s3_bucket.provider_tests.bucket
-    FLOE_AWS_TEST_PREFIX          = var.s3_run_prefix
-    FLOE_AWS_GLUE_DATABASE_PREFIX = var.glue_database_prefix
+    FLOE_AWS_REGION                   = var.aws_region
+    FLOE_AWS_TEST_BUCKET              = aws_s3_bucket.provider_tests.bucket
+    FLOE_AWS_TEST_PREFIX              = var.s3_run_prefix
+    FLOE_AWS_GLUE_DATABASE_PREFIX     = var.glue_database_prefix
+    FLOE_AWS_BUDGET_NAME              = aws_budgets_budget.provider_tests.name
+    FLOE_AWS_PROVIDER_TEST_POLICY_ARN = aws_iam_policy.provider_test_permissions.arn
   }
 }

--- a/infra/aws-provider-tests/terraform.tfvars.example
+++ b/infra/aws-provider-tests/terraform.tfvars.example
@@ -1,0 +1,12 @@
+aws_region                = "ap-southeast-2"
+name_prefix               = "floe-provider-tests"
+owner                     = "your-name"
+budget_email              = "you@example.com"
+monthly_budget_limit_usd  = 25
+run_data_retention_days   = 3
+glue_database_prefix      = "floe_provider_"
+
+common_tags = {
+  Environment = "test"
+  CostCenter  = "floe-provider-tests"
+}

--- a/infra/aws-provider-tests/variables.tf
+++ b/infra/aws-provider-tests/variables.tf
@@ -1,0 +1,119 @@
+variable "aws_region" {
+  description = "AWS region for low-cost provider compatibility resources."
+  type        = string
+  default     = "ap-southeast-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.aws_region))
+    error_message = "aws_region must be a valid AWS region identifier such as ap-southeast-2."
+  }
+}
+
+variable "name_prefix" {
+  description = "Lowercase prefix used for named AWS resources."
+  type        = string
+  default     = "floe-provider-tests"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]+(-[a-z0-9]+)*$", var.name_prefix))
+    error_message = "name_prefix must contain only lowercase letters, numbers, and single hyphens."
+  }
+}
+
+variable "owner" {
+  description = "Human owner for tags and budget traceability."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.owner)) > 0
+    error_message = "owner is required."
+  }
+}
+
+variable "budget_email" {
+  description = "Email address that receives AWS Budget notifications."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$", var.budget_email))
+    error_message = "budget_email must be a valid email address."
+  }
+}
+
+variable "monthly_budget_limit_usd" {
+  description = "Monthly AWS Budget limit in USD."
+  type        = number
+  default     = 25
+
+  validation {
+    condition     = var.monthly_budget_limit_usd > 0 && var.monthly_budget_limit_usd <= 100
+    error_message = "monthly_budget_limit_usd must be greater than 0 and less than or equal to 100."
+  }
+}
+
+variable "s3_bucket_name" {
+  description = "Optional explicit S3 bucket name. Defaults to a deterministic account and region qualified name."
+  type        = string
+  default     = null
+
+  validation {
+    condition = var.s3_bucket_name == null || can(regex(
+      "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+      var.s3_bucket_name,
+    ))
+    error_message = "s3_bucket_name must be null or a valid lowercase S3 bucket name."
+  }
+}
+
+variable "s3_run_prefix" {
+  description = "Relative S3 prefix used for provider test run data."
+  type        = string
+  default     = "runs/"
+
+  validation {
+    condition = can(regex("^[^/][A-Za-z0-9!_.*'()/-]*/$", var.s3_run_prefix)) && (
+      !startswith(var.s3_run_prefix, "/")
+    )
+    error_message = "s3_run_prefix must be a relative prefix ending with a slash."
+  }
+}
+
+variable "run_data_retention_days" {
+  description = "Number of days to retain provider test run objects."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.run_data_retention_days >= 1 && var.run_data_retention_days <= 30
+    error_message = "run_data_retention_days must be between 1 and 30."
+  }
+}
+
+variable "glue_database_prefix" {
+  description = "Prefix for temporary Glue databases created by provider tests."
+  type        = string
+  default     = "floe_provider_"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9_]*_$", var.glue_database_prefix))
+    error_message = "glue_database_prefix must be lowercase snake_case and end with an underscore."
+  }
+}
+
+variable "enable_access_key_user" {
+  description = "Whether to create an IAM user for manually managed provider test credentials. No access keys are created."
+  type        = bool
+  default     = false
+}
+
+variable "enable_aws_devpod_permissions" {
+  description = "Whether to include read-only EC2 inventory permissions needed by AWS DevPod workflows."
+  type        = bool
+  default     = false
+}
+
+variable "common_tags" {
+  description = "Additional tags merged into all taggable resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/aws-provider-tests/variables.tf
+++ b/infra/aws-provider-tests/variables.tf
@@ -71,10 +71,8 @@ variable "s3_run_prefix" {
   default     = "runs/"
 
   validation {
-    condition = can(regex("^[^/][A-Za-z0-9!_.*'()/-]*/$", var.s3_run_prefix)) && (
-      !startswith(var.s3_run_prefix, "/")
-    )
-    error_message = "s3_run_prefix must be a relative prefix ending with a slash."
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9/_-]*/$", var.s3_run_prefix))
+    error_message = "s3_run_prefix must be a relative prefix ending with a slash and contain only letters, numbers, slashes, underscores, and hyphens."
   }
 }
 
@@ -95,7 +93,7 @@ variable "glue_database_prefix" {
   default     = "floe_provider_"
 
   validation {
-    condition     = can(regex("^[a-z][a-z0-9_]*_$", var.glue_database_prefix))
+    condition     = can(regex("^[a-z][a-z0-9_]{2,40}_$", var.glue_database_prefix))
     error_message = "glue_database_prefix must be lowercase snake_case and end with an underscore."
   }
 }

--- a/infra/aws-provider-tests/versions.tf
+++ b/infra/aws-provider-tests/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/aws-provider-tests/versions.tf
+++ b/infra/aws-provider-tests/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0, < 7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/packages/floe-core/uv.lock
+++ b/packages/floe-core/uv.lock
@@ -2279,11 +2279,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]

--- a/scripts/aws-provider-test-cleanup.sh
+++ b/scripts/aws-provider-test-cleanup.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+    echo "[aws-provider-cleanup] $*" >&2
+}
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        echo "[aws-provider-cleanup] ERROR: ${name} is required" >&2
+        exit 1
+    fi
+}
+
+require_env FLOE_AWS_REGION
+require_env FLOE_AWS_TEST_BUCKET
+require_env FLOE_AWS_GLUE_DATABASE_PREFIX
+require_env FLOE_PROVIDER_SPIKE_RUN
+
+aws_args=(--region "${FLOE_AWS_REGION}")
+run_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}${FLOE_PROVIDER_SPIKE_RUN}/"
+run_database="${FLOE_AWS_GLUE_DATABASE_PREFIX}${FLOE_PROVIDER_SPIKE_RUN//-/_}"
+
+log "Cleaning S3 run prefix s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}"
+aws s3 rm "s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}" --recursive "${aws_args[@]}" || true
+
+log "Deleting Glue tables in ${run_database} if the database exists"
+if aws glue get-database --name "${run_database}" "${aws_args[@]}" >/dev/null 2>&1; then
+    table_names="$(
+        aws glue get-tables \
+            --database-name "${run_database}" \
+            --query 'TableList[].Name' \
+            --output text \
+            "${aws_args[@]}"
+    )"
+    for table_name in ${table_names}; do
+        aws glue delete-table \
+            --database-name "${run_database}" \
+            --name "${table_name}" \
+            "${aws_args[@]}" >/dev/null || true
+    done
+    aws glue delete-database \
+        --database-name "${run_database}" \
+        "${aws_args[@]}" >/dev/null || true
+fi
+
+log "Post-cleanup S3 inventory"
+aws s3api list-objects-v2 \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    --prefix "${run_prefix}" \
+    --max-items 10 \
+    "${aws_args[@]}"
+
+log "Post-cleanup Glue inventory"
+aws glue get-database \
+    --name "${run_database}" \
+    "${aws_args[@]}" >/dev/null 2>&1 && {
+        echo "[aws-provider-cleanup] ERROR: Glue database still exists: ${run_database}" >&2
+        exit 1
+    }
+
+log "Cleanup checks passed"

--- a/scripts/aws-provider-test-cleanup.sh
+++ b/scripts/aws-provider-test-cleanup.sh
@@ -90,19 +90,19 @@ if [[ "${database_state}" == "error" ]]; then
 fi
 
 if [[ "${database_state}" == "exists" ]]; then
-    table_names="$(
-        aws glue get-tables \
-            --database-name "${run_database}" \
-            --query 'TableList[].Name' \
-            --output text \
-            "${aws_args[@]}"
-    )"
-    for table_name in ${table_names}; do
+    while IFS= read -r table_name; do
+        [[ -z "${table_name}" ]] && continue
         aws glue delete-table \
             --database-name "${run_database}" \
             --name "${table_name}" \
             "${aws_args[@]}" >/dev/null
-    done
+    done < <(
+        aws glue get-tables \
+            --database-name "${run_database}" \
+            --query 'TableList[].Name' \
+            --output text \
+            "${aws_args[@]}" | tr '\t' '\n'
+    )
     aws glue delete-database \
         --name "${run_database}" \
         "${aws_args[@]}" >/dev/null

--- a/scripts/aws-provider-test-cleanup.sh
+++ b/scripts/aws-provider-test-cleanup.sh
@@ -104,7 +104,7 @@ if [[ "${database_state}" == "exists" ]]; then
             "${aws_args[@]}" >/dev/null
     done
     aws glue delete-database \
-        --database-name "${run_database}" \
+        --name "${run_database}" \
         "${aws_args[@]}" >/dev/null
 fi
 

--- a/scripts/aws-provider-test-cleanup.sh
+++ b/scripts/aws-provider-test-cleanup.sh
@@ -5,11 +5,15 @@ log() {
     echo "[aws-provider-cleanup] $*" >&2
 }
 
+error() {
+    echo "[aws-provider-cleanup] ERROR: $*" >&2
+    exit 1
+}
+
 require_env() {
     local name="$1"
     if [[ -z "${!name:-}" ]]; then
-        echo "[aws-provider-cleanup] ERROR: ${name} is required" >&2
-        exit 1
+        error "${name} is required"
     fi
 }
 
@@ -19,14 +23,69 @@ require_env FLOE_AWS_GLUE_DATABASE_PREFIX
 require_env FLOE_PROVIDER_SPIKE_RUN
 
 aws_args=(--region "${FLOE_AWS_REGION}")
-run_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}${FLOE_PROVIDER_SPIKE_RUN}/"
+test_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}"
+run_prefix="${test_prefix}${FLOE_PROVIDER_SPIKE_RUN}/"
 run_database="${FLOE_AWS_GLUE_DATABASE_PREFIX}${FLOE_PROVIDER_SPIKE_RUN//-/_}"
+glue_stderr="$(mktemp)"
+
+cleanup_temp() {
+    rm -f "${glue_stderr}"
+}
+trap cleanup_temp EXIT
+
+validate_inputs() {
+    if [[ ! "${FLOE_PROVIDER_SPIKE_RUN}" =~ ^floe-provider-[0-9]{8}T[0-9]{6}Z$ ]]; then
+        error "FLOE_PROVIDER_SPIKE_RUN must match ^floe-provider-[0-9]{8}T[0-9]{6}Z$"
+    fi
+
+    if [[ ! "${test_prefix}" =~ ^runs/$ ]]; then
+        error "FLOE_AWS_TEST_PREFIX must match ^runs/$ for first live validation"
+    fi
+
+    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^floe_provider_$ ]]; then
+        error "FLOE_AWS_GLUE_DATABASE_PREFIX must match ^floe_provider_$ for first live validation"
+    fi
+
+    if [[ "${run_prefix}" != "runs/${FLOE_PROVIDER_SPIKE_RUN}/" ]]; then
+        error "computed run_prefix is outside the allowed cleanup target: ${run_prefix}"
+    fi
+
+    if [[ "${run_database}" != "floe_provider_${FLOE_PROVIDER_SPIKE_RUN//-/_}" ]]; then
+        error "computed run_database is outside the allowed cleanup target: ${run_database}"
+    fi
+}
+
+glue_database_state() {
+    : >"${glue_stderr}"
+    if aws glue get-database \
+        --name "${run_database}" \
+        "${aws_args[@]}" >/dev/null 2>"${glue_stderr}"; then
+        echo "exists"
+        return 0
+    fi
+
+    if grep -q "EntityNotFoundException" "${glue_stderr}"; then
+        echo "absent"
+        return 0
+    fi
+
+    cat "${glue_stderr}" >&2
+    echo "error"
+    return 0
+}
+
+validate_inputs
 
 log "Cleaning S3 run prefix s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}"
-aws s3 rm "s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}" --recursive "${aws_args[@]}" || true
+aws s3 rm "s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}" --recursive "${aws_args[@]}"
 
 log "Deleting Glue tables in ${run_database} if the database exists"
-if aws glue get-database --name "${run_database}" "${aws_args[@]}" >/dev/null 2>&1; then
+database_state="$(glue_database_state)"
+if [[ "${database_state}" == "error" ]]; then
+    error "failed to check Glue database: ${run_database}"
+fi
+
+if [[ "${database_state}" == "exists" ]]; then
     table_names="$(
         aws glue get-tables \
             --database-name "${run_database}" \
@@ -38,14 +97,32 @@ if aws glue get-database --name "${run_database}" "${aws_args[@]}" >/dev/null 2>
         aws glue delete-table \
             --database-name "${run_database}" \
             --name "${table_name}" \
-            "${aws_args[@]}" >/dev/null || true
+            "${aws_args[@]}" >/dev/null
     done
     aws glue delete-database \
         --database-name "${run_database}" \
-        "${aws_args[@]}" >/dev/null || true
+        "${aws_args[@]}" >/dev/null
 fi
 
 log "Post-cleanup S3 inventory"
+s3_remaining_count="$(
+    aws s3api list-objects-v2 \
+        --bucket "${FLOE_AWS_TEST_BUCKET}" \
+        --prefix "${run_prefix}" \
+        --query "length(Contents || \`[]\`)" \
+        --output text \
+        "${aws_args[@]}"
+)"
+
+if [[ "${s3_remaining_count}" != "0" ]]; then
+    aws s3api list-objects-v2 \
+        --bucket "${FLOE_AWS_TEST_BUCKET}" \
+        --prefix "${run_prefix}" \
+        --max-items 10 \
+        "${aws_args[@]}" >&2
+    error "S3 objects still exist under s3://${FLOE_AWS_TEST_BUCKET}/${run_prefix}"
+fi
+
 aws s3api list-objects-v2 \
     --bucket "${FLOE_AWS_TEST_BUCKET}" \
     --prefix "${run_prefix}" \
@@ -53,11 +130,12 @@ aws s3api list-objects-v2 \
     "${aws_args[@]}"
 
 log "Post-cleanup Glue inventory"
-aws glue get-database \
-    --name "${run_database}" \
-    "${aws_args[@]}" >/dev/null 2>&1 && {
-        echo "[aws-provider-cleanup] ERROR: Glue database still exists: ${run_database}" >&2
-        exit 1
-    }
+database_state="$(glue_database_state)"
+if [[ "${database_state}" == "exists" ]]; then
+    error "Glue database still exists: ${run_database}"
+fi
+if [[ "${database_state}" == "error" ]]; then
+    error "failed to verify Glue database cleanup: ${run_database}"
+fi
 
 log "Cleanup checks passed"

--- a/scripts/aws-provider-test-cleanup.sh
+++ b/scripts/aws-provider-test-cleanup.sh
@@ -38,19 +38,23 @@ validate_inputs() {
         error "FLOE_PROVIDER_SPIKE_RUN must match ^floe-provider-[0-9]{8}T[0-9]{6}Z$"
     fi
 
-    if [[ ! "${test_prefix}" =~ ^runs/$ ]]; then
-        error "FLOE_AWS_TEST_PREFIX must match ^runs/$ for first live validation"
+    if [[ ! "${test_prefix}" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_-]*/$ ]]; then
+        error "FLOE_AWS_TEST_PREFIX must be a relative S3 prefix ending with /"
     fi
 
-    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^floe_provider_$ ]]; then
-        error "FLOE_AWS_GLUE_DATABASE_PREFIX must match ^floe_provider_$ for first live validation"
+    if [[ "${test_prefix}" == "/" || "${test_prefix}" == "../"* || "${test_prefix}" == *"/../"* ]]; then
+        error "FLOE_AWS_TEST_PREFIX must not be root or contain parent traversal"
     fi
 
-    if [[ "${run_prefix}" != "runs/${FLOE_PROVIDER_SPIKE_RUN}/" ]]; then
+    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^[a-z][a-z0-9_]{2,40}_$ ]]; then
+        error "FLOE_AWS_GLUE_DATABASE_PREFIX must be lowercase snake_case and end with _"
+    fi
+
+    if [[ "${run_prefix}" != "${test_prefix}${FLOE_PROVIDER_SPIKE_RUN}/" ]]; then
         error "computed run_prefix is outside the allowed cleanup target: ${run_prefix}"
     fi
 
-    if [[ "${run_database}" != "floe_provider_${FLOE_PROVIDER_SPIKE_RUN//-/_}" ]]; then
+    if [[ "${run_database}" != "${FLOE_AWS_GLUE_DATABASE_PREFIX}${FLOE_PROVIDER_SPIKE_RUN//-/_}" ]]; then
         error "computed run_database is outside the allowed cleanup target: ${run_database}"
     fi
 }

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+    echo "[aws-provider-readiness] $*" >&2
+}
+
+require_env() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        echo "[aws-provider-readiness] ERROR: ${name} is required" >&2
+        exit 1
+    fi
+}
+
+require_env FLOE_AWS_REGION
+require_env FLOE_AWS_TEST_BUCKET
+require_env FLOE_AWS_GLUE_DATABASE_PREFIX
+
+aws_args=(--region "${FLOE_AWS_REGION}")
+
+log "Checking AWS caller identity"
+aws sts get-caller-identity "${aws_args[@]}"
+
+log "Checking S3 bucket access: ${FLOE_AWS_TEST_BUCKET}"
+aws s3api get-bucket-location \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    "${aws_args[@]}"
+
+log "Checking S3 list access"
+aws s3api list-objects-v2 \
+    --bucket "${FLOE_AWS_TEST_BUCKET}" \
+    --prefix "${FLOE_AWS_TEST_PREFIX:-runs/}" \
+    --max-items 1 \
+    "${aws_args[@]}" >/dev/null
+
+probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
+
+cleanup_probe() {
+    aws glue delete-database \
+        --database-name "${probe_db}" \
+        "${aws_args[@]}" >/dev/null 2>&1 || true
+}
+trap cleanup_probe EXIT
+
+log "Checking Glue create/get/delete access with ${probe_db}"
+aws glue create-database \
+    --database-input "{\"Name\":\"${probe_db}\"}" \
+    "${aws_args[@]}" >/dev/null
+aws glue get-database \
+    --name "${probe_db}" \
+    "${aws_args[@]}" >/dev/null
+aws glue delete-database \
+    --database-name "${probe_db}" \
+    "${aws_args[@]}" >/dev/null
+
+log "Readiness checks passed"

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -177,7 +177,7 @@ jq -e \
 probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
 
 log "Checking Glue create/get/delete access with ${probe_db}"
-printf '{"Name":"%s"}\n' "${probe_db}" >"${database_payload}"
+jq -n --arg name "${probe_db}" '{Name: $name}' >"${database_payload}"
 aws glue create-database \
     --database-input "file://${database_payload}" \
     "${aws_args[@]}" >/dev/null

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -21,9 +21,17 @@ require_env FLOE_AWS_REGION
 require_env FLOE_AWS_TEST_BUCKET
 require_env FLOE_AWS_GLUE_DATABASE_PREFIX
 require_env FLOE_AWS_BUDGET_NAME
+require_env FLOE_AWS_BUDGET_EMAIL
 require_env FLOE_AWS_PROVIDER_TEST_POLICY_ARN
 
 test_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}"
+
+require_command() {
+    local name="$1"
+    if ! command -v "${name}" >/dev/null 2>&1; then
+        error "${name} is required"
+    fi
+}
 
 validate_inputs() {
     if [[ ! "${test_prefix}" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_-]*/$ ]]; then
@@ -40,9 +48,24 @@ validate_inputs() {
 }
 
 validate_inputs
+require_command jq
 
 aws_args=(--region "${FLOE_AWS_REGION}")
 database_payload="$(mktemp)"
+budget_notifications_payload="$(mktemp)"
+budget_subscribers_payload="$(mktemp)"
+policy_payload="$(mktemp)"
+probe_db=""
+
+cleanup_probe() {
+    rm -f "${database_payload}" "${budget_notifications_payload}" "${budget_subscribers_payload}" "${policy_payload}"
+    if [[ -n "${probe_db}" ]]; then
+        aws glue delete-database \
+            --database-name "${probe_db}" \
+            "${aws_args[@]}" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup_probe EXIT
 
 log "Checking AWS caller identity"
 aws sts get-caller-identity "${aws_args[@]}"
@@ -93,20 +116,65 @@ account_id="$(
 aws budgets describe-budget \
     --account-id "${account_id}" \
     --budget-name "${FLOE_AWS_BUDGET_NAME}" >/dev/null
+aws budgets describe-notifications-for-budget \
+    --account-id "${account_id}" \
+    --budget-name "${FLOE_AWS_BUDGET_NAME}" >"${budget_notifications_payload}"
+jq -e '
+  .Notifications
+  | any(.NotificationType == "ACTUAL"
+      and .ComparisonOperator == "GREATER_THAN"
+      and .Threshold == 80
+      and .ThresholdType == "PERCENTAGE")
+    and any(.NotificationType == "FORECASTED"
+      and .ComparisonOperator == "GREATER_THAN"
+      and .Threshold == 100
+      and .ThresholdType == "PERCENTAGE")
+' "${budget_notifications_payload}" >/dev/null || \
+    error "AWS Budget ${FLOE_AWS_BUDGET_NAME} is missing expected 80% actual or 100% forecasted notifications"
+
+for notification in \
+    '{"NotificationType":"ACTUAL","ComparisonOperator":"GREATER_THAN","Threshold":80,"ThresholdType":"PERCENTAGE"}' \
+    '{"NotificationType":"FORECASTED","ComparisonOperator":"GREATER_THAN","Threshold":100,"ThresholdType":"PERCENTAGE"}'; do
+    aws budgets describe-subscribers-for-notification \
+        --account-id "${account_id}" \
+        --budget-name "${FLOE_AWS_BUDGET_NAME}" \
+        --notification "${notification}" >"${budget_subscribers_payload}"
+    jq -e --arg email "${FLOE_AWS_BUDGET_EMAIL}" '
+      .Subscribers
+      | any(.SubscriptionType == "EMAIL" and .Address == $email)
+    ' "${budget_subscribers_payload}" >/dev/null || \
+        error "AWS Budget ${FLOE_AWS_BUDGET_NAME} notification is missing subscriber ${FLOE_AWS_BUDGET_EMAIL}"
+done
 
 log "Checking provider test IAM policy: ${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}"
-aws iam get-policy \
-    --policy-arn "${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}" >/dev/null
+policy_version="$(
+    aws iam get-policy \
+        --policy-arn "${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}" \
+        --query 'Policy.DefaultVersionId' \
+        --output text
+)"
+aws iam get-policy-version \
+    --policy-arn "${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}" \
+    --version-id "${policy_version}" \
+    --query 'PolicyVersion.Document' \
+    --output json >"${policy_payload}"
+jq -e \
+    --arg bucket "arn:aws:s3:::${FLOE_AWS_TEST_BUCKET}" \
+    --arg objects "arn:aws:s3:::${FLOE_AWS_TEST_BUCKET}/${test_prefix}*" \
+    --arg region "${FLOE_AWS_REGION}" \
+    --arg account "${account_id}" \
+    --arg glue_prefix "${FLOE_AWS_GLUE_DATABASE_PREFIX}" '
+  def stmts: .Statement | if type == "array" then . else [.] end;
+  def actions($s): ($s.Action | if type == "array" then . else [.] end);
+  def resources($s): ($s.Resource | if type == "array" then . else [.] end);
+  any(stmts[]; (actions(.) | index("s3:ListBucket")) and (resources(.) | index($bucket)))
+  and any(stmts[]; (actions(.) | index("s3:PutObject")) and (actions(.) | index("s3:DeleteObject")) and (resources(.) | index($objects)))
+  and any(stmts[]; (actions(.) | index("glue:CreateDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):database/\($glue_prefix)*")))
+  and any(stmts[]; (actions(.) | index("glue:CreateTable")) and (resources(.) | index("arn:aws:glue:\($region):\($account):table/\($glue_prefix)*/*")))
+' "${policy_payload}" >/dev/null || \
+    error "provider test IAM policy does not contain the expected scoped S3 and Glue statements"
 
 probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
-
-cleanup_probe() {
-    rm -f "${database_payload}"
-    aws glue delete-database \
-        --database-name "${probe_db}" \
-        "${aws_args[@]}" >/dev/null 2>&1 || true
-}
-trap cleanup_probe EXIT
 
 log "Checking Glue create/get/delete access with ${probe_db}"
 printf '{"Name":"%s"}\n' "${probe_db}" >"${database_payload}"

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -61,7 +61,7 @@ cleanup_probe() {
     rm -f "${database_payload}" "${budget_notifications_payload}" "${budget_subscribers_payload}" "${policy_payload}"
     if [[ -n "${probe_db}" ]]; then
         aws glue delete-database \
-            --database-name "${probe_db}" \
+            --name "${probe_db}" \
             "${aws_args[@]}" >/dev/null 2>&1 || true
     fi
 }
@@ -124,11 +124,11 @@ jq -e '
   | any(.NotificationType == "ACTUAL"
       and .ComparisonOperator == "GREATER_THAN"
       and .Threshold == 80
-      and .ThresholdType == "PERCENTAGE")
+      and ((.ThresholdType // "PERCENTAGE") == "PERCENTAGE"))
     and any(.NotificationType == "FORECASTED"
       and .ComparisonOperator == "GREATER_THAN"
       and .Threshold == 100
-      and .ThresholdType == "PERCENTAGE")
+      and ((.ThresholdType // "PERCENTAGE") == "PERCENTAGE"))
 ' "${budget_notifications_payload}" >/dev/null || \
     error "AWS Budget ${FLOE_AWS_BUDGET_NAME} is missing expected 80% actual or 100% forecasted notifications"
 
@@ -185,7 +185,7 @@ aws glue get-database \
     --name "${probe_db}" \
     "${aws_args[@]}" >/dev/null
 aws glue delete-database \
-    --database-name "${probe_db}" \
+    --name "${probe_db}" \
     "${aws_args[@]}" >/dev/null
 
 log "Readiness checks passed"

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -5,11 +5,15 @@ log() {
     echo "[aws-provider-readiness] $*" >&2
 }
 
+error() {
+    echo "[aws-provider-readiness] ERROR: $*" >&2
+    exit 1
+}
+
 require_env() {
     local name="$1"
     if [[ -z "${!name:-}" ]]; then
-        echo "[aws-provider-readiness] ERROR: ${name} is required" >&2
-        exit 1
+        error "${name} is required"
     fi
 }
 
@@ -17,7 +21,22 @@ require_env FLOE_AWS_REGION
 require_env FLOE_AWS_TEST_BUCKET
 require_env FLOE_AWS_GLUE_DATABASE_PREFIX
 
+test_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}"
+
+validate_inputs() {
+    if [[ ! "${test_prefix}" =~ ^runs/$ ]]; then
+        error "FLOE_AWS_TEST_PREFIX must match ^runs/$ for first live validation"
+    fi
+
+    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^floe_provider_$ ]]; then
+        error "FLOE_AWS_GLUE_DATABASE_PREFIX must match ^floe_provider_$ for first live validation"
+    fi
+}
+
+validate_inputs
+
 aws_args=(--region "${FLOE_AWS_REGION}")
+database_payload="$(mktemp)"
 
 log "Checking AWS caller identity"
 aws sts get-caller-identity "${aws_args[@]}"
@@ -30,13 +49,14 @@ aws s3api get-bucket-location \
 log "Checking S3 list access"
 aws s3api list-objects-v2 \
     --bucket "${FLOE_AWS_TEST_BUCKET}" \
-    --prefix "${FLOE_AWS_TEST_PREFIX:-runs/}" \
+    --prefix "${test_prefix}" \
     --max-items 1 \
     "${aws_args[@]}" >/dev/null
 
 probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
 
 cleanup_probe() {
+    rm -f "${database_payload}"
     aws glue delete-database \
         --database-name "${probe_db}" \
         "${aws_args[@]}" >/dev/null 2>&1 || true
@@ -44,8 +64,9 @@ cleanup_probe() {
 trap cleanup_probe EXIT
 
 log "Checking Glue create/get/delete access with ${probe_db}"
+printf '{"Name":"%s"}\n' "${probe_db}" >"${database_payload}"
 aws glue create-database \
-    --database-input "{\"Name\":\"${probe_db}\"}" \
+    --database-input "file://${database_payload}" \
     "${aws_args[@]}" >/dev/null
 aws glue get-database \
     --name "${probe_db}" \

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -20,16 +20,22 @@ require_env() {
 require_env FLOE_AWS_REGION
 require_env FLOE_AWS_TEST_BUCKET
 require_env FLOE_AWS_GLUE_DATABASE_PREFIX
+require_env FLOE_AWS_BUDGET_NAME
+require_env FLOE_AWS_PROVIDER_TEST_POLICY_ARN
 
 test_prefix="${FLOE_AWS_TEST_PREFIX:-runs/}"
 
 validate_inputs() {
-    if [[ ! "${test_prefix}" =~ ^runs/$ ]]; then
-        error "FLOE_AWS_TEST_PREFIX must match ^runs/$ for first live validation"
+    if [[ ! "${test_prefix}" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_-]*/$ ]]; then
+        error "FLOE_AWS_TEST_PREFIX must be a relative S3 prefix ending with /"
     fi
 
-    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^floe_provider_$ ]]; then
-        error "FLOE_AWS_GLUE_DATABASE_PREFIX must match ^floe_provider_$ for first live validation"
+    if [[ "${test_prefix}" == "/" || "${test_prefix}" == "../"* || "${test_prefix}" == *"/../"* ]]; then
+        error "FLOE_AWS_TEST_PREFIX must not be root or contain parent traversal"
+    fi
+
+    if [[ ! "${FLOE_AWS_GLUE_DATABASE_PREFIX}" =~ ^[a-z][a-z0-9_]{2,40}_$ ]]; then
+        error "FLOE_AWS_GLUE_DATABASE_PREFIX must be lowercase snake_case and end with _"
     fi
 }
 
@@ -52,6 +58,45 @@ aws s3api list-objects-v2 \
     --prefix "${test_prefix}" \
     --max-items 1 \
     "${aws_args[@]}" >/dev/null
+
+log "Checking S3 public access block"
+public_access_state="$(
+    aws s3api get-public-access-block \
+        --bucket "${FLOE_AWS_TEST_BUCKET}" \
+        --query 'PublicAccessBlockConfiguration.[BlockPublicAcls,IgnorePublicAcls,BlockPublicPolicy,RestrictPublicBuckets]' \
+        --output text \
+        "${aws_args[@]}"
+)"
+if [[ "${public_access_state}" != $'True\tTrue\tTrue\tTrue' ]]; then
+    error "S3 public access block is not fully enabled for ${FLOE_AWS_TEST_BUCKET}: ${public_access_state}"
+fi
+
+log "Checking S3 lifecycle rule for ${test_prefix}"
+lifecycle_rule_count="$(
+    aws s3api get-bucket-lifecycle-configuration \
+        --bucket "${FLOE_AWS_TEST_BUCKET}" \
+        --query "length(Rules[?Status == 'Enabled' && Filter.Prefix == '${test_prefix}'])" \
+        --output text \
+        "${aws_args[@]}"
+)"
+if [[ "${lifecycle_rule_count}" == "0" ]]; then
+    error "No enabled S3 lifecycle rule found for prefix ${test_prefix}"
+fi
+
+log "Checking AWS Budget: ${FLOE_AWS_BUDGET_NAME}"
+account_id="$(
+    aws sts get-caller-identity \
+        --query Account \
+        --output text \
+        "${aws_args[@]}"
+)"
+aws budgets describe-budget \
+    --account-id "${account_id}" \
+    --budget-name "${FLOE_AWS_BUDGET_NAME}" >/dev/null
+
+log "Checking provider test IAM policy: ${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}"
+aws iam get-policy \
+    --policy-arn "${FLOE_AWS_PROVIDER_TEST_POLICY_ARN}" >/dev/null
 
 probe_db="${FLOE_AWS_GLUE_DATABASE_PREFIX}readiness_$(date -u +%Y%m%d%H%M%S)"
 

--- a/uv.lock
+++ b/uv.lock
@@ -6644,11 +6644,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584 },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- documents the provider compatibility spike findings and AWS S3 + Glue as the first live target
- adds an OpenTofu scaffold for a low-cost AWS provider test account
- adds AWS readiness/cleanup helpers, contributor handoff docs, and a reusable Floe AWS provider testing skill
- validates the scaffold live against AWS account `278833447053`
- updates `urllib3` lockfile entries to `2.7.0` so the normal pre-push vulnerability gate passes

## Live AWS Evidence
- account: `278833447053`
- profile: `floe-aws-bootstrap`
- region: `ap-southeast-2`
- S3 bucket: `floe-provider-tests-278833447053-ap-southeast-2`
- IAM policy: `arn:aws:iam::278833447053:policy/floe-provider-tests-permissions`
- budget: `floe-provider-tests-monthly-budget`
- readiness: passed
- cleanup: passed for `floe-provider-20260512T014713Z`
- post-cleanup inventory: no `runs/` objects and no `floe_provider_` Glue databases

## Validation
- `uv run python testing/ci/validate-docs-navigation.py`
- `uv run python testing/ci/validate-docs-content.py`
- `bash -n scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh`
- `shellcheck scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh`
- `tofu fmt -check infra/aws-provider-tests`
- `tofu -chdir=infra/aws-provider-tests validate`
- `./testing/ci/uv-security-audit.sh`
- normal `git push` pre-push hook: lint, format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, hardcoded sleep check, traceability, docs validation, Helm lint
- `scripts/aws-provider-test-readiness.sh` against live AWS
- `scripts/aws-provider-test-cleanup.sh` against live AWS no-op cleanup

## Notes
- local ignored `terraform.tfvars`, `terraform.tfstate`, and `tfplan` remain uncommitted
- `floe-bootstrap` still has temporary `AdministratorAccess`; follow-up should replace it with narrower bootstrap/operator permissions