### PR TITLE
feat: add AWS S3 storage plugin

### DIFF
--- a/plugins/floe-storage-aws-s3/README.md
+++ b/plugins/floe-storage-aws-s3/README.md
@@ -1,0 +1,7 @@
+# floe-storage-aws-s3
+
+Native AWS S3 storage plugin for Floe.
+
+This package emits secret-free `StorageDeploymentBinding` contracts for an
+existing S3 bucket. It does not create buckets during compilation and does not
+place AWS credential values in compiled artifacts.

--- a/plugins/floe-storage-aws-s3/pyproject.toml
+++ b/plugins/floe-storage-aws-s3/pyproject.toml
@@ -1,0 +1,89 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "floe-storage-aws-s3"
+version = "0.1.0"
+description = "AWS S3 object storage plugin for the floe data platform"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    { name = "Obsidian Owl", email = "team@obsidianowl.dev" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "floe-core>=0.1.0",
+    "pyiceberg[s3fs]>=0.11.1",
+    "pydantic>=2.0,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=4.0",
+    "mypy>=1.8",
+    "ruff>=0.3",
+]
+
+[project.urls]
+Homepage = "https://github.com/Obsidian-Owl/floe"
+Documentation = "https://github.com/Obsidian-Owl/floe/tree/main/docs"
+Repository = "https://github.com/Obsidian-Owl/floe"
+
+[project.entry-points."floe.storage"]
+aws-s3 = "floe_storage_aws_s3.plugin:AwsS3ObjectStorePlugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/floe_storage_aws_s3"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
+
+[tool.hatch.build]
+include = [
+    "src/floe_storage_aws_s3/**/*.py",
+    "src/floe_storage_aws_s3/py.typed",
+]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "UP",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+markers = [
+    "requirement(id): Mark test with requirement ID for traceability",
+]

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/__init__.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/__init__.py
@@ -1,0 +1,10 @@
+"""AWS S3 storage plugin for Floe."""
+
+from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig, AwsS3ObjectStoreCredentialMode
+from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
+
+__all__ = [
+    "AwsS3ObjectStoreCredentialMode",
+    "AwsS3ObjectStoreConfig",
+    "AwsS3ObjectStorePlugin",
+]

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
@@ -36,6 +36,7 @@ class AwsS3ObjectStoreConfig(BaseModel):
     )
     artifact_bucket: str | None = Field(
         default=None,
+        min_length=1,
         description="Artifact bucket. Defaults to bucket when unset.",
     )
     artifact_prefix: str = Field(

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
@@ -1,0 +1,115 @@
+"""Configuration model for the native AWS S3 storage plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+AwsS3ObjectStoreCredentialMode = Literal["environment", "workload-identity", "kubernetes-secret"]
+CreatePolicy = Literal["must-exist", "never-create"]
+
+
+def _normalize_prefix(value: str) -> str:
+    """Normalize an S3 prefix to either empty or slash-terminated form."""
+    prefix = value.strip("/")
+    if not prefix:
+        return ""
+    return f"{prefix}/"
+
+
+class AwsS3ObjectStoreConfig(BaseModel):
+    """AWS S3 storage configuration.
+
+    Credentials are represented by environment variable names, Kubernetes Secret
+    references, or workload identity service account references. Raw AWS
+    credential values are intentionally not accepted by this model.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    bucket: str = Field(..., min_length=1, description="Warehouse bucket name.")
+    warehouse_prefix: str = Field(
+        default="warehouse/",
+        description="Warehouse prefix within the bucket.",
+    )
+    artifact_bucket: str | None = Field(
+        default=None,
+        description="Artifact bucket. Defaults to bucket when unset.",
+    )
+    artifact_prefix: str = Field(
+        default="artifacts/",
+        description="Artifact prefix within artifact_bucket.",
+    )
+    region: str = Field(..., min_length=1, description="AWS region.")
+    endpoint_override: str | None = Field(
+        default=None,
+        description="Optional S3 endpoint override for local emulation.",
+        pattern=r"^https?://",
+    )
+    path_style_access: bool = Field(
+        default=False,
+        description="Use path-style access. False for native AWS S3.",
+    )
+    credential_mode: AwsS3ObjectStoreCredentialMode = "workload-identity"
+    credential_secret_name: str | None = Field(
+        default=None,
+        description="Kubernetes Secret name for kubernetes-secret mode.",
+        min_length=1,
+    )
+    credential_secret_namespace: str = Field(
+        default="floe-system",
+        description="Kubernetes namespace for credential_secret_name.",
+        min_length=1,
+    )
+    access_key_secret_key: str = Field(default="accessKeyId", min_length=1)
+    secret_key_secret_key: str = Field(default="secretAccessKey", min_length=1)
+    session_token_secret_key: str = Field(default="sessionToken", min_length=1)
+    service_account_ref: str | None = Field(
+        default=None,
+        description="Kubernetes ServiceAccount reference for workload identity.",
+        min_length=1,
+    )
+    create_policy: CreatePolicy = "must-exist"
+    sts_supported: bool = True
+
+    @field_validator("warehouse_prefix", "artifact_prefix")
+    @classmethod
+    def normalize_prefix(cls, value: str) -> str:
+        """Normalize S3 prefixes so URI generation is deterministic."""
+        return _normalize_prefix(value)
+
+    @model_validator(mode="before")
+    @classmethod
+    def default_artifact_bucket(cls, data: Any) -> Any:
+        """Default artifact_bucket to bucket before frozen model creation."""
+        if isinstance(data, dict) and data.get("artifact_bucket") is None and "bucket" in data:
+            data = dict(data)
+            data["artifact_bucket"] = data["bucket"]
+        return data
+
+    @model_validator(mode="after")
+    def validate_credential_mode(self) -> AwsS3ObjectStoreConfig:
+        """Ensure credential reference fields match credential_mode."""
+        if self.credential_mode == "workload-identity":
+            if self.service_account_ref is None:
+                msg = "workload-identity credential_mode requires service_account_ref"
+                raise ValueError(msg)
+            if self.credential_secret_name is not None:
+                msg = "workload-identity credential_mode only accepts service_account_ref"
+                raise ValueError(msg)
+            return self
+
+        if self.credential_mode == "kubernetes-secret":
+            if self.credential_secret_name is None:
+                msg = "kubernetes-secret credential_mode requires credential_secret_name"
+                raise ValueError(msg)
+            if self.service_account_ref is not None:
+                msg = "kubernetes-secret credential_mode only accepts credential_secret_name"
+                raise ValueError(msg)
+            return self
+
+        if self.credential_secret_name is not None or self.service_account_ref is not None:
+            msg = "environment credential_mode only accepts environment variable names"
+            raise ValueError(msg)
+        return self

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Self
 
 AwsS3ObjectStoreCredentialMode = Literal["environment", "workload-identity", "kubernetes-secret"]
 CreatePolicy = Literal["must-exist", "never-create"]
@@ -89,7 +90,7 @@ class AwsS3ObjectStoreConfig(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def validate_credential_mode(self) -> AwsS3ObjectStoreConfig:
+    def validate_credential_mode(self) -> Self:
         """Ensure credential reference fields match credential_mode."""
         if self.credential_mode == "workload-identity":
             if self.service_account_ref is None:

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
@@ -112,17 +112,13 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
         """Return secret-free credential references for the configured mode."""
         config = self._require_config()
         if config.credential_mode == "workload-identity":
-            if config.service_account_ref is None:
-                msg = "workload-identity credential_mode requires service_account_ref"
-                raise ValueError(msg)
+            assert config.service_account_ref is not None
             return StorageCredentialBinding(
                 mode="workload-identity",
                 service_account_ref=config.service_account_ref,
             )
         if config.credential_mode == "kubernetes-secret":
-            if config.credential_secret_name is None:
-                msg = "kubernetes-secret credential_mode requires credential_secret_name"
-                raise ValueError(msg)
+            assert config.credential_secret_name is not None
             return StorageCredentialBinding(
                 mode="kubernetes-secret",
                 secret_ref=KubernetesSecretRef(

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
@@ -168,8 +168,15 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
             else []
         )
         runtime_env_refs = (
-            dict(credential_binding.env_refs) if config.credential_mode == "environment" else {}
+            {
+                KEY_ACCESS_KEY_ID: AWS_ACCESS_KEY_ENV,
+                KEY_SECRET_ACCESS_KEY: AWS_SECRET_KEY_ENV,
+            }
+            if config.credential_mode in {"environment", "kubernetes-secret"}
+            else {}
         )
+        if config.credential_mode == "environment":
+            runtime_env_refs[KEY_SESSION_TOKEN] = AWS_SESSION_TOKEN_ENV
         runtime_properties = self._pyiceberg_properties()
         dbt_profile_fragment: dict[str, Any] = {
             "s3_region": config.region,

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
@@ -1,0 +1,282 @@
+"""AWS S3 StoragePlugin implementation for Floe."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from floe_core.plugins.storage import StoragePlugin
+from floe_core.schemas.compiled_artifacts import (
+    DagsterStorageBinding,
+    DbtStorageBinding,
+    KubernetesSecretRef,
+    StorageBucketRequirement,
+    StorageCapabilities,
+    StorageCredentialBinding,
+    StorageDeploymentBinding,
+    StorageProvisioningIntent,
+    StorageRuntimeBinding,
+    StorageServiceEndpoint,
+    StorageWarehouse,
+)
+
+from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
+
+if TYPE_CHECKING:
+    from floe_core.plugins.storage import FileIO
+    from pydantic import BaseModel
+
+TRACER_NAME = "floe.storage.aws_s3"
+AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID"
+AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY"  # pragma: allowlist secret
+AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
+
+
+def _s3_uri(bucket: str, prefix: str) -> str:
+    """Build an S3 URI from bucket and normalized prefix."""
+    return f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+
+
+class AwsS3ObjectStorePlugin(StoragePlugin):
+    """Native AWS S3 storage plugin implementing the StoragePlugin ABC."""
+
+    def __init__(self, config: AwsS3ObjectStoreConfig | None = None) -> None:
+        """Initialize the AWS S3 storage plugin."""
+        super().__init__()
+        self._config = config
+
+    def _require_config(self) -> AwsS3ObjectStoreConfig:
+        """Return config or raise a structured plugin configuration error."""
+        if self._config is None:
+            from floe_core.plugin_errors import PluginConfigurationError
+
+            raise PluginConfigurationError(
+                "aws-s3",
+                [{"field": "_config", "message": "Plugin 'aws-s3' not configured"}],
+            )
+        return cast(AwsS3ObjectStoreConfig, self._config)
+
+    @property
+    def name(self) -> str:
+        """Return the plugin name."""
+        return "aws-s3"
+
+    @property
+    def version(self) -> str:
+        """Return the plugin version."""
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        """Return the required Floe API version."""
+        return "1.0"
+
+    @property
+    def description(self) -> str:
+        """Return a human-readable plugin description."""
+        return "AWS S3 object storage plugin for Iceberg data"
+
+    @property
+    def tracer_name(self) -> str:
+        """Return the OpenTelemetry tracer name."""
+        return TRACER_NAME
+
+    def get_config_schema(self) -> type[BaseModel]:
+        """Return the Pydantic config schema for this plugin."""
+        return AwsS3ObjectStoreConfig
+
+    def _endpoint_url(self) -> str:
+        """Return the S3 endpoint URL used by runtime consumers."""
+        config = self._require_config()
+        return config.endpoint_override or f"https://s3.{config.region}.amazonaws.com"
+
+    def _pyiceberg_properties(self) -> dict[str, str]:
+        """Return non-secret PyIceberg S3 properties."""
+        config = self._require_config()
+        properties = {"s3.region": config.region}
+        if config.endpoint_override is not None:
+            properties["s3.endpoint"] = config.endpoint_override
+            properties["s3.path-style-access"] = str(config.path_style_access).lower()
+        return properties
+
+    def get_pyiceberg_fileio(self) -> FileIO:
+        """Create a PyIceberg FileIO instance for AWS S3."""
+        from pyiceberg.io.fsspec import FsspecFileIO
+
+        return FsspecFileIO(properties=self._pyiceberg_properties())
+
+    def get_pyiceberg_catalog_config(self) -> dict[str, Any]:
+        """Return non-secret PyIceberg catalog config for legacy callers."""
+        return self._pyiceberg_properties()
+
+    def _credential_binding(self) -> StorageCredentialBinding:
+        """Return secret-free credential references for the configured mode."""
+        config = self._require_config()
+        if config.credential_mode == "workload-identity":
+            if config.service_account_ref is None:
+                msg = "workload-identity credential_mode requires service_account_ref"
+                raise ValueError(msg)
+            return StorageCredentialBinding(
+                mode="workload-identity",
+                service_account_ref=config.service_account_ref,
+            )
+        if config.credential_mode == "kubernetes-secret":
+            if config.credential_secret_name is None:
+                msg = "kubernetes-secret credential_mode requires credential_secret_name"
+                raise ValueError(msg)
+            return StorageCredentialBinding(
+                mode="kubernetes-secret",
+                secret_ref=KubernetesSecretRef(
+                    name=config.credential_secret_name,
+                    namespace=config.credential_secret_namespace,
+                    keys={
+                        "accessKeyId": config.access_key_secret_key,
+                        "secretAccessKey": config.secret_key_secret_key,
+                        "sessionToken": config.session_token_secret_key,
+                    },
+                ),
+            )
+        return StorageCredentialBinding(
+            mode="environment",
+            env_refs={
+                "accessKeyId": AWS_ACCESS_KEY_ENV,
+                "secretAccessKey": AWS_SECRET_KEY_ENV,
+                "sessionToken": AWS_SESSION_TOKEN_ENV,
+            },
+        )
+
+    def get_deployment_binding(self) -> StorageDeploymentBinding:
+        """Return secret-free AWS S3 deployment binding for compiled artifacts."""
+        config = self._require_config()
+        endpoint = self._endpoint_url()
+        warehouse_uri = _s3_uri(config.bucket, config.warehouse_prefix)
+        artifact_bucket = config.artifact_bucket or config.bucket
+        artifact_uri = _s3_uri(artifact_bucket, config.artifact_prefix)
+        credential_binding = self._credential_binding()
+        identity_modes = (
+            ["aws-irsa", "aws-pod-identity"]
+            if config.credential_mode == "workload-identity"
+            else []
+        )
+        runtime_env_refs = (
+            dict(credential_binding.env_refs) if config.credential_mode == "environment" else {}
+        )
+        runtime_properties = self._pyiceberg_properties()
+        dbt_profile_fragment: dict[str, Any] = {
+            "s3_region": config.region,
+            "s3_path_style_access": config.path_style_access,
+        }
+        dagster_resources: dict[str, Any] = {
+            "bucket": config.bucket,
+            "region_name": config.region,
+            "path_style_access": config.path_style_access,
+        }
+        if config.endpoint_override is not None:
+            dbt_profile_fragment["s3_endpoint"] = config.endpoint_override
+            dagster_resources["endpoint_url"] = config.endpoint_override
+
+        dbt_env_refs = (
+            {
+                "s3_access_key_id": AWS_ACCESS_KEY_ENV,
+                "s3_secret_access_key": AWS_SECRET_KEY_ENV,
+                "s3_session_token": AWS_SESSION_TOKEN_ENV,
+            }
+            if config.credential_mode == "environment"
+            else {}
+        )
+        dagster_env_refs = (
+            {
+                AWS_ACCESS_KEY_ENV: AWS_ACCESS_KEY_ENV,
+                AWS_SECRET_KEY_ENV: AWS_SECRET_KEY_ENV,
+                AWS_SESSION_TOKEN_ENV: AWS_SESSION_TOKEN_ENV,
+            }
+            if config.credential_mode == "environment"
+            else {}
+        )
+
+        return StorageDeploymentBinding(
+            provider="aws-s3",
+            protocol="s3",
+            endpoint=StorageServiceEndpoint(
+                internal_url=endpoint,
+                external_url=endpoint,
+                region=config.region,
+                warehouse_path=warehouse_uri,
+                path_style_access=config.path_style_access,
+            ),
+            warehouse=StorageWarehouse(
+                uri=warehouse_uri,
+                bucket=config.bucket,
+                prefix=config.warehouse_prefix,
+            ),
+            allowed_locations=[warehouse_uri, artifact_uri],
+            buckets=[
+                StorageBucketRequirement(
+                    name=config.bucket,
+                    uri=warehouse_uri,
+                    purpose="warehouse",
+                    create_policy=config.create_policy,
+                    prefixes=[config.warehouse_prefix],
+                ),
+                StorageBucketRequirement(
+                    name=artifact_bucket,
+                    uri=artifact_uri,
+                    purpose="artifacts",
+                    create_policy=config.create_policy,
+                    prefixes=[config.artifact_prefix],
+                ),
+            ],
+            credentials=credential_binding,
+            capabilities=StorageCapabilities(
+                protocols=["s3"],
+                credential_modes=[config.credential_mode],
+                identity_modes=identity_modes,
+                sts_supported=config.sts_supported,
+                path_style_access=config.path_style_access,
+            ),
+            provisioning=StorageProvisioningIntent(
+                enabled=False,
+                mode="external",
+                default_create_policy=config.create_policy,
+            ),
+            runtime=StorageRuntimeBinding(
+                pyiceberg_properties=runtime_properties,
+                dbt_profile_fragment=dbt_profile_fragment,
+                dagster_resources=dagster_resources,
+                env_refs=runtime_env_refs,
+            ),
+            dbt=DbtStorageBinding(
+                profile_name="floe",
+                target_name="dev",
+                schema_name="analytics",
+                profile_fragment=dbt_profile_fragment,
+                env_refs=dbt_env_refs,
+            ),
+            dagster=DagsterStorageBinding(
+                resource_key="aws_s3_storage",
+                asset_io_manager_key="iceberg_io_manager",
+                resources=dagster_resources,
+                env_refs=dagster_env_refs,
+            ),
+            notes=[
+                "AWS S3 buckets are externally managed; compile does not create buckets.",
+                f"Artifact location: {artifact_uri}",
+            ],
+        )
+
+    def get_warehouse_uri(self, namespace: str) -> str:
+        """Generate warehouse URI for a namespace."""
+        config = self._require_config()
+        return _s3_uri(config.bucket, f"{config.warehouse_prefix}{namespace}/")
+
+    def get_dbt_profile_config(self) -> dict[str, Any]:
+        """Return storage-specific dbt profile config."""
+        return dict(self.get_deployment_binding().dbt.profile_fragment)
+
+    def get_dagster_io_manager_config(self) -> dict[str, Any]:
+        """Return storage-specific Dagster resource config."""
+        return dict(self.get_deployment_binding().dagster.resources)
+
+    def get_helm_values_override(self) -> dict[str, Any]:
+        """Return no chart values; AWS S3 is externally managed."""
+        self._require_config()
+        return {}

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from floe_core.plugins.storage import StoragePlugin
 from floe_core.schemas.compiled_artifacts import (
@@ -29,6 +29,9 @@ TRACER_NAME = "floe.storage.aws_s3"
 AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID"
 AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY"  # pragma: allowlist secret
 AWS_SESSION_TOKEN_ENV = "AWS_SESSION_TOKEN"
+KEY_ACCESS_KEY_ID = "accessKeyId"
+KEY_SECRET_ACCESS_KEY = "secretAccessKey"  # pragma: allowlist secret
+KEY_SESSION_TOKEN = "sessionToken"
 
 
 def _s3_uri(bucket: str, prefix: str) -> str:
@@ -53,7 +56,14 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
                 "aws-s3",
                 [{"field": "_config", "message": "Plugin 'aws-s3' not configured"}],
             )
-        return cast(AwsS3ObjectStoreConfig, self._config)
+        if not isinstance(self._config, AwsS3ObjectStoreConfig):
+            from floe_core.plugin_errors import PluginConfigurationError
+
+            raise PluginConfigurationError(
+                "aws-s3",
+                [{"field": "_config", "message": "Plugin 'aws-s3' config has invalid type"}],
+            )
+        return self._config
 
     @property
     def name(self) -> str:
@@ -112,31 +122,35 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
         """Return secret-free credential references for the configured mode."""
         config = self._require_config()
         if config.credential_mode == "workload-identity":
-            assert config.service_account_ref is not None
+            if config.service_account_ref is None:
+                msg = "workload-identity credential_mode requires service_account_ref"
+                raise ValueError(msg)
             return StorageCredentialBinding(
                 mode="workload-identity",
                 service_account_ref=config.service_account_ref,
             )
         if config.credential_mode == "kubernetes-secret":
-            assert config.credential_secret_name is not None
+            if config.credential_secret_name is None:
+                msg = "kubernetes-secret credential_mode requires credential_secret_name"
+                raise ValueError(msg)
             return StorageCredentialBinding(
                 mode="kubernetes-secret",
                 secret_ref=KubernetesSecretRef(
                     name=config.credential_secret_name,
                     namespace=config.credential_secret_namespace,
                     keys={
-                        "accessKeyId": config.access_key_secret_key,
-                        "secretAccessKey": config.secret_key_secret_key,
-                        "sessionToken": config.session_token_secret_key,
+                        KEY_ACCESS_KEY_ID: config.access_key_secret_key,
+                        KEY_SECRET_ACCESS_KEY: config.secret_key_secret_key,
+                        KEY_SESSION_TOKEN: config.session_token_secret_key,
                     },
                 ),
             )
         return StorageCredentialBinding(
             mode="environment",
             env_refs={
-                "accessKeyId": AWS_ACCESS_KEY_ENV,
-                "secretAccessKey": AWS_SECRET_KEY_ENV,
-                "sessionToken": AWS_SESSION_TOKEN_ENV,
+                KEY_ACCESS_KEY_ID: AWS_ACCESS_KEY_ENV,
+                KEY_SECRET_ACCESS_KEY: AWS_SECRET_KEY_ENV,
+                KEY_SESSION_TOKEN: AWS_SESSION_TOKEN_ENV,
             },
         )
 
@@ -174,7 +188,6 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
             {
                 "s3_access_key_id": AWS_ACCESS_KEY_ENV,
                 "s3_secret_access_key": AWS_SECRET_KEY_ENV,
-                "s3_session_token": AWS_SESSION_TOKEN_ENV,
             }
             if config.credential_mode == "environment"
             else {}

--- a/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
+++ b/plugins/floe-storage-aws-s3/src/floe_storage_aws_s3/plugin.py
@@ -105,6 +105,7 @@ class AwsS3ObjectStorePlugin(StoragePlugin):
         properties = {"s3.region": config.region}
         if config.endpoint_override is not None:
             properties["s3.endpoint"] = config.endpoint_override
+        if config.endpoint_override is not None or config.path_style_access:
             properties["s3.path-style-access"] = str(config.path_style_access).lower()
         return properties
 

--- a/plugins/floe-storage-aws-s3/tests/conftest.py
+++ b/plugins/floe-storage-aws-s3/tests/conftest.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+# The package is intentionally not registered in the root workspace until the
+# provider integration branch. Package-local pytest already uses pythonpath,
+# but root-level CI collection needs this explicit source path.
 PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
 if str(PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(PACKAGE_SRC))

--- a/plugins/floe-storage-aws-s3/tests/conftest.py
+++ b/plugins/floe-storage-aws-s3/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared pytest configuration for floe-storage-aws-s3 tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_SRC))

--- a/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
+++ b/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
@@ -318,6 +318,23 @@ class TestAwsS3DeploymentBinding:
             "s3.path-style-access": "true",
         }
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-026")
+    def test_path_style_access_projects_without_endpoint_override(self) -> None:
+        """PyIceberg path-style access config is preserved without endpoint overrides."""
+        config = AwsS3ObjectStoreConfig(
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
+            path_style_access=True,
+            credential_mode="environment",
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert binding.endpoint.path_style_access is True
+        assert binding.runtime.pyiceberg_properties == {
+            "s3.region": TEST_REGION,
+            "s3.path-style-access": "true",
+        }
+
 
 class TestStoragePluginMethods:
     """Test required StoragePlugin methods."""

--- a/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
+++ b/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
@@ -1,0 +1,279 @@
+"""Unit tests for the native AWS S3 storage plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import tomllib
+from pydantic import ValidationError
+
+from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
+from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
+
+
+class TestPluginMetadata:
+    """Test plugin metadata and config schema."""
+
+    def test_plugin_metadata(self) -> None:
+        plugin = AwsS3ObjectStorePlugin()
+
+        assert plugin.name == "aws-s3"
+        assert plugin.version.count(".") == 2
+        assert plugin.floe_api_version == "1.0"
+        assert plugin.description == "AWS S3 object storage plugin for Iceberg data"
+        assert plugin.tracer_name == "floe.storage.aws_s3"
+
+    def test_get_config_schema_returns_aws_s3_config(self) -> None:
+        assert AwsS3ObjectStorePlugin().get_config_schema() is AwsS3ObjectStoreConfig
+
+
+class TestAwsS3ObjectStoreConfig:
+    """Test AWS S3 config validation."""
+
+    def test_workload_identity_config_requires_service_account(self) -> None:
+        with pytest.raises(ValidationError, match="service_account_ref"):
+            AwsS3ObjectStoreConfig(
+                bucket="floe-provider-tests",
+                region="ap-southeast-2",
+                credential_mode="workload-identity",
+            )
+
+    def test_kubernetes_secret_config_requires_secret_name(self) -> None:
+        with pytest.raises(ValidationError, match="credential_secret_name"):
+            AwsS3ObjectStoreConfig(
+                bucket="floe-provider-tests",
+                region="ap-southeast-2",
+                credential_mode="kubernetes-secret",
+            )
+
+    def test_environment_config_rejects_secret_fields(self) -> None:
+        with pytest.raises(ValidationError, match="only accepts environment variable names"):
+            AwsS3ObjectStoreConfig(
+                bucket="floe-provider-tests",
+                region="ap-southeast-2",
+                credential_mode="environment",
+                credential_secret_name="aws-creds",  # pragma: allowlist secret
+            )
+
+    def test_endpoint_override_must_be_http_url(self) -> None:
+        with pytest.raises(ValidationError, match="endpoint_override"):
+            AwsS3ObjectStoreConfig(
+                bucket="floe-provider-tests",
+                region="ap-southeast-2",
+                endpoint_override="s3.ap-southeast-2.amazonaws.com",
+            )
+
+    def test_config_defaults_are_native_aws(self) -> None:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+
+        assert config.warehouse_prefix == "warehouse/"
+        assert config.artifact_bucket == "floe-provider-tests"
+        assert config.artifact_prefix == "artifacts/"
+        assert config.path_style_access is False
+        assert config.sts_supported is True
+        assert config.create_policy == "must-exist"
+
+
+class TestAwsS3DeploymentBinding:
+    """Test secret-free AWS S3 deployment bindings."""
+
+    def test_workload_identity_binding_emits_native_s3_contract(self) -> None:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+        plugin = AwsS3ObjectStorePlugin(config=config)
+
+        binding = plugin.get_deployment_binding()
+        payload = binding.model_dump_json()
+
+        assert binding.provider == "aws-s3"
+        assert binding.protocol == "s3"
+        assert binding.endpoint.internal_url == "https://s3.ap-southeast-2.amazonaws.com"
+        assert binding.endpoint.external_url == "https://s3.ap-southeast-2.amazonaws.com"
+        assert binding.endpoint.region == "ap-southeast-2"
+        assert binding.endpoint.warehouse_path == "s3://floe-provider-tests/warehouse/"
+        assert binding.endpoint.path_style_access is False
+        assert binding.warehouse is not None
+        assert binding.warehouse.uri == "s3://floe-provider-tests/warehouse/"
+        assert binding.warehouse.bucket == "floe-provider-tests"
+        assert binding.warehouse.prefix == "warehouse/"
+        assert binding.allowed_locations == [
+            "s3://floe-provider-tests/warehouse/",
+            "s3://floe-provider-tests/artifacts/",
+        ]
+        bucket_contracts = [
+            (bucket.name, bucket.purpose, bucket.create_policy) for bucket in binding.buckets
+        ]
+        assert bucket_contracts == [
+            ("floe-provider-tests", "warehouse", "must-exist"),
+            ("floe-provider-tests", "artifacts", "must-exist"),
+        ]
+        assert binding.credentials.mode == "workload-identity"
+        assert binding.credentials.service_account_ref == "floe-provider-tests"
+        assert binding.capabilities.protocols == ["s3"]
+        assert binding.capabilities.credential_modes == ["workload-identity"]
+        assert binding.capabilities.identity_modes == ["aws-irsa", "aws-pod-identity"]
+        assert binding.capabilities.sts_supported is True
+        assert binding.capabilities.path_style_access is False
+        assert binding.provisioning.enabled is False
+        assert binding.provisioning.mode == "external"
+        assert binding.provisioning.default_create_policy == "must-exist"
+        assert binding.runtime.pyiceberg_properties == {"s3.region": "ap-southeast-2"}
+        assert binding.runtime.env_refs == {}
+        assert binding.dbt.profile_fragment == {
+            "s3_region": "ap-southeast-2",
+            "s3_path_style_access": False,
+        }
+        assert binding.dagster.resources == {
+            "bucket": "floe-provider-tests",
+            "region_name": "ap-southeast-2",
+            "path_style_access": False,
+        }
+        assert "AWS_SECRET_ACCESS_KEY" not in payload
+        assert "raw-secret-value" not in payload
+
+    def test_environment_binding_uses_env_refs_without_values(self) -> None:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            credential_mode="environment",
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert binding.credentials.mode == "environment"
+        assert binding.credentials.env_refs == {
+            "accessKeyId": "AWS_ACCESS_KEY_ID",
+            "secretAccessKey": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
+            "sessionToken": "AWS_SESSION_TOKEN",
+        }
+        assert binding.runtime.env_refs == binding.credentials.env_refs
+        assert binding.dbt.env_refs == {
+            "s3_access_key_id": "AWS_ACCESS_KEY_ID",
+            "s3_secret_access_key": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
+            "s3_session_token": "AWS_SESSION_TOKEN",
+        }
+
+    def test_kubernetes_secret_binding_uses_secret_refs_without_values(self) -> None:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            credential_mode="kubernetes-secret",
+            credential_secret_name="aws-s3-credentials",  # pragma: allowlist secret
+            credential_secret_namespace="floe-system",  # pragma: allowlist secret
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert binding.credentials.mode == "kubernetes-secret"
+        assert binding.credentials.secret_ref is not None
+        assert binding.credentials.secret_ref.name == "aws-s3-credentials"
+        assert binding.credentials.secret_ref.namespace == "floe-system"
+        assert binding.credentials.secret_ref.keys == {
+            "accessKeyId": "accessKeyId",
+            "secretAccessKey": "secretAccessKey",  # pragma: allowlist secret
+            "sessionToken": "sessionToken",
+        }
+
+    def test_endpoint_override_projects_localstack_properties(self) -> None:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            endpoint_override="http://localhost:4566",
+            path_style_access=True,
+            credential_mode="environment",
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert binding.endpoint.internal_url == "http://localhost:4566"
+        assert binding.endpoint.external_url == "http://localhost:4566"
+        assert binding.endpoint.path_style_access is True
+        assert binding.runtime.pyiceberg_properties == {
+            "s3.endpoint": "http://localhost:4566",
+            "s3.region": "ap-southeast-2",
+            "s3.path-style-access": "true",
+        }
+
+
+class TestStoragePluginMethods:
+    """Test required StoragePlugin methods."""
+
+    @pytest.fixture()
+    def configured_plugin(self) -> AwsS3ObjectStorePlugin:
+        config = AwsS3ObjectStoreConfig(
+            bucket="floe-provider-tests",
+            region="ap-southeast-2",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+        return AwsS3ObjectStorePlugin(config=config)
+
+    def test_get_warehouse_uri(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        assert configured_plugin.get_warehouse_uri("bronze") == (
+            "s3://floe-provider-tests/warehouse/bronze/"
+        )
+
+    def test_get_dbt_profile_config(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        assert configured_plugin.get_dbt_profile_config() == {
+            "s3_region": "ap-southeast-2",
+            "s3_path_style_access": False,
+        }
+
+    def test_get_dagster_io_manager_config(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        assert configured_plugin.get_dagster_io_manager_config() == {
+            "bucket": "floe-provider-tests",
+            "region_name": "ap-southeast-2",
+            "path_style_access": False,
+        }
+
+    def test_get_pyiceberg_catalog_config_has_no_credentials(
+        self, configured_plugin: AwsS3ObjectStorePlugin
+    ) -> None:
+        assert configured_plugin.get_pyiceberg_catalog_config() == {"s3.region": "ap-southeast-2"}
+
+    def test_get_pyiceberg_fileio(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        from pyiceberg.io.fsspec import FsspecFileIO
+
+        with patch.dict("os.environ", {}, clear=False):
+            fileio = configured_plugin.get_pyiceberg_fileio()
+
+        assert isinstance(fileio, FsspecFileIO)
+
+    def test_get_helm_values_override_is_empty(
+        self,
+        configured_plugin: AwsS3ObjectStorePlugin,
+    ) -> None:
+        assert configured_plugin.get_helm_values_override() == {}
+
+    def test_methods_raise_without_config(self) -> None:
+        from floe_core.plugin_errors import PluginConfigurationError
+
+        plugin = AwsS3ObjectStorePlugin()
+
+        with pytest.raises(PluginConfigurationError, match="not configured"):
+            plugin.get_deployment_binding()
+        with pytest.raises(PluginConfigurationError, match="not configured"):
+            plugin.get_warehouse_uri("bronze")
+        with pytest.raises(PluginConfigurationError, match="not configured"):
+            plugin.get_pyiceberg_catalog_config()
+
+
+class TestPackageMetadata:
+    """Test package metadata without requiring workspace registration."""
+
+    def test_pyproject_declares_floe_storage_entry_point(self) -> None:
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+        assert pyproject["project"]["name"] == "floe-storage-aws-s3"
+        assert pyproject["project"]["entry-points"]["floe.storage"] == {
+            "aws-s3": "floe_storage_aws_s3.plugin:AwsS3ObjectStorePlugin"
+        }

--- a/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
+++ b/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
@@ -2,21 +2,35 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import tomllib
 from pydantic import ValidationError
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
 from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
+
+TEST_BUCKET = "floe-provider-tests"
+TEST_REGION = "ap-southeast-2"
+TEST_SERVICE_ACCOUNT = "floe-provider-tests"
+TEST_WAREHOUSE_URI = f"s3://{TEST_BUCKET}/warehouse/"
+TEST_ARTIFACT_URI = f"s3://{TEST_BUCKET}/artifacts/"
+TEST_AWS_ENDPOINT = f"https://s3.{TEST_REGION}.amazonaws.com"
 
 
 class TestPluginMetadata:
     """Test plugin metadata and config schema."""
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-001")
     def test_plugin_metadata(self) -> None:
+        """Plugin metadata exposes the stable aws-s3 identity and tracer name."""
         plugin = AwsS3ObjectStorePlugin()
 
         assert plugin.name == "aws-s3"
@@ -25,56 +39,68 @@ class TestPluginMetadata:
         assert plugin.description == "AWS S3 object storage plugin for Iceberg data"
         assert plugin.tracer_name == "floe.storage.aws_s3"
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-002")
     def test_get_config_schema_returns_aws_s3_config(self) -> None:
+        """Plugin config schema points consumers at the AWS S3 config model."""
         assert AwsS3ObjectStorePlugin().get_config_schema() is AwsS3ObjectStoreConfig
 
 
 class TestAwsS3ObjectStoreConfig:
     """Test AWS S3 config validation."""
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-003")
     def test_workload_identity_config_requires_service_account(self) -> None:
+        """Workload-identity mode rejects config without a service account ref."""
         with pytest.raises(ValidationError, match="service_account_ref"):
             AwsS3ObjectStoreConfig(
-                bucket="floe-provider-tests",
-                region="ap-southeast-2",
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
                 credential_mode="workload-identity",
             )
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-004")
     def test_kubernetes_secret_config_requires_secret_name(self) -> None:
+        """Kubernetes-secret mode rejects config without a Secret reference."""
         with pytest.raises(ValidationError, match="credential_secret_name"):
             AwsS3ObjectStoreConfig(
-                bucket="floe-provider-tests",
-                region="ap-southeast-2",
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
                 credential_mode="kubernetes-secret",
             )
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-005")
     def test_environment_config_rejects_secret_fields(self) -> None:
+        """Environment mode rejects Kubernetes Secret fields to keep sources exclusive."""
         with pytest.raises(ValidationError, match="only accepts environment variable names"):
             AwsS3ObjectStoreConfig(
-                bucket="floe-provider-tests",
-                region="ap-southeast-2",
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
                 credential_mode="environment",
                 credential_secret_name="aws-creds",  # pragma: allowlist secret
             )
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-006")
     def test_endpoint_override_must_be_http_url(self) -> None:
+        """Endpoint overrides must be explicit HTTP URLs for runtime clients."""
         with pytest.raises(ValidationError, match="endpoint_override"):
             AwsS3ObjectStoreConfig(
-                bucket="floe-provider-tests",
-                region="ap-southeast-2",
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
                 endpoint_override="s3.ap-southeast-2.amazonaws.com",
             )
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-007")
     def test_config_defaults_are_native_aws(self) -> None:
+        """Default config favors native AWS S3 behavior and externally managed buckets."""
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
 
         assert config.warehouse_prefix == "warehouse/"
-        assert config.artifact_bucket == "floe-provider-tests"
+        assert config.artifact_bucket == TEST_BUCKET
         assert config.artifact_prefix == "artifacts/"
         assert config.path_style_access is False
         assert config.sts_supported is True
@@ -84,12 +110,14 @@ class TestAwsS3ObjectStoreConfig:
 class TestAwsS3DeploymentBinding:
     """Test secret-free AWS S3 deployment bindings."""
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-008")
     def test_workload_identity_binding_emits_native_s3_contract(self) -> None:
+        """Workload identity emits native s3 bindings without credential values."""
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
         plugin = AwsS3ObjectStorePlugin(config=config)
 
@@ -98,28 +126,27 @@ class TestAwsS3DeploymentBinding:
 
         assert binding.provider == "aws-s3"
         assert binding.protocol == "s3"
-        assert binding.endpoint.internal_url == "https://s3.ap-southeast-2.amazonaws.com"
-        assert binding.endpoint.external_url == "https://s3.ap-southeast-2.amazonaws.com"
-        assert binding.endpoint.region == "ap-southeast-2"
-        assert binding.endpoint.warehouse_path == "s3://floe-provider-tests/warehouse/"
+        assert binding.endpoint.internal_url == TEST_AWS_ENDPOINT
+        assert binding.endpoint.external_url == TEST_AWS_ENDPOINT
+        assert binding.endpoint.region == TEST_REGION
+        assert binding.endpoint.warehouse_path == TEST_WAREHOUSE_URI
         assert binding.endpoint.path_style_access is False
-        assert binding.warehouse is not None
-        assert binding.warehouse.uri == "s3://floe-provider-tests/warehouse/"
-        assert binding.warehouse.bucket == "floe-provider-tests"
+        assert binding.warehouse.uri == TEST_WAREHOUSE_URI
+        assert binding.warehouse.bucket == TEST_BUCKET
         assert binding.warehouse.prefix == "warehouse/"
         assert binding.allowed_locations == [
-            "s3://floe-provider-tests/warehouse/",
-            "s3://floe-provider-tests/artifacts/",
+            TEST_WAREHOUSE_URI,
+            TEST_ARTIFACT_URI,
         ]
         bucket_contracts = [
             (bucket.name, bucket.purpose, bucket.create_policy) for bucket in binding.buckets
         ]
         assert bucket_contracts == [
-            ("floe-provider-tests", "warehouse", "must-exist"),
-            ("floe-provider-tests", "artifacts", "must-exist"),
+            (TEST_BUCKET, "warehouse", "must-exist"),
+            (TEST_BUCKET, "artifacts", "must-exist"),
         ]
         assert binding.credentials.mode == "workload-identity"
-        assert binding.credentials.service_account_ref == "floe-provider-tests"
+        assert binding.credentials.service_account_ref == TEST_SERVICE_ACCOUNT
         assert binding.capabilities.protocols == ["s3"]
         assert binding.capabilities.credential_modes == ["workload-identity"]
         assert binding.capabilities.identity_modes == ["aws-irsa", "aws-pod-identity"]
@@ -128,24 +155,26 @@ class TestAwsS3DeploymentBinding:
         assert binding.provisioning.enabled is False
         assert binding.provisioning.mode == "external"
         assert binding.provisioning.default_create_policy == "must-exist"
-        assert binding.runtime.pyiceberg_properties == {"s3.region": "ap-southeast-2"}
+        assert binding.runtime.pyiceberg_properties == {"s3.region": TEST_REGION}
         assert binding.runtime.env_refs == {}
         assert binding.dbt.profile_fragment == {
-            "s3_region": "ap-southeast-2",
+            "s3_region": TEST_REGION,
             "s3_path_style_access": False,
         }
         assert binding.dagster.resources == {
-            "bucket": "floe-provider-tests",
-            "region_name": "ap-southeast-2",
+            "bucket": TEST_BUCKET,
+            "region_name": TEST_REGION,
             "path_style_access": False,
         }
         assert "AWS_SECRET_ACCESS_KEY" not in payload
         assert "raw-secret-value" not in payload
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-009")
     def test_environment_binding_uses_env_refs_without_values(self) -> None:
+        """Environment mode projects environment variable names instead of values."""
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             credential_mode="environment",
         )
         binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
@@ -163,10 +192,12 @@ class TestAwsS3DeploymentBinding:
             "s3_session_token": "AWS_SESSION_TOKEN",
         }
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-010")
     def test_kubernetes_secret_binding_uses_secret_refs_without_values(self) -> None:
+        """Kubernetes-secret mode projects Secret key references without values."""
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             credential_mode="kubernetes-secret",
             credential_secret_name="aws-s3-credentials",  # pragma: allowlist secret
             credential_secret_namespace="floe-system",  # pragma: allowlist secret
@@ -183,10 +214,12 @@ class TestAwsS3DeploymentBinding:
             "sessionToken": "sessionToken",
         }
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-011")
     def test_endpoint_override_projects_localstack_properties(self) -> None:
+        """Endpoint overrides are projected for local S3-compatible testing."""
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             endpoint_override="http://localhost:4566",
             path_style_access=True,
             credential_mode="environment",
@@ -198,7 +231,7 @@ class TestAwsS3DeploymentBinding:
         assert binding.endpoint.path_style_access is True
         assert binding.runtime.pyiceberg_properties == {
             "s3.endpoint": "http://localhost:4566",
-            "s3.region": "ap-southeast-2",
+            "s3.region": TEST_REGION,
             "s3.path-style-access": "true",
         }
 
@@ -209,37 +242,45 @@ class TestStoragePluginMethods:
     @pytest.fixture()
     def configured_plugin(self) -> AwsS3ObjectStorePlugin:
         config = AwsS3ObjectStoreConfig(
-            bucket="floe-provider-tests",
-            region="ap-southeast-2",
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
         return AwsS3ObjectStorePlugin(config=config)
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-012")
     def test_get_warehouse_uri(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
-        assert configured_plugin.get_warehouse_uri("bronze") == (
-            "s3://floe-provider-tests/warehouse/bronze/"
-        )
+        """Namespace warehouse URIs are derived below the configured warehouse prefix."""
+        assert configured_plugin.get_warehouse_uri("bronze") == f"{TEST_WAREHOUSE_URI}bronze/"
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-013")
     def test_get_dbt_profile_config(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        """Legacy dbt profile helper returns the binding-derived storage fragment."""
         assert configured_plugin.get_dbt_profile_config() == {
-            "s3_region": "ap-southeast-2",
+            "s3_region": TEST_REGION,
             "s3_path_style_access": False,
         }
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-014")
     def test_get_dagster_io_manager_config(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        """Legacy Dagster helper returns the binding-derived storage fragment."""
         assert configured_plugin.get_dagster_io_manager_config() == {
-            "bucket": "floe-provider-tests",
-            "region_name": "ap-southeast-2",
+            "bucket": TEST_BUCKET,
+            "region_name": TEST_REGION,
             "path_style_access": False,
         }
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-015")
     def test_get_pyiceberg_catalog_config_has_no_credentials(
         self, configured_plugin: AwsS3ObjectStorePlugin
     ) -> None:
-        assert configured_plugin.get_pyiceberg_catalog_config() == {"s3.region": "ap-southeast-2"}
+        """PyIceberg catalog config exposes only non-secret S3 properties."""
+        assert configured_plugin.get_pyiceberg_catalog_config() == {"s3.region": TEST_REGION}
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-016")
     def test_get_pyiceberg_fileio(self, configured_plugin: AwsS3ObjectStorePlugin) -> None:
+        """FileIO construction delegates to PyIceberg without needing inline credentials."""
         from pyiceberg.io.fsspec import FsspecFileIO
 
         with patch.dict("os.environ", {}, clear=False):
@@ -247,13 +288,17 @@ class TestStoragePluginMethods:
 
         assert isinstance(fileio, FsspecFileIO)
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-017")
     def test_get_helm_values_override_is_empty(
         self,
         configured_plugin: AwsS3ObjectStorePlugin,
     ) -> None:
+        """AWS S3 has no Helm-managed service values because buckets are external."""
         assert configured_plugin.get_helm_values_override() == {}
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-018")
     def test_methods_raise_without_config(self) -> None:
+        """Unconfigured plugin methods raise structured configuration errors."""
         from floe_core.plugin_errors import PluginConfigurationError
 
         plugin = AwsS3ObjectStorePlugin()
@@ -269,7 +314,9 @@ class TestStoragePluginMethods:
 class TestPackageMetadata:
     """Test package metadata without requiring workspace registration."""
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-019")
     def test_pyproject_declares_floe_storage_entry_point(self) -> None:
+        """Package metadata declares the aws-s3 storage plugin entry point."""
         pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
         pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 

--- a/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
+++ b/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
@@ -14,7 +14,7 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
+from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig, _normalize_prefix
 from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
 
 TEST_BUCKET = "floe-provider-tests"
@@ -78,6 +78,46 @@ class TestAwsS3ObjectStoreConfig:
                 credential_mode="environment",
                 credential_secret_name="aws-creds",  # pragma: allowlist secret
             )
+
+    @pytest.mark.requirement("STORAGE-AWS-S3-020")
+    def test_workload_identity_config_rejects_secret_name(self) -> None:
+        """Workload-identity mode rejects Kubernetes Secret fields from other modes."""
+        with pytest.raises(ValidationError, match="only accepts service_account_ref"):
+            AwsS3ObjectStoreConfig(
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
+                credential_mode="workload-identity",
+                service_account_ref=TEST_SERVICE_ACCOUNT,
+                credential_secret_name="aws-creds",  # pragma: allowlist secret
+            )
+
+    @pytest.mark.requirement("STORAGE-AWS-S3-021")
+    def test_kubernetes_secret_config_rejects_service_account(self) -> None:
+        """Kubernetes-secret mode rejects workload identity service account refs."""
+        with pytest.raises(ValidationError, match="only accepts credential_secret_name"):
+            AwsS3ObjectStoreConfig(
+                bucket=TEST_BUCKET,
+                region=TEST_REGION,
+                credential_mode="kubernetes-secret",
+                credential_secret_name="aws-creds",  # pragma: allowlist secret
+                service_account_ref=TEST_SERVICE_ACCOUNT,
+            )
+
+    @pytest.mark.requirement("STORAGE-AWS-S3-022")
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("warehouse", "warehouse/"),
+            ("/warehouse/", "warehouse/"),
+            ("", ""),
+            ("/", ""),
+            ("//", ""),
+            ("a/b/c", "a/b/c/"),
+        ],
+    )
+    def test_normalize_prefix_edge_cases(self, raw: str, expected: str) -> None:
+        """Prefix normalization handles slash-stripping edge cases deterministically."""
+        assert _normalize_prefix(raw) == expected
 
     @pytest.mark.requirement("STORAGE-AWS-S3-006")
     def test_endpoint_override_must_be_http_url(self) -> None:
@@ -189,8 +229,20 @@ class TestAwsS3DeploymentBinding:
         assert binding.dbt.env_refs == {
             "s3_access_key_id": "AWS_ACCESS_KEY_ID",
             "s3_secret_access_key": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
-            "s3_session_token": "AWS_SESSION_TOKEN",
         }
+
+    @pytest.mark.requirement("STORAGE-AWS-S3-023")
+    def test_environment_dbt_binding_does_not_require_session_token(self) -> None:
+        """dbt profile env refs omit optional AWS_SESSION_TOKEN for non-STS credentials."""
+        config = AwsS3ObjectStoreConfig(
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
+            credential_mode="environment",
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert "s3_session_token" not in binding.dbt.env_refs
+        assert "sessionToken" in binding.credentials.env_refs
 
     @pytest.mark.requirement("STORAGE-AWS-S3-010")
     def test_kubernetes_secret_binding_uses_secret_refs_without_values(self) -> None:
@@ -241,6 +293,7 @@ class TestStoragePluginMethods:
 
     @pytest.fixture()
     def configured_plugin(self) -> AwsS3ObjectStorePlugin:
+        """Return an AWS S3 plugin configured for workload-identity testing."""
         config = AwsS3ObjectStoreConfig(
             bucket=TEST_BUCKET,
             region=TEST_REGION,

--- a/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
+++ b/plugins/floe-storage-aws-s3/tests/unit/test_plugin.py
@@ -146,6 +146,17 @@ class TestAwsS3ObjectStoreConfig:
         assert config.sts_supported is True
         assert config.create_policy == "must-exist"
 
+    @pytest.mark.requirement("STORAGE-AWS-S3-024")
+    def test_artifact_bucket_rejects_empty_string(self) -> None:
+        """Artifact bucket overrides must be non-empty when explicitly provided."""
+        with pytest.raises(ValidationError, match="artifact_bucket"):
+            AwsS3ObjectStoreConfig(
+                bucket=TEST_BUCKET,
+                artifact_bucket="",
+                region=TEST_REGION,
+                credential_mode="environment",
+            )
+
 
 class TestAwsS3DeploymentBinding:
     """Test secret-free AWS S3 deployment bindings."""
@@ -264,6 +275,26 @@ class TestAwsS3DeploymentBinding:
             "accessKeyId": "accessKeyId",
             "secretAccessKey": "secretAccessKey",  # pragma: allowlist secret
             "sessionToken": "sessionToken",
+        }
+        assert binding.runtime.env_refs == {
+            "accessKeyId": "AWS_ACCESS_KEY_ID",
+            "secretAccessKey": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
+        }
+
+    @pytest.mark.requirement("STORAGE-AWS-S3-025")
+    def test_kubernetes_secret_runtime_env_refs_project_aws_env_names(self) -> None:
+        """Secret-backed mode still exposes runtime AWS env names for job wiring."""
+        config = AwsS3ObjectStoreConfig(
+            bucket=TEST_BUCKET,
+            region=TEST_REGION,
+            credential_mode="kubernetes-secret",
+            credential_secret_name="aws-s3-credentials",  # pragma: allowlist secret
+        )
+        binding = AwsS3ObjectStorePlugin(config=config).get_deployment_binding()
+
+        assert binding.runtime.env_refs == {
+            "accessKeyId": "AWS_ACCESS_KEY_ID",
+            "secretAccessKey": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
         }
 
     @pytest.mark.requirement("STORAGE-AWS-S3-011")


### PR DESCRIPTION
## Summary

Adds the native AWS S3 storage plugin package as an isolated provider-plugin slice.

This introduces `plugins/floe-storage-aws-s3` with:
- secret-free AWS S3 storage configuration
- `aws-s3` entry point for `floe.storage`
- `StorageDeploymentBinding` emission for native `s3` protocol
- support for environment, workload identity, and Kubernetes Secret credential reference modes
- non-secret PyIceberg, dbt, and Dagster runtime fragments
- package-local tests that can run both package-scoped and under root pytest collection

The public class names avoid the stale legacy `S3StoragePlugin` / `S3StorageConfig` names so the existing MinIO rename audits continue to enforce that the old generic `s3` plugin identity is gone.

## Validation

- `uv run pytest plugins/floe-storage-aws-s3/tests/unit/test_plugin.py tests/contract/test_storage_minio_reference_audit.py tests/contract/test_storage_minio_rename.py -q`
- `PYTHONPATH=plugins/floe-storage-aws-s3/src:packages/floe-core/src uv run ruff check plugins/floe-storage-aws-s3`
- `PYTHONPATH=plugins/floe-storage-aws-s3/src:packages/floe-core/src uv run mypy plugins/floe-storage-aws-s3/src/floe_storage_aws_s3`
- normal pre-push hooks passed: ruff, ruff format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, no hardcoded sleep, requirement traceability, docs content validation, helm lint
