### PR TITLE
Add AWS S3 and Glue core composition contracts

### DIFF
--- a/docs/contracts/compiled-artifacts.md
+++ b/docs/contracts/compiled-artifacts.md
@@ -63,7 +63,7 @@ class CompiledArtifacts(BaseModel):
     """Output of the compilation pipeline - unified for all deployment modes."""
 
     # Schema version
-    version: str = COMPILED_ARTIFACTS_VERSION  # currently "0.15.0"
+    version: str = COMPILED_ARTIFACTS_VERSION  # currently "0.16.0"
 
     # Compilation metadata
     metadata: CompilationMetadata
@@ -520,7 +520,7 @@ class ContractMonitoringConfig(BaseModel):
 
 ```json
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "metadata": {
     "compiled_at": "2026-01-03T10:00:00Z",
     "floe_version": "0.3.0",
@@ -602,7 +602,7 @@ class ContractMonitoringConfig(BaseModel):
 
 ```json
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "metadata": {
     "compiled_at": "2026-01-03T10:00:00Z",
     "floe_version": "0.3.0",
@@ -661,7 +661,7 @@ class ContractMonitoringConfig(BaseModel):
 
 ```json
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "metadata": {
     "compiled_at": "2026-01-03T10:00:00Z",
     "floe_version": "0.3.0",

--- a/docs/superpowers/plans/2026-05-12-aws-provider-core-contracts.md
+++ b/docs/superpowers/plans/2026-05-12-aws-provider-core-contracts.md
@@ -1,0 +1,788 @@
+# AWS Provider Core Contracts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the shared Glue catalog binding, runtime projection, and resolver proof needed before implementing native AWS S3 and Glue plugins.
+
+**Architecture:** The core branch extends typed, secret-free contracts only. S3 and Glue provider packages remain out of scope; tests use schema objects and fake plugin behavior where needed so plugin implementation branches can depend on this contract without editing it.
+
+**Tech Stack:** Python 3.10+, Pydantic v2, pytest, PyIceberg config translation, Floe composition resolver.
+
+---
+
+## File Map
+
+- Modify: `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+  - Add `GlueCatalogDeploymentBinding`.
+  - Extend `CatalogDeploymentBinding` with `glue`.
+  - Validate `provider == "glue"` has Glue details.
+  - Export the new model in `__all__`.
+- Modify: `packages/floe-core/src/floe_core/runtime_catalog_connection.py`
+  - Build `RuntimeCatalogConnection` from `CatalogDeploymentBinding.glue`.
+- Modify: `packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py`
+  - Preserve Glue/PyIceberg properties from the runtime projection without REST-only assumptions.
+- Modify: `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`
+  - Add schema and secret-free tests for Glue binding.
+- Modify: `packages/floe-core/tests/unit/test_runtime_catalog_connection.py`
+  - Add Glue runtime projection tests.
+- Modify: `packages/floe-iceberg/tests/unit/test_runtime_catalog.py`
+  - Add PyIceberg Glue config translation test.
+- Modify: `packages/floe-core/tests/unit/composition/test_resolver.py`
+  - Add AWS S3 plus Glue resolver cases.
+- Optional update: `tests/fixtures/golden/compiled_artifacts_v2_schema.json`
+  - Regenerate only if schema tests require it.
+
+Do not create `plugins/floe-storage-aws-s3` or `plugins/floe-catalog-glue` in this branch.
+
+---
+
+### Task 1: Add Glue Catalog Binding Schema
+
+**Files:**
+- Modify: `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`
+- Test: `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append these tests near the existing catalog/runtime binding tests in `packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py`:
+
+```python
+class TestGlueCatalogDeploymentBinding:
+    """Tests for AWS Glue catalog deployment binding."""
+
+    def test_glue_catalog_binding_serializes_secret_free_fields(self) -> None:
+        from floe_core.schemas.compiled_artifacts import (
+            CatalogDeploymentBinding,
+            CredentialRef,
+            GlueCatalogDeploymentBinding,
+        )
+
+        binding = CatalogDeploymentBinding(
+            provider="glue",
+            glue=GlueCatalogDeploymentBinding(
+                catalog_name="glue",
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                catalog_id="278833447053",
+                database_prefix="floe_provider_",
+                skip_archive=True,
+                max_retries=5,
+                retry_mode="standard",
+                credential_refs={
+                    "role": CredentialRef(
+                        source="workload-identity",
+                        name="floe-provider-tests",
+                    )
+                },
+                properties={"glue.skip-archive": "true"},
+            ),
+        )
+
+        payload = binding.model_dump(mode="json")
+
+        assert payload["provider"] == "glue"
+        assert payload["glue"]["region"] == "ap-southeast-2"
+        assert payload["glue"]["warehouse"] == "s3://floe-provider-tests/warehouse/"
+        assert payload["glue"]["catalog_id"] == "278833447053"
+        assert payload["glue"]["credential_refs"]["role"]["source"] == "workload-identity"
+        assert "raw-secret-value" not in binding.model_dump_json()
+
+    def test_glue_provider_requires_glue_details(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import CatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="glue catalog deployment binding"):
+            CatalogDeploymentBinding(provider="glue")
+
+    def test_glue_binding_rejects_raw_secret_properties(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="raw credential material"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                properties={"glue.secret-access-key": "raw-secret-value"},
+            )
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestGlueCatalogDeploymentBinding -q
+```
+
+Expected: FAIL because `GlueCatalogDeploymentBinding` does not exist.
+
+- [ ] **Step 3: Implement schema model**
+
+In `packages/floe-core/src/floe_core/schemas/compiled_artifacts.py`, add the model after `PolarisCatalogDeploymentBinding`:
+
+```python
+class GlueCatalogDeploymentBinding(BaseModel):
+    """AWS Glue catalog-owned deployment and runtime configuration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    catalog_name: NonEmptyString = "glue"
+    region: NonEmptyString
+    warehouse: NonEmptyString
+    catalog_id: NonEmptyString | None = None
+    database_prefix: NonEmptyString | None = None
+    endpoint: NonEmptyString | None = None
+    skip_archive: bool = True
+    max_retries: int | None = Field(default=None, ge=1)
+    retry_mode: NonEmptyString | None = None
+    credential_refs: dict[str, CredentialRef] = Field(default_factory=dict)
+    properties: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("properties")
+    @classmethod
+    def validate_secret_free_properties(cls, value: dict[str, str]) -> dict[str, str]:
+        """Ensure Glue catalog properties do not inline credential values."""
+        _assert_no_secret_material(value, "catalog.glue.properties")
+        return value
+```
+
+Then update `CatalogDeploymentBinding`:
+
+```python
+class CatalogDeploymentBinding(BaseModel):
+    """Secret-free catalog deployment binding."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: NonEmptyString
+    polaris: PolarisCatalogDeploymentBinding | None = None
+    glue: GlueCatalogDeploymentBinding | None = None
+    iceberg_rest: IcebergRestCatalogBinding | None = None
+    dbt: DbtCatalogBinding | None = None
+
+    @model_validator(mode="after")
+    def validate_provider_binding(self) -> CatalogDeploymentBinding:
+        """Ensure provider-specific catalog binding is present when required."""
+        if self.provider == "polaris" and self.polaris is None:
+            msg = "polaris catalog deployment binding requires polaris details"
+            raise ValueError(msg)
+        if self.provider == "glue" and self.glue is None:
+            msg = "glue catalog deployment binding requires glue details"
+            raise ValueError(msg)
+        return self
+```
+
+Add `"GlueCatalogDeploymentBinding"` to the module `__all__` list.
+
+- [ ] **Step 4: Run schema tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestGlueCatalogDeploymentBinding -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/floe-core/src/floe_core/schemas/compiled_artifacts.py \
+  packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+git commit -m "feat: add Glue catalog deployment binding"
+```
+
+---
+
+### Task 2: Build RuntimeCatalogConnection From Glue Binding
+
+**Files:**
+- Modify: `packages/floe-core/src/floe_core/runtime_catalog_connection.py`
+- Test: `packages/floe-core/tests/unit/test_runtime_catalog_connection.py`
+
+- [ ] **Step 1: Write failing runtime projection test**
+
+Append to `packages/floe-core/tests/unit/test_runtime_catalog_connection.py`:
+
+```python
+def test_build_runtime_catalog_connection_maps_glue_binding() -> None:
+    from floe_core.runtime_catalog_connection import build_runtime_catalog_connection
+    from floe_core.schemas.compiled_artifacts import (
+        CatalogDeploymentBinding,
+        GlueCatalogDeploymentBinding,
+    )
+
+    catalog = CatalogDeploymentBinding(
+        provider="glue",
+        glue=GlueCatalogDeploymentBinding(
+            catalog_name="glue",
+            region="ap-southeast-2",
+            warehouse="s3://floe-provider-tests/warehouse/",
+            catalog_id="278833447053",
+            database_prefix="floe_provider_",
+            endpoint="https://glue.ap-southeast-2.amazonaws.com",
+            skip_archive=True,
+            max_retries=5,
+            retry_mode="standard",
+        ),
+    )
+
+    connection = build_runtime_catalog_connection(storage=None, catalog=catalog)
+
+    assert connection.catalog_name == "glue"
+    assert connection.warehouse == "s3://floe-provider-tests/warehouse/"
+    assert connection.region == "ap-southeast-2"
+    assert connection.properties == {
+        "type": "glue",
+        "glue.region": "ap-southeast-2",
+        "glue.id": "278833447053",
+        "glue.endpoint": "https://glue.ap-southeast-2.amazonaws.com",
+        "glue.skip-archive": "true",
+        "glue.max-retries": "5",
+        "glue.retry-mode": "standard",
+    }
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/test_runtime_catalog_connection.py::test_build_runtime_catalog_connection_maps_glue_binding -q
+```
+
+Expected: FAIL because Glue binding is not projected.
+
+- [ ] **Step 3: Implement Glue projection**
+
+In `packages/floe-core/src/floe_core/runtime_catalog_connection.py`, add this block after the Polaris block and before storage handling:
+
+```python
+    if catalog is not None and catalog.glue is not None:
+        glue = catalog.glue
+        catalog_name = glue.catalog_name
+        warehouse = glue.warehouse
+        region = glue.region
+        credential_refs.update(glue.credential_refs)
+        properties["type"] = "glue"
+        properties["glue.region"] = glue.region
+        properties["glue.skip-archive"] = str(glue.skip_archive).lower()
+        if glue.catalog_id is not None:
+            properties["glue.id"] = glue.catalog_id
+        if glue.endpoint is not None:
+            properties["glue.endpoint"] = glue.endpoint
+        if glue.max_retries is not None:
+            properties["glue.max-retries"] = str(glue.max_retries)
+        if glue.retry_mode is not None:
+            properties["glue.retry-mode"] = glue.retry_mode
+        properties.update(glue.properties)
+```
+
+- [ ] **Step 4: Run runtime projection tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/test_runtime_catalog_connection.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/floe-core/src/floe_core/runtime_catalog_connection.py \
+  packages/floe-core/tests/unit/test_runtime_catalog_connection.py
+git commit -m "feat: project Glue catalog runtime connection"
+```
+
+---
+
+### Task 3: Prove PyIceberg Glue Config Translation
+
+**Files:**
+- Modify: `packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py`
+- Test: `packages/floe-iceberg/tests/unit/test_runtime_catalog.py`
+
+- [ ] **Step 1: Write PyIceberg Glue translation test**
+
+Append to `packages/floe-iceberg/tests/unit/test_runtime_catalog.py`:
+
+```python
+def test_runtime_catalog_connection_to_pyiceberg_config_preserves_glue_properties() -> None:
+    connection = RuntimeCatalogConnection(
+        catalog_name="glue",
+        warehouse="s3://floe-provider-tests/warehouse/",
+        properties={
+            "type": "glue",
+            "glue.region": "ap-southeast-2",
+            "glue.id": "278833447053",
+            "glue.skip-archive": "true",
+            "glue.max-retries": "5",
+            "glue.retry-mode": "standard",
+        },
+    )
+
+    config = runtime_catalog_connection_to_pyiceberg_config(connection)
+
+    assert config == {
+        "warehouse": "s3://floe-provider-tests/warehouse/",
+        "type": "glue",
+        "glue.region": "ap-southeast-2",
+        "glue.id": "278833447053",
+        "glue.skip-archive": "true",
+        "glue.max-retries": "5",
+        "glue.retry-mode": "standard",
+    }
+```
+
+- [ ] **Step 2: Run test**
+
+Run:
+
+```bash
+uv run pytest packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q
+```
+
+Expected: PASS or expose a REST-only assumption. If it already passes, keep the test as regression coverage.
+
+- [ ] **Step 3: Implement only if needed**
+
+If the test fails because `runtime_catalog_connection_to_pyiceberg_config()` drops arbitrary properties, update it to keep `config.update(connection.properties)` last:
+
+```python
+    config.update(connection.properties)
+    return config
+```
+
+Do not add Glue-specific branches in `floe-iceberg`; the typed runtime projection owns those properties.
+
+- [ ] **Step 4: Run PyIceberg translator tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py \
+  packages/floe-iceberg/tests/unit/test_runtime_catalog.py
+git commit -m "test: prove Glue runtime catalog translation"
+```
+
+---
+
+### Task 4: Add AWS S3 Plus Glue Resolver Proof
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/composition/test_resolver.py`
+
+- [ ] **Step 1: Add valid AWS S3 plus Glue resolver test**
+
+Append:
+
+```python
+def test_resolver_accepts_aws_s3_plus_glue_with_workload_identity() -> None:
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="aws-s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            sts=True,
+            path_style_access=False,
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa", "aws-pod-identity"],
+            requires_server_side_storage_access=True,
+            supports_no_sts=False,
+            supports_path_style_access=False,
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws-irsa",
+        capabilities=CapabilitySet(identity_modes=["aws-irsa"]),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+```
+
+- [ ] **Step 2: Add invalid MinIO plus Glue resolver test**
+
+Append:
+
+```python
+def test_resolver_rejects_minio_plus_glue_native_s3_requirement() -> None:
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            path_style_access=True,
+            sts=False,
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert [issue.code for issue in result.issues] == [
+        "COMPOSITION_PROTOCOL_UNSUPPORTED",
+        "COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED",
+    ]
+```
+
+- [ ] **Step 3: Add missing identity rejection test**
+
+Append:
+
+```python
+def test_resolver_rejects_glue_workload_identity_without_identity_provider() -> None:
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="aws-s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues[0].code == "COMPOSITION_IDENTITY_PROVIDER_MISSING"
+```
+
+- [ ] **Step 4: Run resolver tests**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py -q
+```
+
+Expected: PASS. If any test fails because the expected diagnostic order differs, keep all asserted codes but sort them explicitly:
+
+```python
+assert sorted(issue.code for issue in result.issues) == [
+    "COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED",
+    "COMPOSITION_PROTOCOL_UNSUPPORTED",
+]
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/floe-core/tests/unit/composition/test_resolver.py
+git commit -m "test: prove AWS S3 and Glue resolver compatibility"
+```
+
+---
+
+### Task 5: Add Compilation-Level Fake Plugin Contract Tests
+
+**Files:**
+- Modify: `packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py`
+
+- [ ] **Step 1: Add fake binding helpers**
+
+Add local helpers near the existing fake plugin tests:
+
+```python
+def _fake_aws_s3_binding() -> StorageDeploymentBinding:
+    from floe_core.schemas.compiled_artifacts import (
+        DagsterStorageBinding,
+        DbtStorageBinding,
+        StorageCapabilities,
+        StorageCredentialBinding,
+        StorageDeploymentBinding,
+        StorageProvisioningIntent,
+        StorageRuntimeBinding,
+        StorageServiceEndpoint,
+        StorageWarehouse,
+    )
+
+    return StorageDeploymentBinding(
+        provider="aws-s3",
+        protocol="s3",
+        endpoint=StorageServiceEndpoint(
+            internal_url="https://s3.ap-southeast-2.amazonaws.com",
+            external_url="https://s3.ap-southeast-2.amazonaws.com",
+            region="ap-southeast-2",
+            warehouse_path="s3://floe-provider-tests/warehouse/",
+            path_style_access=False,
+        ),
+        warehouse=StorageWarehouse(
+            uri="s3://floe-provider-tests/warehouse/",
+            bucket="floe-provider-tests",
+            prefix="warehouse/",
+        ),
+        allowed_locations=["s3://floe-provider-tests/warehouse/"],
+        credentials=StorageCredentialBinding(
+            mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        ),
+        capabilities=StorageCapabilities(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            sts_supported=True,
+            path_style_access=False,
+        ),
+        provisioning=StorageProvisioningIntent(
+            enabled=False,
+            mode="external",
+            default_create_policy="must-exist",
+        ),
+        runtime=StorageRuntimeBinding(
+            pyiceberg_properties={"s3.region": "ap-southeast-2"},
+        ),
+        dbt=DbtStorageBinding(
+            profile_name="floe",
+            target_name="dev",
+            schema_name="analytics",
+        ),
+        dagster=DagsterStorageBinding(
+            resource_key="aws_s3_storage",
+            asset_io_manager_key="iceberg_io_manager",
+        ),
+    )
+```
+
+- [ ] **Step 2: Add fake plugin compile test**
+
+Add a test that monkeypatches `PluginRegistry` with fake `StoragePlugin` and `CatalogPlugin` classes. The fake catalog should return Glue requirements and a `CatalogDeploymentBinding(provider="glue", glue=...)`.
+
+```python
+def test_compile_accepts_fake_aws_s3_plus_glue_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from floe_core.composition.models import PluginRequirements, RequirementSet
+    from floe_core.plugin_types import PluginType
+    from floe_core.schemas.compiled_artifacts import (
+        CatalogDeploymentBinding,
+        GlueCatalogDeploymentBinding,
+    )
+
+    class FakeAwsS3Plugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "aws-s3"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://floe-provider-tests/warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return _fake_aws_s3_binding()
+
+    class FakeGluePlugin(CatalogPlugin):
+        @property
+        def name(self) -> str:
+            return "glue"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_storage_requirements(self) -> PluginRequirements:
+            return PluginRequirements(
+                plugin_type="catalog",
+                plugin_name="glue",
+                requirements=RequirementSet(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    identity_modes=["aws-irsa"],
+                ),
+            )
+
+        def build_catalog_deployment(
+            self,
+            storage: StorageDeploymentBinding,
+        ) -> CatalogDeploymentBinding:
+            return CatalogDeploymentBinding(
+                provider="glue",
+                glue=GlueCatalogDeploymentBinding(
+                    region=storage.endpoint.region,
+                    warehouse=storage.warehouse.uri if storage.warehouse else storage.endpoint.warehouse_path,
+                    catalog_id="278833447053",
+                    database_prefix="floe_provider_",
+                ),
+            )
+```
+
+Complete the fake catalog's unused abstract methods with `raise NotImplementedError`, and wire a registry that returns `FakeAwsS3Plugin` for `PluginType.STORAGE` and `FakeGluePlugin` for `PluginType.CATALOG`.
+
+Use a copied `demo/manifest.yaml` with:
+
+```python
+manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+manifest["plugins"]["storage"]["type"] = "aws-s3"
+manifest["plugins"]["storage"]["config"] = {}
+manifest["plugins"]["catalog"]["type"] = "glue"
+manifest["plugins"]["catalog"]["config"] = {}
+manifest_path = tmp_path / "manifest.yaml"
+manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+```
+
+Assert:
+
+```python
+artifacts = compile_pipeline(
+    ROOT / "demo" / "customer-360" / "floe.yaml",
+    manifest_path,
+    emit_lineage=False,
+)
+
+assert artifacts.deployment is not None
+assert artifacts.deployment.storage.provider == "aws-s3"
+assert artifacts.deployment.catalog.provider == "glue"
+assert artifacts.deployment.catalog.glue.region == "ap-southeast-2"
+assert "raw-secret-value" not in artifacts.model_dump_json()
+```
+
+- [ ] **Step 3: Run focused compilation test**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py::test_compile_accepts_fake_aws_s3_plus_glue_contract -q
+```
+
+Expected: PASS after abstract method stubs and registry monkeypatch are complete.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+git commit -m "test: prove compile contract for AWS S3 plus Glue"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No new source files.
+
+- [ ] **Step 1: Run focused test set**
+
+Run:
+
+```bash
+uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestGlueCatalogDeploymentBinding -q
+uv run pytest packages/floe-core/tests/unit/test_runtime_catalog_connection.py -q
+uv run pytest packages/floe-core/tests/unit/composition/test_resolver.py -q
+uv run pytest packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py -q
+uv run pytest packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run static checks**
+
+Run:
+
+```bash
+uv run ruff check packages/floe-core/src/floe_core/schemas/compiled_artifacts.py \
+  packages/floe-core/src/floe_core/runtime_catalog_connection.py \
+  packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py \
+  packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py \
+  packages/floe-core/tests/unit/test_runtime_catalog_connection.py \
+  packages/floe-core/tests/unit/composition/test_resolver.py \
+  packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py \
+  packages/floe-iceberg/tests/unit/test_runtime_catalog.py
+uv run mypy packages/floe-core/src/floe_core/schemas/compiled_artifacts.py \
+  packages/floe-core/src/floe_core/runtime_catalog_connection.py \
+  packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py
+git diff --check
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Commit any final fixups**
+
+If static checks required formatting or type fixups:
+
+```bash
+git add <changed-files>
+git commit -m "chore: finalize AWS provider core contracts"
+```
+
+If no files changed, skip this commit.
+
+- [ ] **Step 4: Report handoff**
+
+Report:
+
+- branch name
+- commit SHAs
+- tests run
+- whether plugin implementation worktrees can now be created
+
+Do not create plugin worktrees until this branch is merged or explicitly selected as their base.

--- a/docs/superpowers/specs/2026-05-12-aws-s3-glue-provider-design.md
+++ b/docs/superpowers/specs/2026-05-12-aws-s3-glue-provider-design.md
@@ -1,0 +1,426 @@
+# AWS S3 and Glue Provider Design
+
+Date: 2026-05-12
+Repo: `/Users/dmccarthy/Projects/floe`
+Branch: `feat/aws-provider-design`
+Status: Draft for review
+
+## Purpose
+
+Design native AWS S3 storage and AWS Glue catalog support against Floe's
+implemented composition model before starting plugin implementation, live AWS
+validation, AWS DevPod work, or `floe-bootstrap` IAM hardening.
+
+The merged AWS account scaffold prepares a low-cost validation substrate. It
+does not implement provider plugins. This design defines the missing provider
+contracts and the worktree sequencing needed to implement them without
+weakening composability.
+
+## Current System Map
+
+The current trunk already has the composition foundation needed for a native
+provider slice:
+
+- `CapabilitySet`, `RequirementSet`, `PluginCapabilities`, and
+  `PluginRequirements` live in `floe-core`.
+- `CompositionResolver` validates storage, catalog, ingestion, secrets, and
+  identity compatibility from declared capabilities and requirements.
+- `StorageDeploymentBinding` is the secret-free storage contract emitted by
+  `floe-storage-minio`.
+- `CatalogDeploymentBinding` is the secret-free catalog contract currently used
+  by Polaris.
+- `RuntimeCatalogConnection` is derived from deployment bindings and translated
+  by `floe-iceberg` into PyIceberg connection config.
+- `CompiledArtifacts` rejects raw credential material in runtime/catalog/storage
+  fragments.
+- Helm/renderers consume deployment bindings rather than rediscovering plugin
+  config.
+
+The missing pieces are explicit in the provider compatibility gap ledger:
+
+- No `floe-storage-aws-s3` package or `floe.storage` entry point exists.
+- No `floe-catalog-glue` package or `floe.catalogs` entry point exists.
+- Glue catalog runtime projection is not proven from
+  `RuntimeCatalogConnection`.
+- AWS credential and identity modes need resolver proof.
+
+## Design Options Considered
+
+### Option A: Implement S3 and Glue as thin config shims
+
+This would add provider packages that mostly translate manifest values directly
+to PyIceberg config and live AWS calls.
+
+Pros:
+
+- Fastest first live test.
+- Minimal core schema changes.
+
+Cons:
+
+- Runtime code would be tempted to rediscover plugin config.
+- Glue-specific facts would not be visible in `CompiledArtifacts`.
+- IAM and secret behavior would be harder to validate statically.
+
+Decision: reject. It moves too much integration knowledge into runtime code.
+
+### Option B: Add a broad provider abstraction layer
+
+This would introduce a generalized cloud provider model for AWS, GCP, Azure,
+IAM, endpoints, catalogs, and object storage.
+
+Pros:
+
+- Could support future clouds in one conceptual model.
+- Might reduce future schema churn.
+
+Cons:
+
+- Overgeneralizes before GCS and Azure have concrete product paths.
+- Risks a leaky abstraction that hides real provider differences.
+- Delays the first AWS proof.
+
+Decision: reject for this slice. Use GCS and Azure as pressure tests, not scope.
+
+### Option C: Provider-owned bindings on top of current neutral contracts
+
+AWS S3 emits the existing neutral `StorageDeploymentBinding` with native `s3`
+protocol and AWS credential/identity modes. Glue declares storage requirements
+and emits a provider-owned catalog binding plus runtime properties sufficient
+for PyIceberg Glue.
+
+Pros:
+
+- Preserves the current composition model.
+- Keeps provider-specific Glue details in the Glue plugin.
+- Keeps `CompiledArtifacts` secret-free while making runtime facts explicit.
+- Lets the resolver reject MinIO plus Glue and accept AWS S3 plus Glue.
+- Gives IAM hardening a concrete action inventory after plugin design.
+
+Cons:
+
+- Requires a small core contract extension for Glue catalog binding.
+- Requires careful runtime translator tests to avoid accidental REST-only bias.
+
+Decision: use Option C.
+
+## Architecture
+
+The target flow is:
+
+```text
+manifest plugin selections
+  -> AWS S3 plugin config validation
+  -> S3 StorageDeploymentBinding
+  -> Glue storage requirements
+  -> CompositionResolver validation
+  -> Glue CatalogDeploymentBinding
+  -> RuntimeCatalogConnection
+  -> PyIceberg Glue catalog config
+  -> live S3 + Glue validation
+```
+
+No plugin may inspect another plugin's concrete class or config model. The Glue
+plugin receives only `StorageDeploymentBinding` and its own config. The S3
+plugin does not know Glue exists.
+
+## AWS S3 Storage Plugin
+
+Package:
+
+- `plugins/floe-storage-aws-s3`
+- Module: `floe_storage_aws_s3`
+- Entry point: `aws-s3 = "floe_storage_aws_s3.plugin:AwsS3StoragePlugin"`
+- Plugin type: `floe.storage`
+
+Configuration model:
+
+- `bucket`: existing warehouse bucket name.
+- `warehouse_prefix`: warehouse prefix, default `warehouse/`.
+- `artifact_bucket`: optional artifact bucket. Defaults to `bucket`.
+- `artifact_prefix`: default `artifacts/`.
+- `region`: AWS region.
+- `endpoint_override`: optional. Only for localstack or non-standard S3
+  endpoints; unset for real AWS.
+- `path_style_access`: default `false`.
+- `credential_mode`: one of `environment`, `workload-identity`, or
+  `kubernetes-secret`.
+- `credential_secret_name`, `credential_secret_namespace`,
+  `access_key_secret_key`, `secret_key_secret_key`, and
+  `session_token_secret_key`: required only for `kubernetes-secret`.
+- `service_account_ref`: required only for `workload-identity`.
+- `create_policy`: default `must-exist`.
+- `sts_supported`: default `true`.
+
+Deployment binding:
+
+- `provider = "aws-s3"`.
+- `protocol = "s3"`.
+- `endpoint.region = region`.
+- `endpoint.warehouse_path = s3://<bucket>/<warehouse_prefix>`.
+- `endpoint.internal_url` and `endpoint.external_url` use the AWS regional S3
+  endpoint when `endpoint_override` is unset, and the override when set.
+- `warehouse.uri = s3://<bucket>/<warehouse_prefix>`.
+- `allowed_locations` includes the warehouse URI and optional artifact URI.
+- `buckets` declares warehouse and artifact requirements with `must-exist` by
+  default. Compile does not create buckets.
+- `capabilities.protocols = ["s3"]`.
+- `capabilities.credential_modes` mirrors the configured supported mode and may
+  include `environment` and `workload-identity` in tests where both are valid.
+- `capabilities.identity_modes` includes `aws-irsa` and `aws-pod-identity` when
+  workload identity is configured.
+- `capabilities.sts_supported = true`.
+- `capabilities.path_style_access = false` for native AWS by default.
+- `provisioning.enabled = false`, `mode = "external"`,
+  `default_create_policy = "must-exist"`.
+- `runtime.pyiceberg_properties` carries non-secret S3 properties only:
+  `s3.region`, optional `s3.endpoint`, and optional
+  `s3.path-style-access`.
+- `runtime.env_refs` carries AWS credential variable names for environment
+  mode only. It never carries values.
+
+The plugin should retain legacy abstract methods such as
+`get_dbt_profile_config()` and `get_dagster_io_manager_config()` for interface
+compliance, but new consumers must use `get_deployment_binding()`.
+
+## AWS Glue Catalog Plugin
+
+Package:
+
+- `plugins/floe-catalog-glue`
+- Module: `floe_catalog_glue`
+- Entry point: `glue = "floe_catalog_glue.plugin:GlueCatalogPlugin"`
+- Plugin type: `floe.catalogs`
+
+Configuration model:
+
+- `region`: AWS region.
+- `catalog_id`: optional AWS account/catalog ID.
+- `warehouse`: optional warehouse URI override. Defaults to the composed
+  storage warehouse URI.
+- `database_prefix`: optional prefix for Floe-created test namespaces.
+- `endpoint_override`: optional Glue endpoint for tests or local emulation.
+- `credential_mode`: one of `environment`, `workload-identity`, or
+  `kubernetes-secret`.
+- `skip_archive`: default `true`, matching PyIceberg Glue behavior unless a
+  future requirement proves otherwise.
+- `max_retries` and `retry_mode`: optional PyIceberg Glue client settings.
+
+Storage requirements:
+
+- `protocols = ["s3"]`.
+- `credential_modes` includes the configured AWS credential mode.
+- `identity_modes` includes `aws-irsa` and `aws-pod-identity` when configured
+  for workload identity.
+- `requires_server_side_storage_access = true`.
+- `supports_path_style_access = false` for real AWS S3.
+- `supports_no_sts = false` unless a specific non-STS path is proven.
+
+Catalog capabilities for peer consumers:
+
+- `catalog_providers = ["glue"]`.
+- `table_formats = ["iceberg"]`.
+
+Deployment binding:
+
+Add a provider-owned Glue binding to `CompiledArtifacts`:
+
+```python
+class GlueCatalogDeploymentBinding(BaseModel):
+    catalog_name: NonEmptyString = "glue"
+    region: NonEmptyString
+    warehouse: NonEmptyString
+    catalog_id: NonEmptyString | None = None
+    database_prefix: NonEmptyString | None = None
+    endpoint: NonEmptyString | None = None
+    skip_archive: bool = True
+    max_retries: int | None = None
+    retry_mode: NonEmptyString | None = None
+    credential_refs: dict[str, CredentialRef] = Field(default_factory=dict)
+    properties: dict[str, str] = Field(default_factory=dict)
+```
+
+Extend `CatalogDeploymentBinding` with:
+
+```python
+glue: GlueCatalogDeploymentBinding | None = None
+```
+
+Provider validation requires `provider == "glue"` to include `glue` details.
+Existing Polaris validation remains unchanged.
+
+Runtime projection:
+
+`build_runtime_catalog_connection()` must recognize `catalog.glue` and produce
+a `RuntimeCatalogConnection` that contains enough information for PyIceberg
+Glue without reading the original manifest or plugin config. Required
+properties:
+
+- `type = "glue"`.
+- `warehouse = <s3 warehouse uri>`.
+- `glue.region = <region>`.
+- `glue.id = <catalog_id>` when set.
+- `glue.endpoint = <endpoint_override>` when set.
+- `glue.skip-archive = "true"` or `"false"`.
+- `glue.max-retries` and `glue.retry-mode` when set.
+- client credential property names only when using environment references.
+
+The runtime translator in `floe-iceberg` must preserve those properties and
+must not assume all catalogs are Iceberg REST catalogs. The live implementation
+must verify the exact PyIceberg property names against the installed
+`pyiceberg.catalog.glue` constants before coding.
+
+## Core Contract Changes
+
+The first implementation branch should own shared contracts only:
+
+- Add `GlueCatalogDeploymentBinding`.
+- Extend `CatalogDeploymentBinding` validation.
+- Add schema and serialization tests proving Glue bindings are secret-free.
+- Add runtime connection tests for Glue.
+- Add resolver tests:
+  - AWS S3 plus Glue succeeds.
+  - MinIO plus Glue fails on protocol.
+  - AWS S3 plus Glue fails when credential modes do not overlap.
+  - Workload identity mode requires a compatible identity provider when no
+    non-identity credential mode overlaps.
+  - dlt or other ingestion consumers see Glue as an Iceberg-capable catalog
+    only if they require the right catalog provider. If existing ingestion
+    requires `iceberg-rest`, the AWS Glue path should fail until ingestion
+    explicitly supports `glue`.
+
+Do not widen `CompiledArtifacts` with raw provider config dumps. Add only the
+typed Glue binding and runtime properties needed by consumers.
+
+## Live AWS Validation
+
+Live validation happens after plugin contracts and package tests pass. It uses
+the existing `infra/aws-provider-tests` scaffold but does not let that scaffold
+define product contracts.
+
+Required live proof:
+
+- Compile a manifest selecting `aws-s3` and `glue`.
+- Confirm `CompiledArtifacts` has no raw credential values.
+- Confirm resolver accepts the AWS S3 plus Glue combination.
+- Confirm PyIceberg can connect to Glue using config derived from
+  `RuntimeCatalogConnection`.
+- Create/list/drop a Glue namespace under the test prefix.
+- Write/read/delete at least one Iceberg table or metadata object under the
+  test S3 run prefix if PyIceberg support is complete in the slice.
+- Run readiness before the live test and cleanup after the live test.
+- Record S3 object inventory and Glue database inventory after cleanup.
+
+The first live run should use environment credentials from the local
+`floe-aws-bootstrap` profile only as a sandbox proof. Kubernetes IRSA or AWS
+Pod Identity should be validated in a later AWS DevPod target once plugin
+contracts are stable.
+
+## Bootstrap IAM Sequencing
+
+Do not narrow `floe-bootstrap` before the plugin contract exists. Narrowing it
+too early would hard-code assumptions from infrastructure scaffolding instead
+of actual plugin/runtime behavior.
+
+After S3 and Glue plugins define and validate their required AWS actions, issue
+#331 should scope `floe-bootstrap` to:
+
+- OpenTofu management of the provider-test scaffold.
+- S3 bucket and object operations under the test bucket/prefix.
+- Glue database and table operations under the `floe_provider_*` namespace.
+- Budget read/write operations for the sandbox budget.
+- IAM policy management only for the provider-test policy.
+
+Runtime tests should eventually use a separate test principal or role, not the
+bootstrap identity.
+
+## Worktree Execution Plan
+
+Use `main` as trunk only. Branches should land in this order:
+
+1. `feat/aws-provider-design`
+   - Owns this design document.
+   - No production code.
+
+2. `feat/aws-provider-core-contracts`
+   - Owns `floe-core` and `floe-iceberg` contract/runtime projection changes.
+   - Adds resolver, schema, and runtime translator tests.
+   - Merges before plugin implementation branches.
+
+3. `feat/storage-aws-s3`
+   - Owns `plugins/floe-storage-aws-s3`.
+   - Adds package unit tests and plugin entry point.
+   - Does not edit root workspace metadata until integration.
+
+4. `feat/catalog-glue`
+   - Owns `plugins/floe-catalog-glue`.
+   - Adds package unit tests and plugin entry point.
+   - Does not edit root workspace metadata until integration.
+
+5. `feat/aws-provider-live-validation`
+   - Registers both plugins in workspace metadata.
+   - Adds cross-package contract tests and live AWS validation docs.
+   - Uses `infra/aws-provider-tests` readiness and cleanup scripts.
+
+6. `feat/aws-bootstrap-scope`
+   - Owns #331 IAM hardening.
+   - Uses evidence from the plugin and live validation branches to narrow
+     `floe-bootstrap`.
+
+Run at most two plugin implementation sessions in parallel after core
+contracts merge: one for S3 and one for Glue. Keep core contracts, integration,
+live validation, and IAM hardening sequential.
+
+## Testing Strategy
+
+Static and unit evidence:
+
+- Plugin config validation tests for all credential modes.
+- Entry point discovery tests for both packages.
+- Resolver tests for valid and invalid AWS S3 plus Glue combinations.
+- `CompiledArtifacts` schema tests for Glue binding serialization and
+  secret-free validation.
+- Runtime translator tests for PyIceberg Glue config.
+- Package tests proving `get_deployment_binding()` emits only refs and
+  non-secret properties.
+
+Contract evidence:
+
+- Core-to-storage contract for `aws-s3`.
+- Core-to-catalog contract for `glue`.
+- Cross-plugin compilation test for `aws-s3` plus `glue`.
+- Negative compilation test for `minio` plus `glue`.
+
+Live evidence:
+
+- AWS readiness script passes before validation.
+- PyIceberg/Glue namespace or table lifecycle succeeds against live AWS.
+- Cleanup script passes after validation.
+- S3 and Glue inventories are empty for the run prefix after cleanup.
+
+CI and local validation:
+
+- `make test-unit` or targeted package/unit equivalents.
+- `uv run pytest packages/floe-core/tests/unit/composition -q`.
+- `uv run pytest packages/floe-core/tests/unit/schemas -q` focused to changed
+  schema tests.
+- `uv run pytest packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q`.
+- Package unit tests for each new plugin.
+- Docs validation for design and validation artifacts.
+
+## Out Of Scope
+
+- AWS DevPod or EKS deployment target.
+- Full Kubernetes IRSA validation.
+- GCS, Azure, Nessie, or Hive implementation.
+- Glue crawlers, Glue jobs, Lake Formation, and S3 Tables.
+- Destroying or recreating the AWS provider-test scaffold.
+- Compatibility aliases for the removed legacy `s3` storage plugin identity.
+- Any path that places AWS access keys, secret keys, session tokens, OAuth
+  tokens, or credential values in `CompiledArtifacts`.
+
+## Approval Gate
+
+Implementation should not start until this design is reviewed and approved.
+After approval, create a dedicated plan for the core contract branch before
+opening the S3 and Glue plugin worktrees.

--- a/packages/floe-core/src/floe_core/runtime_catalog_connection.py
+++ b/packages/floe-core/src/floe_core/runtime_catalog_connection.py
@@ -19,6 +19,7 @@ def build_runtime_catalog_connection(
     catalog_name = "iceberg"
     catalog_uri: str | None = None
     warehouse: str | None = None
+    region: str | None = None
     path_style_access: bool | None = None
     properties: dict[str, str] = {}
     credential_refs: dict[str, CredentialRef] = {}
@@ -45,8 +46,26 @@ def build_runtime_catalog_connection(
         path_style_access = polaris.path_style_access
         credential_refs.update(polaris.credential_refs)
 
+    if catalog is not None and catalog.glue is not None:
+        glue = catalog.glue
+        catalog_name = glue.catalog_name
+        warehouse = glue.warehouse
+        region = glue.region
+        credential_refs.update(glue.credential_refs)
+        properties["type"] = "glue"
+        properties["glue.region"] = glue.region
+        properties["glue.skip-archive"] = str(glue.skip_archive).lower()
+        if glue.catalog_id is not None:
+            properties["glue.id"] = glue.catalog_id
+        if glue.endpoint is not None:
+            properties["glue.endpoint"] = glue.endpoint
+        if glue.max_retries is not None:
+            properties["glue.max-retries"] = str(glue.max_retries)
+        if glue.retry_mode is not None:
+            properties["glue.retry-mode"] = glue.retry_mode
+        properties.update(glue.properties)
+
     storage_endpoint: str | None = None
-    region: str | None = None
     if storage is not None:
         storage_endpoint = storage.endpoint.internal_url
         region = storage.endpoint.region

--- a/packages/floe-core/src/floe_core/runtime_catalog_connection.py
+++ b/packages/floe-core/src/floe_core/runtime_catalog_connection.py
@@ -6,6 +6,7 @@ from floe_core.schemas.compiled_artifacts import (
     CatalogDeploymentBinding,
     CredentialRef,
     RuntimeCatalogConnection,
+    RuntimeCatalogPropertyValue,
     StorageDeploymentBinding,
 )
 
@@ -21,7 +22,7 @@ def build_runtime_catalog_connection(
     warehouse: str | None = None
     region: str | None = None
     path_style_access: bool | None = None
-    properties: dict[str, str] = {}
+    properties: dict[str, RuntimeCatalogPropertyValue] = {}
     credential_refs: dict[str, CredentialRef] = {}
     env_refs: dict[str, str] = {}
 
@@ -54,13 +55,14 @@ def build_runtime_catalog_connection(
         credential_refs.update(glue.credential_refs)
         properties["type"] = "glue"
         properties["glue.region"] = glue.region
+        # PyIceberg parses skip-archive with strtobool, so keep its canonical string form.
         properties["glue.skip-archive"] = str(glue.skip_archive).lower()
         if glue.catalog_id is not None:
             properties["glue.id"] = glue.catalog_id
         if glue.endpoint is not None:
             properties["glue.endpoint"] = glue.endpoint
         if glue.max_retries is not None:
-            properties["glue.max-retries"] = str(glue.max_retries)
+            properties["glue.max-retries"] = glue.max_retries
         if glue.retry_mode is not None:
             properties["glue.retry-mode"] = glue.retry_mode
         properties.update(glue.properties)

--- a/packages/floe-core/src/floe_core/runtime_catalog_connection.py
+++ b/packages/floe-core/src/floe_core/runtime_catalog_connection.py
@@ -57,6 +57,7 @@ def build_runtime_catalog_connection(
         properties["glue.region"] = glue.region
         # PyIceberg parses skip-archive with strtobool, so keep its canonical string form.
         properties["glue.skip-archive"] = str(glue.skip_archive).lower()
+        # database_prefix is consumed by Glue namespace operations, not PyIceberg loading.
         if glue.catalog_id is not None:
             properties["glue.id"] = glue.catalog_id
         if glue.endpoint is not None:

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -42,6 +42,7 @@ PRODUCT_NAME_PATTERN = r"^[a-zA-Z][a-zA-Z0-9_-]*$"
 _MAX_K8S_NAME_LENGTH = 253
 _MAX_K8S_NAMESPACE_LENGTH = 63
 NonEmptyString = Annotated[str, Field(min_length=1)]
+RuntimeCatalogPropertyValue = str | int | bool
 _SECRET_FIELD_MARKERS = (
     "access-key",
     "access_key",
@@ -1072,13 +1073,16 @@ class RuntimeCatalogConnection(BaseModel):
     storage_endpoint: NonEmptyString | None = None
     region: NonEmptyString | None = None
     path_style_access: bool | None = None
-    properties: dict[str, str] = Field(default_factory=dict)
+    properties: dict[str, RuntimeCatalogPropertyValue] = Field(default_factory=dict)
     credential_refs: dict[str, CredentialRef] = Field(default_factory=dict)
     env_refs: dict[str, NonEmptyString] = Field(default_factory=dict)
 
     @field_validator("properties")
     @classmethod
-    def validate_secret_free_properties(cls, value: dict[str, str]) -> dict[str, str]:
+    def validate_secret_free_properties(
+        cls,
+        value: dict[str, RuntimeCatalogPropertyValue],
+    ) -> dict[str, RuntimeCatalogPropertyValue]:
         """Ensure runtime catalog properties do not inline credential material."""
         for key, property_value in value.items():
             if key == "token-refresh-enabled":
@@ -1979,6 +1983,7 @@ __all__ = [
     # Governance resolution (v0.2.0)
     "ResolvedGovernance",
     "RuntimeCatalogConnection",
+    "RuntimeCatalogPropertyValue",
     # Enforcement summary (v0.3.0 - Epic 3B)
     "EnforcementResultSummary",
     # Deployment bindings

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -949,6 +949,31 @@ class PolarisCatalogDeploymentBinding(BaseModel):
     credential_refs: dict[str, CredentialRef] = Field(default_factory=dict)
 
 
+class GlueCatalogDeploymentBinding(BaseModel):
+    """AWS Glue catalog-owned deployment and runtime configuration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    catalog_name: NonEmptyString = "glue"
+    region: NonEmptyString
+    warehouse: NonEmptyString
+    catalog_id: NonEmptyString | None = None
+    database_prefix: NonEmptyString | None = None
+    endpoint: NonEmptyString | None = None
+    skip_archive: bool = True
+    max_retries: int | None = Field(default=None, ge=1)
+    retry_mode: NonEmptyString | None = None
+    credential_refs: dict[str, CredentialRef] = Field(default_factory=dict)
+    properties: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("properties")
+    @classmethod
+    def validate_secret_free_properties(cls, value: dict[str, str]) -> dict[str, str]:
+        """Ensure Glue catalog properties do not inline credential values."""
+        _assert_no_secret_material(value, "catalog.glue.properties")
+        return value
+
+
 class IcebergRestOAuth2Binding(BaseModel):
     """Secret-free OAuth2 references for an Iceberg REST catalog consumer."""
 
@@ -1005,6 +1030,7 @@ class CatalogDeploymentBinding(BaseModel):
 
     provider: NonEmptyString
     polaris: PolarisCatalogDeploymentBinding | None = None
+    glue: GlueCatalogDeploymentBinding | None = None
     iceberg_rest: IcebergRestCatalogBinding | None = None
     dbt: DbtCatalogBinding | None = None
 
@@ -1013,6 +1039,9 @@ class CatalogDeploymentBinding(BaseModel):
         """Ensure provider-specific catalog binding is present when required."""
         if self.provider == "polaris" and self.polaris is None:
             msg = "polaris catalog deployment binding requires polaris details"
+            raise ValueError(msg)
+        if self.provider == "glue" and self.glue is None:
+            msg = "glue catalog deployment binding requires glue details"
             raise ValueError(msg)
         return self
 
@@ -1917,6 +1946,7 @@ __all__ = [
     "DeploymentConfig",
     "DeploymentMode",
     "DltIngestionBinding",
+    "GlueCatalogDeploymentBinding",
     "IcebergRestCatalogBinding",
     "IcebergRestOAuth2Binding",
     "IngestionDeploymentBinding",

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -42,6 +42,7 @@ PRODUCT_NAME_PATTERN = r"^[a-zA-Z][a-zA-Z0-9_-]*$"
 _MAX_K8S_NAME_LENGTH = 253
 _MAX_K8S_NAMESPACE_LENGTH = 63
 NonEmptyString = Annotated[str, Field(min_length=1)]
+AwsAccountId = Annotated[str, Field(pattern=r"^\d{12}$")]
 RuntimeCatalogPropertyValue = str | int | bool
 _SECRET_FIELD_MARKERS = (
     "access-key",
@@ -958,7 +959,7 @@ class GlueCatalogDeploymentBinding(BaseModel):
     catalog_name: NonEmptyString = "glue"
     region: NonEmptyString
     warehouse: NonEmptyString
-    catalog_id: NonEmptyString | None = None
+    catalog_id: AwsAccountId | None = None
     database_prefix: NonEmptyString | None = None
     endpoint: NonEmptyString | None = None
     skip_archive: bool = True
@@ -1053,8 +1054,14 @@ class CatalogDeploymentBinding(BaseModel):
     @model_validator(mode="after")
     def validate_provider_binding(self) -> CatalogDeploymentBinding:
         """Ensure provider-specific catalog binding is present when required."""
+        if self.provider != "polaris" and self.polaris is not None:
+            msg = "polaris catalog deployment binding requires provider 'polaris'"
+            raise ValueError(msg)
         if self.provider == "polaris" and self.polaris is None:
             msg = "polaris catalog deployment binding requires polaris details"
+            raise ValueError(msg)
+        if self.provider != "glue" and self.glue is not None:
+            msg = "glue catalog deployment binding requires provider 'glue'"
             raise ValueError(msg)
         if self.provider == "glue" and self.glue is None:
             msg = "glue catalog deployment binding requires glue details"

--- a/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
+++ b/packages/floe-core/src/floe_core/schemas/compiled_artifacts.py
@@ -973,6 +973,21 @@ class GlueCatalogDeploymentBinding(BaseModel):
         _assert_no_secret_material(value, "catalog.glue.properties")
         return value
 
+    @field_validator("warehouse")
+    @classmethod
+    def validate_secret_free_warehouse(cls, value: str) -> str:
+        """Ensure Glue warehouse URI does not inline credential values."""
+        _assert_no_secret_material(value, "catalog.glue.warehouse")
+        return value
+
+    @field_validator("endpoint")
+    @classmethod
+    def validate_secret_free_endpoint(cls, value: str | None) -> str | None:
+        """Ensure Glue endpoint URI does not inline credential values."""
+        if value is not None:
+            _assert_no_secret_material(value, "catalog.glue.endpoint")
+        return value
+
 
 class IcebergRestOAuth2Binding(BaseModel):
     """Secret-free OAuth2 references for an Iceberg REST catalog consumer."""

--- a/packages/floe-core/src/floe_core/schemas/versions.py
+++ b/packages/floe-core/src/floe_core/schemas/versions.py
@@ -29,7 +29,7 @@ FLOE_VERSION: str = "0.3.0"
 # Increment MAJOR for breaking changes (remove fields, change types)
 # Increment MINOR for backward-compatible additions (new optional fields)
 # Increment PATCH for documentation/metadata only changes
-COMPILED_ARTIFACTS_VERSION: str = "0.15.0"
+COMPILED_ARTIFACTS_VERSION: str = "0.16.0"
 
 # Version history (for documentation and compatibility checks)
 COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
@@ -48,6 +48,7 @@ COMPILED_ARTIFACTS_VERSION_HISTORY: dict[str, str] = {
     "0.13.0": "Add secret projection credential binding modes",
     "0.14.0": "Add ingestion_outputs to CompiledArtifacts",
     "0.15.0": "Add Iceberg REST catalog projection to catalog deployment bindings",
+    "0.16.0": ("Add Glue catalog deployment binding and typed runtime catalog property values"),
 }
 
 
@@ -61,7 +62,7 @@ def get_compiled_artifacts_version() -> str:
         >>> from floe_core.schemas.versions import get_compiled_artifacts_version
         >>> version = get_compiled_artifacts_version()
         >>> version
-        '0.15.0'
+        '0.16.0'
     """
     return COMPILED_ARTIFACTS_VERSION
 

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -281,6 +281,7 @@ def test_compile_accepts_fake_aws_s3_plus_glue_contract(
     from floe_core.composition.models import CapabilitySet, PluginCapabilities
     from floe_core.plugin_types import PluginType
     from floe_core.plugins.identity import IdentityPlugin, TokenValidationResult, UserInfo
+    from floe_core.runtime_catalog_connection import build_runtime_catalog_connection
     from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
 
     class FakeAwsS3Plugin(StoragePlugin):
@@ -490,11 +491,64 @@ transforms:
     assert artifacts.deployment is not None
     assert artifacts.deployment.storage is not None
     assert artifacts.deployment.catalog is not None
-    assert artifacts.deployment.storage.provider == "aws-s3"
-    assert artifacts.deployment.catalog.provider == "glue"
-    assert artifacts.deployment.catalog.glue is not None
-    assert artifacts.deployment.catalog.glue.region == "ap-southeast-2"
-    assert "raw-secret-value" not in artifacts.model_dump_json()
+
+    storage = artifacts.deployment.storage
+    catalog = artifacts.deployment.catalog
+    assert storage.provider == "aws-s3"
+    assert storage.protocol == "s3"
+    assert storage.endpoint.region == "ap-southeast-2"
+    assert storage.endpoint.warehouse_path == "s3://floe-provider-tests/warehouse/"
+    assert storage.endpoint.path_style_access is False
+    assert storage.warehouse is not None
+    assert storage.warehouse.bucket == "floe-provider-tests"
+    assert storage.warehouse.prefix == "warehouse/"
+    assert storage.warehouse.uri == "s3://floe-provider-tests/warehouse/"
+    assert storage.credentials.mode == "workload-identity"
+    assert storage.credentials.service_account_ref == "floe-provider-tests"
+    assert storage.capabilities.protocols == ["s3"]
+    assert storage.capabilities.credential_modes == ["workload-identity"]
+    assert storage.capabilities.identity_modes == ["aws-irsa"]
+    assert storage.capabilities.sts_supported is True
+    assert storage.capabilities.path_style_access is False
+    assert storage.provisioning.enabled is False
+    assert storage.provisioning.mode == "external"
+    assert storage.runtime.pyiceberg_properties["s3.region"] == "ap-southeast-2"
+    assert storage.dbt.profile_name == "floe"
+    assert storage.dbt.target_name == "dev"
+    assert storage.dbt.schema_name == "analytics"
+    assert storage.dagster.resource_key == "aws_s3_storage"
+    assert storage.dagster.asset_io_manager_key == "iceberg_io_manager"
+
+    assert catalog.provider == "glue"
+    assert catalog.glue is not None
+    glue = catalog.glue
+    assert glue.region == "ap-southeast-2"
+    assert glue.warehouse == "s3://floe-provider-tests/warehouse/"
+    assert glue.catalog_id == "278833447053"
+    assert glue.database_prefix == "floe_provider_"
+    assert glue.properties == {"glue.region": "ap-southeast-2"}
+    assert glue.credential_refs["role"].source == "workload-identity"
+    assert glue.credential_refs["role"].name == "floe-provider-tests"
+    assert glue.credential_refs["role"].key is None
+
+    runtime_connection = build_runtime_catalog_connection(storage=storage, catalog=catalog)
+    assert runtime_connection.catalog_name == "glue"
+    assert runtime_connection.warehouse == "s3://floe-provider-tests/warehouse/"
+    assert runtime_connection.storage_endpoint == "https://s3.ap-southeast-2.amazonaws.com"
+    assert runtime_connection.region == "ap-southeast-2"
+    assert runtime_connection.path_style_access is False
+    assert runtime_connection.properties["type"] == "glue"
+    assert runtime_connection.properties["glue.region"] == "ap-southeast-2"
+    assert runtime_connection.properties["glue.id"] == "278833447053"
+    assert runtime_connection.properties["s3.region"] == "ap-southeast-2"
+    assert runtime_connection.credential_refs["role"].source == "workload-identity"
+    assert runtime_connection.credential_refs["role"].name == "floe-provider-tests"
+
+    serialized_artifacts = artifacts.model_dump_json()
+    assert "raw-secret-value" not in serialized_artifacts
+    assert "aws_secret_access_key" not in serialized_artifacts.lower()
+    assert "secretAccessKey" not in serialized_artifacts
+    assert "AKIA" not in serialized_artifacts
 
 
 def test_incompatible_storage_catalog_composition_raises_structured_error(

--- a/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
+++ b/packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py
@@ -40,6 +40,59 @@ def _disable_plugin_instrumentation_audit(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(stages, "_discover_plugins_for_audit", lambda: [])
 
 
+def _fake_aws_s3_binding() -> StorageDeploymentBinding:
+    from floe_core.schemas.compiled_artifacts import (
+        StorageProvisioningIntent,
+        StorageRuntimeBinding,
+    )
+
+    return StorageDeploymentBinding(
+        provider="aws-s3",
+        protocol="s3",
+        endpoint=StorageServiceEndpoint(
+            internal_url="https://s3.ap-southeast-2.amazonaws.com",
+            external_url="https://s3.ap-southeast-2.amazonaws.com",
+            region="ap-southeast-2",
+            warehouse_path="s3://floe-provider-tests/warehouse/",
+            path_style_access=False,
+        ),
+        warehouse=StorageWarehouse(
+            uri="s3://floe-provider-tests/warehouse/",
+            bucket="floe-provider-tests",
+            prefix="warehouse/",
+        ),
+        allowed_locations=["s3://floe-provider-tests/warehouse/"],
+        credentials=StorageCredentialBinding(
+            mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        ),
+        capabilities=StorageCapabilities(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            sts_supported=True,
+            path_style_access=False,
+        ),
+        provisioning=StorageProvisioningIntent(
+            enabled=False,
+            mode="external",
+            default_create_policy="must-exist",
+        ),
+        runtime=StorageRuntimeBinding(
+            pyiceberg_properties={"s3.region": "ap-southeast-2"},
+        ),
+        dbt=DbtStorageBinding(
+            profile_name="floe",
+            target_name="dev",
+            schema_name="analytics",
+        ),
+        dagster=DagsterStorageBinding(
+            resource_key="aws_s3_storage",
+            asset_io_manager_key="iceberg_io_manager",
+        ),
+    )
+
+
 def test_demo_compile_emits_minio_storage_deployment_binding() -> None:
     """Demo compilation must attach the MinIO deployment storage binding."""
     artifacts = compile_pipeline(
@@ -218,6 +271,230 @@ def test_storage_plugin_binding_failure_raises_structured_compilation_error(
         "storage_plugin": "minio",
         "error_type": "PluginConfigurationError",
     }
+
+
+def test_compile_accepts_fake_aws_s3_plus_glue_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compilation accepts fake AWS S3 storage with fake Glue catalog binding."""
+    from floe_core.composition.models import CapabilitySet, PluginCapabilities
+    from floe_core.plugin_types import PluginType
+    from floe_core.plugins.identity import IdentityPlugin, TokenValidationResult, UserInfo
+    from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+    class FakeAwsS3Plugin(StoragePlugin):
+        @property
+        def name(self) -> str:
+            return "aws-s3"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def get_pyiceberg_fileio(self) -> FileIO:
+            raise NotImplementedError
+
+        def get_warehouse_uri(self, namespace: str) -> str:
+            return f"s3://floe-provider-tests/warehouse/{namespace}"
+
+        def get_dbt_profile_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_dagster_io_manager_config(self) -> dict[str, Any]:
+            return {}
+
+        def get_helm_values_override(self) -> dict[str, Any]:
+            return {}
+
+        def get_deployment_binding(self) -> StorageDeploymentBinding:
+            return _fake_aws_s3_binding()
+
+    class FakeAwsIrsaPlugin(IdentityPlugin):
+        @property
+        def name(self) -> str:
+            return "aws-irsa"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def authenticate(self, credentials: dict[str, Any]) -> str | None:
+            raise NotImplementedError
+
+        def get_user_info(self, token: str) -> UserInfo | None:
+            raise NotImplementedError
+
+        def validate_token(self, token: str) -> TokenValidationResult:
+            raise NotImplementedError
+
+        def get_identity_capabilities(self) -> PluginCapabilities:
+            return PluginCapabilities(
+                plugin_type="identity",
+                plugin_name="aws-irsa",
+                capabilities=CapabilitySet(identity_modes=["aws-irsa"]),
+            )
+
+    class FakeGluePlugin(CatalogPlugin):
+        @property
+        def name(self) -> str:
+            return "glue"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        @property
+        def floe_api_version(self) -> str:
+            return "1.0"
+
+        def connect(self, config: dict[str, Any]) -> Any:
+            raise NotImplementedError
+
+        def create_namespace(
+            self,
+            namespace: str,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            raise NotImplementedError
+
+        def vend_credentials(self, table_path: str, operations: list[str]) -> dict[str, Any]:
+            raise NotImplementedError
+
+        def list_namespaces(self, parent: str | None = None) -> list[str]:
+            raise NotImplementedError
+
+        def delete_namespace(self, namespace: str) -> None:
+            raise NotImplementedError
+
+        def create_table(
+            self,
+            identifier: str,
+            schema: dict[str, Any],
+            location: str | None = None,
+            properties: dict[str, str] | None = None,
+        ) -> None:
+            raise NotImplementedError
+
+        def list_tables(self, namespace: str) -> list[str]:
+            raise NotImplementedError
+
+        def drop_table(self, identifier: str, purge: bool = False) -> None:
+            raise NotImplementedError
+
+        def get_storage_requirements(self) -> PluginRequirements:
+            return PluginRequirements(
+                plugin_type="catalog",
+                plugin_name="glue",
+                requirements=RequirementSet(
+                    protocols=["s3"],
+                    credential_modes=["workload-identity"],
+                    identity_modes=["aws-irsa"],
+                ),
+            )
+
+        def build_catalog_deployment(
+            self,
+            storage: StorageDeploymentBinding,
+        ) -> CatalogDeploymentBinding:
+            warehouse = (
+                storage.warehouse.uri if storage.warehouse else storage.endpoint.warehouse_path
+            )
+            return CatalogDeploymentBinding(
+                provider="glue",
+                glue=GlueCatalogDeploymentBinding(
+                    region=storage.endpoint.region,
+                    warehouse=warehouse,
+                    catalog_id="278833447053",
+                    database_prefix="floe_provider_",
+                    credential_refs={
+                        "role": storage.credentials.as_credential_ref("role"),
+                    },
+                    properties={"glue.region": storage.runtime.pyiceberg_properties["s3.region"]},
+                ),
+            )
+
+    import floe_core.plugin_registry as plugin_registry
+
+    original_registry = plugin_registry.PluginRegistry
+
+    class IsolatedAwsGlueRegistry:
+        def __init__(self) -> None:
+            self._delegate = original_registry()
+
+        def discover_all(self) -> None:
+            self._delegate.discover_all()
+
+        def configure(
+            self,
+            plugin_type: PluginType,
+            name: str,
+            config: dict[str, Any],
+        ) -> None:
+            if plugin_type in {PluginType.STORAGE, PluginType.CATALOG, PluginType.IDENTITY}:
+                return None
+            self._delegate.configure(plugin_type, name, config)
+            return None
+
+        def get(
+            self,
+            plugin_type: PluginType,
+            name: str,
+        ) -> StoragePlugin | CatalogPlugin | IdentityPlugin:
+            if plugin_type == PluginType.STORAGE:
+                return FakeAwsS3Plugin()
+            if plugin_type == PluginType.CATALOG:
+                return FakeGluePlugin()
+            if plugin_type == PluginType.IDENTITY:
+                return FakeAwsIrsaPlugin()
+            return self._delegate.get(plugin_type, name)
+
+    monkeypatch.setattr(plugin_registry, "PluginRegistry", IsolatedAwsGlueRegistry)
+
+    spec_path = tmp_path / "floe.yaml"
+    spec_path.write_text(
+        """
+apiVersion: floe.dev/v1
+kind: FloeSpec
+metadata:
+  name: aws-glue-contract
+  version: 1.0.0
+transforms:
+  - name: orders
+""",
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest = yaml.safe_load((ROOT / "demo" / "manifest.yaml").read_text(encoding="utf-8"))
+    manifest["plugins"]["storage"]["type"] = "aws-s3"
+    manifest["plugins"]["storage"]["config"] = {}
+    manifest["plugins"]["catalog"]["type"] = "glue"
+    manifest["plugins"]["catalog"]["config"] = {}
+    manifest["plugins"]["identity"] = {"type": "aws-irsa", "config": {}}
+    manifest_path.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+    artifacts = compile_pipeline(
+        spec_path,
+        manifest_path,
+        emit_lineage=False,
+    )
+
+    assert artifacts.deployment is not None
+    assert artifacts.deployment.storage is not None
+    assert artifacts.deployment.catalog is not None
+    assert artifacts.deployment.storage.provider == "aws-s3"
+    assert artifacts.deployment.catalog.provider == "glue"
+    assert artifacts.deployment.catalog.glue is not None
+    assert artifacts.deployment.catalog.glue.region == "ap-southeast-2"
+    assert "raw-secret-value" not in artifacts.model_dump_json()
 
 
 def test_incompatible_storage_catalog_composition_raises_structured_error(

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -344,8 +344,6 @@ def test_resolver_rejects_minio_plus_glue_native_s3_requirement() -> None:
         capabilities=CapabilitySet(
             protocols=["s3-compatible"],
             credential_modes=["kubernetes-secret"],
-            path_style_access=True,
-            sts=False,
         ),
     )
     catalog = PluginRequirements(
@@ -366,10 +364,34 @@ def test_resolver_rejects_minio_plus_glue_native_s3_requirement() -> None:
     result = resolver.validate([storage, identity], [catalog])
 
     assert result.valid is False
-    assert sorted(issue.code for issue in result.issues) == [
-        "COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED",
-        "COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
-        "COMPOSITION_PROTOCOL_UNSUPPORTED",
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_PROTOCOL_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of protocols ['s3']; "
+                "storage minio provides ['s3-compatible']"
+            ),
+            plugins=["storage:minio", "catalog:glue"],
+        ),
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of credential modes ['workload-identity']; "
+                "storage minio provides ['kubernetes-secret']"
+            ),
+            plugins=["storage:minio", "catalog:glue"],
+        ),
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+            message=(
+                "catalog glue requires one of identity modes ['aws-irsa']; "
+                "storage minio provides []; identity aws-irsa provides ['aws-irsa']"
+            ),
+            plugins=["storage:minio", "identity:aws-irsa", "catalog:glue"],
+        ),
     ]
 
 

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -300,3 +300,107 @@ def test_resolver_ingestion_credential_error_names_ingestion_plugin() -> None:
             plugins=["storage:minio", "ingestion:dlt"],
         )
     ]
+
+
+def test_resolver_accepts_aws_s3_plus_glue_with_workload_identity() -> None:
+    """Resolver must accept AWS S3 plus Glue with native S3 workload identity."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="aws-s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+            sts=True,
+            path_style_access=False,
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa", "aws-pod-identity"],
+            requires_server_side_storage_access=True,
+            supports_no_sts=False,
+            supports_path_style_access=False,
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws-irsa",
+        capabilities=CapabilitySet(identity_modes=["aws-irsa"]),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is True
+    assert result.issues == []
+
+
+def test_resolver_rejects_minio_plus_glue_native_s3_requirement() -> None:
+    """Resolver must reject MinIO when Glue requires native S3 workload identity."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="minio",
+        capabilities=CapabilitySet(
+            protocols=["s3-compatible"],
+            credential_modes=["kubernetes-secret"],
+            path_style_access=True,
+            sts=False,
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    identity = PluginCapabilities(
+        plugin_type="identity",
+        plugin_name="aws-irsa",
+        capabilities=CapabilitySet(identity_modes=["aws-irsa"]),
+    )
+
+    result = resolver.validate([storage, identity], [catalog])
+
+    assert result.valid is False
+    assert sorted(issue.code for issue in result.issues) == [
+        "COMPOSITION_CREDENTIAL_MODE_UNSUPPORTED",
+        "COMPOSITION_IDENTITY_MODE_UNSUPPORTED",
+        "COMPOSITION_PROTOCOL_UNSUPPORTED",
+    ]
+
+
+def test_resolver_rejects_glue_workload_identity_without_identity_provider() -> None:
+    """Resolver must reject Glue workload identity without an identity plugin."""
+    resolver = CompositionResolver()
+    storage = PluginCapabilities(
+        plugin_type="storage",
+        plugin_name="aws-s3",
+        capabilities=CapabilitySet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+    catalog = PluginRequirements(
+        plugin_type="catalog",
+        plugin_name="glue",
+        requirements=RequirementSet(
+            protocols=["s3"],
+            credential_modes=["workload-identity"],
+            identity_modes=["aws-irsa"],
+        ),
+    )
+
+    result = resolver.validate([storage], [catalog])
+
+    assert result.valid is False
+    assert result.issues[0].code == "COMPOSITION_IDENTITY_PROVIDER_MISSING"

--- a/packages/floe-core/tests/unit/composition/test_resolver.py
+++ b/packages/floe-core/tests/unit/composition/test_resolver.py
@@ -312,8 +312,6 @@ def test_resolver_accepts_aws_s3_plus_glue_with_workload_identity() -> None:
             protocols=["s3"],
             credential_modes=["workload-identity"],
             identity_modes=["aws-irsa"],
-            sts=True,
-            path_style_access=False,
         ),
     )
     catalog = PluginRequirements(
@@ -323,9 +321,6 @@ def test_resolver_accepts_aws_s3_plus_glue_with_workload_identity() -> None:
             protocols=["s3"],
             credential_modes=["workload-identity"],
             identity_modes=["aws-irsa", "aws-pod-identity"],
-            requires_server_side_storage_access=True,
-            supports_no_sts=False,
-            supports_path_style_access=False,
         ),
     )
     identity = PluginCapabilities(
@@ -403,4 +398,13 @@ def test_resolver_rejects_glue_workload_identity_without_identity_provider() -> 
     result = resolver.validate([storage], [catalog])
 
     assert result.valid is False
-    assert result.issues[0].code == "COMPOSITION_IDENTITY_PROVIDER_MISSING"
+    assert result.issues == [
+        CompositionIssue(
+            severity="error",
+            code="COMPOSITION_IDENTITY_PROVIDER_MISSING",
+            message=(
+                "catalog glue requires identity mode aws-irsa but no identity plugin was selected"
+            ),
+            plugins=["catalog:glue"],
+        )
+    ]

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1030,6 +1030,67 @@ class TestStorageDeploymentBinding:
             factory()
 
 
+class TestGlueCatalogDeploymentBinding:
+    """Tests for AWS Glue catalog deployment binding."""
+
+    def test_glue_catalog_binding_serializes_secret_free_fields(self) -> None:
+        from floe_core.schemas.compiled_artifacts import (
+            CatalogDeploymentBinding,
+            CredentialRef,
+            GlueCatalogDeploymentBinding,
+        )
+
+        binding = CatalogDeploymentBinding(
+            provider="glue",
+            glue=GlueCatalogDeploymentBinding(
+                catalog_name="glue",
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                catalog_id="278833447053",
+                database_prefix="floe_provider_",
+                skip_archive=True,
+                max_retries=5,
+                retry_mode="standard",
+                credential_refs={
+                    "role": CredentialRef(
+                        source="workload-identity",
+                        name="floe-provider-tests",
+                    )
+                },
+                properties={"glue.skip-archive": "true"},
+            ),
+        )
+
+        payload = binding.model_dump(mode="json")
+
+        assert payload["provider"] == "glue"
+        assert payload["glue"]["region"] == "ap-southeast-2"
+        assert payload["glue"]["warehouse"] == "s3://floe-provider-tests/warehouse/"
+        assert payload["glue"]["catalog_id"] == "278833447053"
+        assert payload["glue"]["credential_refs"]["role"]["source"] == "workload-identity"
+        assert "raw-secret-value" not in binding.model_dump_json()
+
+    def test_glue_provider_requires_glue_details(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import CatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="glue catalog deployment binding"):
+            CatalogDeploymentBinding(provider="glue")
+
+    def test_glue_binding_rejects_raw_secret_properties(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="raw credential material"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                properties={"glue.secret-access-key": "raw-secret-value"},
+            )
+
+
 class TestRuntimeCatalogConnection:
     """Tests for secret-free runtime catalog connection projection."""
 

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1071,16 +1071,74 @@ class TestGlueCatalogDeploymentBinding:
         assert "raw-secret-value" not in binding.model_dump_json()
 
     def test_glue_provider_requires_glue_details(self) -> None:
-        from pydantic import ValidationError
-
         from floe_core.schemas.compiled_artifacts import CatalogDeploymentBinding
 
         with pytest.raises(ValidationError, match="glue catalog deployment binding"):
             CatalogDeploymentBinding(provider="glue")
 
-    def test_glue_binding_rejects_raw_secret_properties(self) -> None:
-        from pydantic import ValidationError
+    def test_non_glue_provider_rejects_glue_details(self) -> None:
+        from floe_core.schemas.compiled_artifacts import (
+            CatalogDeploymentBinding,
+            GlueCatalogDeploymentBinding,
+            PolarisCatalogDeploymentBinding,
+        )
 
+        with pytest.raises(ValidationError, match="requires provider 'glue'"):
+            CatalogDeploymentBinding(
+                provider="polaris",
+                polaris=PolarisCatalogDeploymentBinding(
+                    storage_type="S3",
+                    warehouse="floe-demo",
+                    default_base_location="s3://floe-iceberg",
+                    allowed_locations=["s3://floe-iceberg"],
+                    endpoint="http://localhost:8181",
+                    endpoint_internal="http://polaris:8181",
+                    path_style_access=True,
+                    sts_unavailable=True,
+                ),
+                glue=GlueCatalogDeploymentBinding(
+                    region="ap-southeast-2",
+                    warehouse="s3://floe-provider-tests/warehouse/",
+                ),
+            )
+
+    def test_non_polaris_provider_rejects_polaris_details(self) -> None:
+        from floe_core.schemas.compiled_artifacts import (
+            CatalogDeploymentBinding,
+            GlueCatalogDeploymentBinding,
+            PolarisCatalogDeploymentBinding,
+        )
+
+        with pytest.raises(ValidationError, match="requires provider 'polaris'"):
+            CatalogDeploymentBinding(
+                provider="glue",
+                glue=GlueCatalogDeploymentBinding(
+                    region="ap-southeast-2",
+                    warehouse="s3://floe-provider-tests/warehouse/",
+                ),
+                polaris=PolarisCatalogDeploymentBinding(
+                    storage_type="S3",
+                    warehouse="floe-demo",
+                    default_base_location="s3://floe-iceberg",
+                    allowed_locations=["s3://floe-iceberg"],
+                    endpoint="http://localhost:8181",
+                    endpoint_internal="http://polaris:8181",
+                    path_style_access=True,
+                    sts_unavailable=True,
+                ),
+            )
+
+    def test_glue_binding_rejects_invalid_catalog_id(self) -> None:
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="catalog_id"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                catalog_id="arn:aws:iam::278833447053:role/floe",
+            )
+
+    def test_glue_binding_rejects_raw_secret_properties(self) -> None:
         from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
 
         with pytest.raises(ValidationError, match="raw credential material"):
@@ -2156,31 +2214,31 @@ class TestCompiledArtifactsVersionBump:
     """Tests for AC-6: current contract version and history entries."""
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_version_is_0_12_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.15.0'."""
-        assert COMPILED_ARTIFACTS_VERSION == "0.15.0", (
-            f"Expected version '0.15.0', got '{COMPILED_ARTIFACTS_VERSION}'"
+    def test_compiled_artifacts_version_is_0_16_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION is exactly '0.16.0'."""
+        assert COMPILED_ARTIFACTS_VERSION == "0.16.0", (
+            f"Expected version '0.16.0', got '{COMPILED_ARTIFACTS_VERSION}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_contains_0_12_0(self) -> None:
-        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.15.0' entry."""
-        assert "0.15.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
-            f"Version '0.15.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
+    def test_version_history_contains_0_16_0(self) -> None:
+        """Test that COMPILED_ARTIFACTS_VERSION_HISTORY has a '0.16.0' entry."""
+        assert "0.16.0" in COMPILED_ARTIFACTS_VERSION_HISTORY, (
+            f"Version '0.16.0' not in history: {list(COMPILED_ARTIFACTS_VERSION_HISTORY.keys())}"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_version_history_0_12_0_references_iceberg_catalog_projection(self) -> None:
-        """Test that the 0.15.0 history entry mentions contract additions."""
-        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.15.0", "")
+    def test_version_history_0_16_0_references_glue_catalog_projection(self) -> None:
+        """Test that the 0.16.0 history entry mentions contract additions."""
+        entry = COMPILED_ARTIFACTS_VERSION_HISTORY.get("0.16.0", "")
         entry_lower = entry.lower()
-        assert "iceberg" in entry_lower and "catalog" in entry_lower, (
-            f"Version 0.15.0 history entry does not reference Iceberg catalog projection: '{entry}'"
+        assert "glue" in entry_lower and "runtime" in entry_lower, (
+            f"Version 0.16.0 history entry does not reference Glue runtime changes: '{entry}'"
         )
 
     @pytest.mark.requirement("T1-AC-6")
-    def test_compiled_artifacts_default_version_is_0_12_0(self) -> None:
-        """Test that CompiledArtifacts().version defaults to '0.15.0'."""
+    def test_compiled_artifacts_default_version_is_0_16_0(self) -> None:
+        """Test that CompiledArtifacts().version defaults to '0.16.0'."""
         artifacts = CompiledArtifacts(
             metadata=CompilationMetadata(
                 compiled_at=datetime.now(),
@@ -2209,7 +2267,7 @@ class TestCompiledArtifactsVersionBump:
                 lineage_namespace="test",
             ),
         )
-        assert artifacts.version == "0.15.0"
+        assert artifacts.version == "0.16.0"
 
 
 class TestGovernanceBackwardCompatibility:

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1090,6 +1090,41 @@ class TestGlueCatalogDeploymentBinding:
                 properties={"glue.secret-access-key": "raw-secret-value"},
             )
 
+    def test_glue_binding_rejects_raw_secret_warehouse_uri(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="raw credential material"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://raw-secret-value/warehouse",
+            )
+
+    def test_glue_binding_rejects_endpoint_userinfo_credentials(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="raw credential material"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                endpoint="https://" + "user:raw-secret-value" + "@glue.example",
+            )
+
+    def test_glue_binding_rejects_endpoint_signed_query_material(self) -> None:
+        from pydantic import ValidationError
+
+        from floe_core.schemas.compiled_artifacts import GlueCatalogDeploymentBinding
+
+        with pytest.raises(ValidationError, match="raw credential material"):
+            GlueCatalogDeploymentBinding(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                endpoint="https://glue.example?X-Amz-Signature=abc123",
+            )
+
 
 class TestRuntimeCatalogConnection:
     """Tests for secret-free runtime catalog connection projection."""

--- a/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
+++ b/packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py
@@ -1165,6 +1165,29 @@ class TestRuntimeCatalogConnection:
             "PYICEBERG_CATALOG__POLARIS__CREDENTIAL": "POLARIS_CREDENTIAL"
         }
 
+    def test_runtime_catalog_connection_preserves_secret_free_primitive_properties(self) -> None:
+        from floe_core.schemas.compiled_artifacts import RuntimeCatalogConnection
+
+        connection = RuntimeCatalogConnection(
+            catalog_name="glue",
+            properties={
+                "type": "glue",
+                "glue.max-retries": 5,
+                "feature.enabled": True,
+            },
+        )
+
+        assert connection.properties == {
+            "type": "glue",
+            "glue.max-retries": 5,
+            "feature.enabled": True,
+        }
+        assert connection.model_dump(mode="json")["properties"] == {
+            "type": "glue",
+            "glue.max-retries": 5,
+            "feature.enabled": True,
+        }
+
     def test_runtime_catalog_connection_rejects_raw_secret_material(self) -> None:
         from floe_core.schemas.compiled_artifacts import RuntimeCatalogConnection
 

--- a/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
+++ b/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
@@ -87,3 +87,41 @@ def test_build_runtime_catalog_connection_degrades_without_catalog() -> None:
     assert connection.storage_endpoint == "http://floe-platform-minio:9000"
     assert connection.region == "us-east-1"
     assert connection.path_style_access is True
+
+
+def test_build_runtime_catalog_connection_maps_glue_binding() -> None:
+    from floe_core.runtime_catalog_connection import build_runtime_catalog_connection
+    from floe_core.schemas.compiled_artifacts import (
+        CatalogDeploymentBinding,
+        GlueCatalogDeploymentBinding,
+    )
+
+    catalog = CatalogDeploymentBinding(
+        provider="glue",
+        glue=GlueCatalogDeploymentBinding(
+            catalog_name="glue",
+            region="ap-southeast-2",
+            warehouse="s3://floe-provider-tests/warehouse/",
+            catalog_id="278833447053",
+            database_prefix="floe_provider_",
+            endpoint="https://glue.ap-southeast-2.amazonaws.com",
+            skip_archive=True,
+            max_retries=5,
+            retry_mode="standard",
+        ),
+    )
+
+    connection = build_runtime_catalog_connection(storage=None, catalog=catalog)
+
+    assert connection.catalog_name == "glue"
+    assert connection.warehouse == "s3://floe-provider-tests/warehouse/"
+    assert connection.region == "ap-southeast-2"
+    assert connection.properties == {
+        "type": "glue",
+        "glue.region": "ap-southeast-2",
+        "glue.id": "278833447053",
+        "glue.endpoint": "https://glue.ap-southeast-2.amazonaws.com",
+        "glue.skip-archive": "true",
+        "glue.max-retries": "5",
+        "glue.retry-mode": "standard",
+    }

--- a/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
+++ b/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
@@ -6,6 +6,7 @@ from floe_core.schemas.compiled_artifacts import (
     CredentialRef,
     DagsterStorageBinding,
     DbtStorageBinding,
+    GlueCatalogDeploymentBinding,
     PolarisCatalogDeploymentBinding,
     StorageCredentialBinding,
     StorageDeploymentBinding,
@@ -90,12 +91,6 @@ def test_build_runtime_catalog_connection_degrades_without_catalog() -> None:
 
 
 def test_build_runtime_catalog_connection_maps_glue_binding() -> None:
-    from floe_core.runtime_catalog_connection import build_runtime_catalog_connection
-    from floe_core.schemas.compiled_artifacts import (
-        CatalogDeploymentBinding,
-        GlueCatalogDeploymentBinding,
-    )
-
     catalog = CatalogDeploymentBinding(
         provider="glue",
         glue=GlueCatalogDeploymentBinding(

--- a/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
+++ b/packages/floe-core/tests/unit/test_runtime_catalog_connection.py
@@ -122,6 +122,6 @@ def test_build_runtime_catalog_connection_maps_glue_binding() -> None:
         "glue.id": "278833447053",
         "glue.endpoint": "https://glue.ap-southeast-2.amazonaws.com",
         "glue.skip-archive": "true",
-        "glue.max-retries": "5",
+        "glue.max-retries": 5,
         "glue.retry-mode": "standard",
     }

--- a/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
+++ b/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
@@ -130,6 +130,7 @@ def test_pyiceberg_glue_catalog_accepts_typed_retry_config_without_aws_call() ->
     )
     config = runtime_catalog_connection_to_pyiceberg_config(connection)
 
+    # This patch intentionally tracks PyIceberg's GlueCatalog boto3 import site.
     with patch("pyiceberg.catalog.glue.boto3.Session") as session_cls:
         session = session_cls.return_value
         session.client.return_value = Mock()

--- a/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
+++ b/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
@@ -65,3 +65,30 @@ def test_runtime_catalog_connection_to_pyiceberg_config_merges_properties_last()
     assert config["s3.endpoint"] == "http://override-minio:9000"
     assert config["s3.path-style-access"] == "false"
     assert config["s3.region"] == "us-east-1"
+
+
+def test_runtime_catalog_connection_to_pyiceberg_config_preserves_glue_properties() -> None:
+    connection = RuntimeCatalogConnection(
+        catalog_name="glue",
+        warehouse="s3://floe-provider-tests/warehouse/",
+        properties={
+            "type": "glue",
+            "glue.region": "ap-southeast-2",
+            "glue.id": "278833447053",
+            "glue.skip-archive": "true",
+            "glue.max-retries": "5",
+            "glue.retry-mode": "standard",
+        },
+    )
+
+    config = runtime_catalog_connection_to_pyiceberg_config(connection)
+
+    assert config == {
+        "warehouse": "s3://floe-provider-tests/warehouse/",
+        "type": "glue",
+        "glue.region": "ap-southeast-2",
+        "glue.id": "278833447053",
+        "glue.skip-archive": "true",
+        "glue.max-retries": "5",
+        "glue.retry-mode": "standard",
+    }

--- a/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
+++ b/packages/floe-iceberg/tests/unit/test_runtime_catalog.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 from floe_core.schemas.compiled_artifacts import CredentialRef, RuntimeCatalogConnection
 
 from floe_iceberg.runtime_catalog import runtime_catalog_connection_to_pyiceberg_config
@@ -76,7 +78,7 @@ def test_runtime_catalog_connection_to_pyiceberg_config_preserves_glue_propertie
             "glue.region": "ap-southeast-2",
             "glue.id": "278833447053",
             "glue.skip-archive": "true",
-            "glue.max-retries": "5",
+            "glue.max-retries": 5,
             "glue.retry-mode": "standard",
         },
     )
@@ -89,6 +91,53 @@ def test_runtime_catalog_connection_to_pyiceberg_config_preserves_glue_propertie
         "glue.region": "ap-southeast-2",
         "glue.id": "278833447053",
         "glue.skip-archive": "true",
-        "glue.max-retries": "5",
+        "glue.max-retries": 5,
         "glue.retry-mode": "standard",
+    }
+
+
+def test_runtime_catalog_connection_to_pyiceberg_config_preserves_glue_retry_type() -> None:
+    connection = RuntimeCatalogConnection(
+        catalog_name="glue",
+        warehouse="s3://floe-provider-tests/warehouse/",
+        properties={
+            "type": "glue",
+            "glue.region": "ap-southeast-2",
+            "glue.max-retries": 5,
+            "glue.retry-mode": "standard",
+        },
+    )
+
+    config = runtime_catalog_connection_to_pyiceberg_config(connection)
+
+    assert config["glue.max-retries"] == 5
+    assert isinstance(config["glue.max-retries"], int)
+
+
+def test_pyiceberg_glue_catalog_accepts_typed_retry_config_without_aws_call() -> None:
+    from pyiceberg.catalog import load_catalog
+
+    connection = RuntimeCatalogConnection(
+        catalog_name="glue",
+        warehouse="s3://floe-provider-tests/warehouse/",
+        properties={
+            "type": "glue",
+            "glue.region": "ap-southeast-2",
+            "glue.skip-archive": "true",
+            "glue.max-retries": 5,
+            "glue.retry-mode": "standard",
+        },
+    )
+    config = runtime_catalog_connection_to_pyiceberg_config(connection)
+
+    with patch("pyiceberg.catalog.glue.boto3.Session") as session_cls:
+        session = session_cls.return_value
+        session.client.return_value = Mock()
+
+        load_catalog("glue", **config)
+
+    client_kwargs = session.client.call_args.kwargs
+    assert client_kwargs["config"].retries == {
+        "max_attempts": 5,
+        "mode": "standard",
     }

--- a/tests/contract/test_resolved_governance_contract.py
+++ b/tests/contract/test_resolved_governance_contract.py
@@ -6,12 +6,12 @@ to ensure GovernanceConfig scalar fields stay synchronized with ResolvedGovernan
 
 Task: T5
 Acceptance Criteria:
-    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.15.0"
+    - AC-6: COMPILED_ARTIFACTS_VERSION is "0.16.0"
     - AC-7: Old JSON without lifecycle fields deserializes correctly
     - AC-9: ResolvedGovernance has all lifecycle fields; drift detection
 
 Contract Guarantees:
-1. COMPILED_ARTIFACTS_VERSION == "0.15.0" (contract-level assertion)
+1. COMPILED_ARTIFACTS_VERSION == "0.16.0" (contract-level assertion)
 2. CompiledArtifacts JSON without default_ttl_hours/snapshot_keep_last -> both None
 3. ResolvedGovernance contains every scalar field from GovernanceConfig
 4. Adding a new scalar field to GovernanceConfig without mirroring in
@@ -209,24 +209,24 @@ def _make_minimal_artifacts_dict() -> dict[str, Any]:
 
 
 class TestCompiledArtifactsVersionBump:
-    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.15.0."""
+    """Contract: COMPILED_ARTIFACTS_VERSION must be exactly 0.16.0."""
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_compiled_artifacts_version_is_0_13_0(self) -> None:
-        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.15.0'.
+    def test_compiled_artifacts_version_is_0_16_0(self) -> None:
+        """AC-6: COMPILED_ARTIFACTS_VERSION MUST be '0.16.0'.
 
         This is a contract-level assertion that locks the version constant.
         If the version changes, this test must be updated deliberately --
         never silently.
         """
-        assert COMPILED_ARTIFACTS_VERSION == "0.15.0", (
+        assert COMPILED_ARTIFACTS_VERSION == "0.16.0", (
             f"COMPILED_ARTIFACTS_VERSION is {COMPILED_ARTIFACTS_VERSION!r}, "
-            "expected '0.15.0'. If this is intentional, update this contract test."
+            "expected '0.16.0'. If this is intentional, update this contract test."
         )
 
     @pytest.mark.requirement("T5-AC-6")
-    def test_default_version_on_new_artifacts_is_0_13_0(self) -> None:
-        """AC-6: A new CompiledArtifacts instance defaults to version '0.15.0'.
+    def test_default_version_on_new_artifacts_is_0_16_0(self) -> None:
+        """AC-6: A new CompiledArtifacts instance defaults to version '0.16.0'.
 
         Ensures the constant is actually wired into the schema default,
         not just defined but unused.
@@ -247,7 +247,7 @@ class TestCompiledArtifactsVersionBump:
             inheritance_chain=[],
             observability=_make_observability(),
         )
-        assert artifacts.version == "0.15.0"
+        assert artifacts.version == "0.16.0"
 
 
 # ===========================================================================

--- a/tests/fixtures/golden/compiled_artifacts_v2_schema.json
+++ b/tests/fixtures/golden/compiled_artifacts_v2_schema.json
@@ -155,6 +155,17 @@
           ],
           "default": null
         },
+        "glue": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GlueCatalogDeploymentBinding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "iceberg_rest": {
           "anyOf": [
             {
@@ -1148,6 +1159,118 @@
         }
       },
       "title": "GateTier",
+      "type": "object"
+    },
+    "GlueCatalogDeploymentBinding": {
+      "additionalProperties": false,
+      "description": "AWS Glue catalog-owned deployment and runtime configuration.",
+      "properties": {
+        "catalog_name": {
+          "default": "glue",
+          "minLength": 1,
+          "title": "Catalog Name",
+          "type": "string"
+        },
+        "region": {
+          "minLength": 1,
+          "title": "Region",
+          "type": "string"
+        },
+        "warehouse": {
+          "minLength": 1,
+          "title": "Warehouse",
+          "type": "string"
+        },
+        "catalog_id": {
+          "anyOf": [
+            {
+              "pattern": "^\\d{12}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Catalog Id"
+        },
+        "database_prefix": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Database Prefix"
+        },
+        "endpoint": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Endpoint"
+        },
+        "skip_archive": {
+          "default": true,
+          "title": "Skip Archive",
+          "type": "boolean"
+        },
+        "max_retries": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Max Retries"
+        },
+        "retry_mode": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retry Mode"
+        },
+        "credential_refs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CredentialRef"
+          },
+          "title": "Credential Refs",
+          "type": "object"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Properties"
+        }
+      },
+      "required": [
+        "region",
+        "warehouse"
+      ],
+      "title": "GlueCatalogDeploymentBinding",
       "type": "object"
     },
     "IcebergRestCatalogBinding": {
@@ -4772,7 +4895,7 @@
   "description": "Output of floe compile - unified for all deployment modes.\n\nCompiledArtifacts is the single source of truth for pipeline execution.\nIt contains resolved, validated configuration after manifest inheritance.\n\nThe observability field contains TelemetryConfig which provides:\n- OpenTelemetry SDK configuration (Layer 1 - ENFORCED)\n- OTLP Collector endpoint (Layer 2 - ENFORCED)\n- Backend plugin selection (Layer 3 - PLUGGABLE)\n\nContract Version: 0.5.0 (see docstring header for version history)\n\nAttributes:\n    version: Schema version (semver) - default 0.5.0\n    metadata: Compilation metadata\n    identity: Product identity from catalog\n    mode: Deployment mode (simple, centralized, mesh)\n    inheritance_chain: Manifest inheritance lineage\n    observability: Observability configuration with TelemetryConfig\n    plugins: Resolved plugin selections (v0.2.0+)\n    transforms: Compiled transform configuration (v0.2.0+)\n    dbt_profiles: Generated profiles.yml content (v0.2.0+)\n    governance: Resolved governance settings (v0.2.0+, optional)\n    enforcement_result: Enforcement result summary (v0.3.0+, optional)\n    data_contracts: Validated data contracts (v0.3.0+, Epic 3C)\n\nExamples:\n    >>> from datetime import datetime\n    >>> from floe_core.schemas.telemetry import TelemetryConfig, ResourceAttributes\n    >>> artifacts = CompiledArtifacts(\n    ...     version=\"0.2.0\",\n    ...     metadata=CompilationMetadata(\n    ...         compiled_at=datetime.now(),\n    ...         floe_version=\"0.2.0\",\n    ...         source_hash=\"sha256:abc123\",\n    ...         product_name=\"my-pipeline\",\n    ...         product_version=\"1.0.0\",\n    ...     ),\n    ...     identity=ProductIdentity(\n    ...         product_id=\"default.my_pipeline\",\n    ...         domain=\"default\",\n    ...         repository=\"github.com/acme/my-pipeline\",\n    ...     ),\n    ...     mode=\"simple\",\n    ...     observability=ObservabilityConfig(\n    ...         telemetry=TelemetryConfig(\n    ...             resource_attributes=ResourceAttributes(...),\n    ...         ),\n    ...         lineage_namespace=\"my-pipeline\",\n    ...     ),\n    ...     plugins=ResolvedPlugins(\n    ...         compute=PluginRef(type=\"duckdb\", version=\"0.9.0\"),\n    ...         orchestrator=PluginRef(type=\"dagster\", version=\"1.5.0\"),\n    ...     ),\n    ...     transforms=ResolvedTransforms(\n    ...         models=[ResolvedModel(name=\"stg_customers\", compute=\"duckdb\")],\n    ...         default_compute=\"duckdb\",\n    ...     ),\n    ...     dbt_profiles={\"default\": {\"target\": \"dev\", \"outputs\": {...}}},\n    ... )\n\nSee Also:\n    - docs/contracts/compiled-artifacts.md: Full specification\n    - ADR-0012: CompiledArtifacts contract design\n    - TelemetryConfig: OpenTelemetry configuration",
   "properties": {
     "version": {
-      "default": "0.15.0",
+      "default": "0.16.0",
       "description": "Schema version (semver)",
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
       "title": "Version",


### PR DESCRIPTION
## Summary
- add secret-free Glue catalog deployment binding and runtime projection
- prove Glue PyIceberg config translation, preserving typed runtime properties
- add resolver and compile-pipeline contract proofs for AWS S3 + Glue workload identity compatibility
- document the AWS S3/Glue provider design and core-contract implementation plan

## Verification
- uv run pytest packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestGlueCatalogDeploymentBinding packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py::TestRuntimeCatalogConnection packages/floe-core/tests/unit/test_runtime_catalog_connection.py packages/floe-core/tests/unit/composition/test_resolver.py packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q -> 49 passed
- uv run ruff check packages/floe-core/src/floe_core/schemas/compiled_artifacts.py packages/floe-core/src/floe_core/runtime_catalog_connection.py packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py packages/floe-core/tests/unit/schemas/test_compiled_artifacts.py packages/floe-core/tests/unit/test_runtime_catalog_connection.py packages/floe-core/tests/unit/composition/test_resolver.py packages/floe-core/tests/unit/compilation/test_storage_deployment_binding.py packages/floe-iceberg/tests/unit/test_runtime_catalog.py -> passed
- uv run mypy packages/floe-core/src/floe_core/schemas/compiled_artifacts.py packages/floe-core/src/floe_core/runtime_catalog_connection.py packages/floe-iceberg/src/floe_iceberg/runtime_catalog.py -> passed
- git diff --check -> passed
- pre-push hook -> passed: ruff, format, mypy, dbt requirements, bandit, uv-secure, unit tests, contract tests, traceability, docs validation, helm lint

## Notes
- This branch intentionally does not create real `floe-storage-aws-s3` or `floe-catalog-glue` provider packages. It establishes the shared core contracts those branches should consume.