### PR TITLE
feat: add AWS Glue catalog plugin

### DIFF
--- a/plugins/floe-catalog-glue/README.md
+++ b/plugins/floe-catalog-glue/README.md
@@ -1,0 +1,7 @@
+# floe-catalog-glue
+
+Native AWS Glue catalog plugin for Floe.
+
+This package emits secret-free `CatalogDeploymentBinding` contracts for AWS
+Glue and delegates runtime catalog access to PyIceberg's Glue catalog. It does
+not place AWS credential values in compiled artifacts.

--- a/plugins/floe-catalog-glue/pyproject.toml
+++ b/plugins/floe-catalog-glue/pyproject.toml
@@ -1,0 +1,89 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "floe-catalog-glue"
+version = "0.1.0"
+description = "AWS Glue catalog plugin for the floe data platform"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    { name = "Obsidian Owl", email = "team@obsidianowl.dev" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "floe-core>=0.1.0",
+    "pyiceberg[glue]>=0.11.1",
+    "pydantic>=2.0,<3.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=4.0",
+    "mypy>=1.8",
+    "ruff>=0.3",
+]
+
+[project.urls]
+Homepage = "https://github.com/Obsidian-Owl/floe"
+Documentation = "https://github.com/Obsidian-Owl/floe/tree/main/docs"
+Repository = "https://github.com/Obsidian-Owl/floe"
+
+[project.entry-points."floe.catalogs"]
+glue = "floe_catalog_glue.plugin:GlueCatalogPlugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/floe_catalog_glue"]
+
+[tool.hatch.build.targets.wheel.sources]
+"src" = ""
+
+[tool.hatch.build]
+include = [
+    "src/floe_catalog_glue/**/*.py",
+    "src/floe_catalog_glue/py.typed",
+]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "UP",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --tb=short"
+markers = [
+    "requirement(id): Mark test with requirement ID for traceability",
+]

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/__init__.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/__init__.py
@@ -1,0 +1,10 @@
+"""AWS Glue catalog plugin for Floe."""
+
+from floe_catalog_glue.config import GlueCatalogConfig, GlueCredentialMode
+from floe_catalog_glue.plugin import GlueCatalogPlugin
+
+__all__ = [
+    "GlueCatalogConfig",
+    "GlueCatalogPlugin",
+    "GlueCredentialMode",
+]

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/config.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/config.py
@@ -1,0 +1,114 @@
+"""Configuration model for the native AWS Glue catalog plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+GlueCredentialMode = Literal["environment", "workload-identity", "kubernetes-secret"]
+RetryMode = Literal["standard", "adaptive", "legacy"]
+
+
+class GlueCatalogConfig(BaseModel):
+    """AWS Glue catalog configuration.
+
+    Credentials are represented by environment variable names, Kubernetes Secret
+    references, or workload identity service account references. Raw AWS
+    credential values are intentionally not accepted by this model.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    region: str = Field(..., min_length=1, description="AWS region.")
+    catalog_id: str | None = Field(
+        default=None,
+        pattern=r"^\d{12}$",
+        description="Optional AWS account/catalog ID.",
+    )
+    warehouse: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional warehouse URI override.",
+    )
+    database_prefix: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional namespace prefix for Floe-created databases.",
+    )
+    endpoint_override: str | None = Field(
+        default=None,
+        pattern=r"^https?://",
+        description="Optional Glue endpoint override for tests or local emulation.",
+    )
+    credential_mode: GlueCredentialMode = "workload-identity"
+    credential_secret_name: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Kubernetes Secret name for kubernetes-secret mode.",
+    )
+    credential_secret_namespace: str = Field(
+        default="floe-system",
+        min_length=1,
+        description="Kubernetes namespace for credential_secret_name.",
+    )
+    access_key_secret_key: str = Field(default="accessKeyId", min_length=1)
+    secret_key_secret_key: str = Field(default="secretAccessKey", min_length=1)
+    session_token_secret_key: str = Field(default="sessionToken", min_length=1)
+    service_account_ref: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Kubernetes ServiceAccount reference for workload identity.",
+    )
+    skip_archive: bool = True
+    max_retries: int | None = Field(default=None, ge=1)
+    retry_mode: RetryMode | None = None
+
+    @field_validator("warehouse")
+    @classmethod
+    def normalize_warehouse(cls, value: str | None) -> str | None:
+        """Normalize S3 warehouse overrides to slash-terminated form."""
+        if value is None:
+            return value
+        if not value.startswith("s3://"):
+            msg = "warehouse must be an s3:// URI"
+            raise ValueError(msg)
+        return value if value.endswith("/") else f"{value}/"
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_raw_aws_key_fields(cls, data: Any) -> Any:
+        """Reject common raw AWS credential keys if provided by mistake."""
+        if isinstance(data, dict):
+            raw_keys = {"access_key_id", "secret_access_key", "session_token"}
+            present = raw_keys & set(data)
+            if present:
+                msg = f"raw AWS credential fields are not accepted: {sorted(present)}"
+                raise ValueError(msg)
+        return data
+
+    @model_validator(mode="after")
+    def validate_credential_mode(self) -> GlueCatalogConfig:
+        """Ensure credential reference fields match credential_mode."""
+        if self.credential_mode == "workload-identity":
+            if self.service_account_ref is None:
+                msg = "workload-identity credential_mode requires service_account_ref"
+                raise ValueError(msg)
+            if self.credential_secret_name is not None:
+                msg = "workload-identity credential_mode only accepts service_account_ref"
+                raise ValueError(msg)
+            return self
+
+        if self.credential_mode == "kubernetes-secret":
+            if self.credential_secret_name is None:
+                msg = "kubernetes-secret credential_mode requires credential_secret_name"
+                raise ValueError(msg)
+            if self.service_account_ref is not None:
+                msg = "kubernetes-secret credential_mode only accepts credential_secret_name"
+                raise ValueError(msg)
+            return self
+
+        if self.credential_secret_name is not None or self.service_account_ref is not None:
+            msg = "environment credential_mode only accepts environment variable names"
+            raise ValueError(msg)
+        return self

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/config.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Self
 
 GlueCredentialMode = Literal["environment", "workload-identity", "kubernetes-secret"]
 RetryMode = Literal["standard", "adaptive", "legacy"]
@@ -88,7 +89,7 @@ class GlueCatalogConfig(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def validate_credential_mode(self) -> GlueCatalogConfig:
+    def validate_credential_mode(self) -> Self:
         """Ensure credential reference fields match credential_mode."""
         if self.credential_mode == "workload-identity":
             if self.service_account_ref is None:

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
@@ -1,0 +1,261 @@
+"""AWS Glue CatalogPlugin implementation for Floe."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from floe_core.composition.models import (
+    CredentialMode,
+    IdentityMode,
+    PluginRequirements,
+    RequirementSet,
+)
+from floe_core.plugin_errors import CatalogUnavailableError, NotSupportedError
+from floe_core.plugins import CatalogPlugin
+from floe_core.plugins.catalog import Catalog
+from floe_core.schemas.compiled_artifacts import (
+    CatalogDeploymentBinding,
+    CredentialRef,
+    GlueCatalogDeploymentBinding,
+    KubernetesSecretRef,
+    StorageDeploymentBinding,
+)
+from pyiceberg.catalog import load_catalog
+
+from floe_catalog_glue.config import GlueCatalogConfig
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+TRACER_NAME = "floe.catalog.glue"
+
+
+class GlueCatalogPlugin(CatalogPlugin):
+    """Native AWS Glue catalog plugin implementing the CatalogPlugin ABC."""
+
+    def __init__(self, config: GlueCatalogConfig | None = None) -> None:
+        """Initialize the AWS Glue catalog plugin."""
+        super().__init__()
+        self._config = config
+        self._catalog: Catalog | None = None
+
+    def _require_config(self) -> GlueCatalogConfig:
+        """Return config or raise a structured plugin configuration error."""
+        if self._config is None:
+            from floe_core.plugin_errors import PluginConfigurationError
+
+            raise PluginConfigurationError(
+                "glue",
+                [{"field": "_config", "message": "Plugin 'glue' not configured"}],
+            )
+        return cast(GlueCatalogConfig, self._config)
+
+    @property
+    def name(self) -> str:
+        """Return the plugin name."""
+        return "glue"
+
+    @property
+    def version(self) -> str:
+        """Return the plugin version."""
+        return "0.1.0"
+
+    @property
+    def floe_api_version(self) -> str:
+        """Return the required Floe API version."""
+        return "1.0"
+
+    @property
+    def description(self) -> str:
+        """Return a human-readable plugin description."""
+        return "AWS Glue catalog plugin for Iceberg table management"
+
+    @property
+    def tracer_name(self) -> str:
+        """Return the OpenTelemetry tracer name."""
+        return TRACER_NAME
+
+    def get_config_schema(self) -> type[BaseModel]:
+        """Return the Pydantic config schema for this plugin."""
+        return GlueCatalogConfig
+
+    def connect(self, config: dict[str, Any]) -> Catalog:
+        """Connect to AWS Glue using PyIceberg's Glue catalog."""
+        catalog_config = self._pyiceberg_config()
+        catalog_config.update(config)
+        catalog = cast(Catalog, load_catalog("glue", **catalog_config))
+        self._catalog = catalog
+        return catalog
+
+    def _pyiceberg_config(self) -> dict[str, Any]:
+        """Return non-secret PyIceberg Glue catalog properties."""
+        cfg = self._require_config()
+        catalog_config: dict[str, Any] = {
+            "type": "glue",
+            "glue.region": cfg.region,
+            "glue.skip-archive": str(cfg.skip_archive).lower(),
+        }
+        if cfg.warehouse is not None:
+            catalog_config["warehouse"] = cfg.warehouse
+        if cfg.catalog_id is not None:
+            catalog_config["glue.id"] = cfg.catalog_id
+        if cfg.endpoint_override is not None:
+            catalog_config["glue.endpoint"] = cfg.endpoint_override
+        if cfg.max_retries is not None:
+            catalog_config["glue.max-retries"] = cfg.max_retries
+        if cfg.retry_mode is not None:
+            catalog_config["glue.retry-mode"] = cfg.retry_mode
+        return catalog_config
+
+    def get_storage_requirements(self) -> PluginRequirements:
+        """Return storage requirements Glue can compose with."""
+        cfg = self._require_config()
+        identity_modes: list[IdentityMode] = (
+            ["aws-irsa", "aws-pod-identity"] if cfg.credential_mode == "workload-identity" else []
+        )
+        credential_modes: list[CredentialMode] = [cast(CredentialMode, cfg.credential_mode)]
+        return PluginRequirements(
+            plugin_type="catalog",
+            plugin_name="glue",
+            requirements=RequirementSet(
+                protocols=["s3"],
+                credential_modes=credential_modes,
+                identity_modes=identity_modes,
+                requires_server_side_storage_access=True,
+                supports_no_sts=False,
+                supports_path_style_access=False,
+            ),
+        )
+
+    def build_catalog_deployment(
+        self,
+        storage: StorageDeploymentBinding,
+    ) -> CatalogDeploymentBinding:
+        """Translate neutral AWS S3 storage state into Glue deployment config."""
+        cfg = self._require_config()
+        if storage.protocol != "s3":
+            msg = "AWS Glue catalog requires storage protocol 's3'"
+            raise ValueError(msg)
+        if storage.warehouse is None:
+            msg = "AWS Glue catalog deployment requires storage warehouse binding"
+            raise ValueError(msg)
+        if storage.credentials.mode != cfg.credential_mode:
+            msg = f"AWS Glue catalog requires storage credential mode {cfg.credential_mode!r}"
+            raise ValueError(msg)
+
+        warehouse = cfg.warehouse or storage.warehouse.uri
+        return CatalogDeploymentBinding(
+            provider="glue",
+            glue=GlueCatalogDeploymentBinding(
+                catalog_name="glue",
+                region=cfg.region,
+                warehouse=warehouse,
+                catalog_id=cfg.catalog_id,
+                database_prefix=cfg.database_prefix,
+                endpoint=cfg.endpoint_override,
+                skip_archive=cfg.skip_archive,
+                max_retries=cfg.max_retries,
+                retry_mode=cfg.retry_mode,
+                credential_refs=self._credential_refs(storage),
+            ),
+        )
+
+    def _credential_refs(self, storage: StorageDeploymentBinding) -> dict[str, CredentialRef]:
+        """Return secret-free Glue credential references derived from storage."""
+        cfg = self._require_config()
+        if cfg.credential_mode == "kubernetes-secret":
+            if cfg.credential_secret_name is None:
+                msg = "kubernetes-secret credential_mode requires credential_secret_name"
+                raise ValueError(msg)
+            secret_ref = KubernetesSecretRef(
+                name=cfg.credential_secret_name,
+                namespace=cfg.credential_secret_namespace,
+                keys={
+                    "accessKeyId": cfg.access_key_secret_key,
+                    "secretAccessKey": cfg.secret_key_secret_key,
+                    "sessionToken": cfg.session_token_secret_key,
+                },
+            )
+            return {
+                logical_key: CredentialRef(
+                    source="kubernetes-secret",
+                    name=secret_ref.name,
+                    key=secret_key,
+                )
+                for logical_key, secret_key in secret_ref.keys.items()
+            }
+        return {
+            "accessKeyId": storage.credentials.as_credential_ref("accessKeyId"),
+            "secretAccessKey": storage.credentials.as_credential_ref("secretAccessKey"),
+            "sessionToken": storage.credentials.as_credential_ref("sessionToken"),
+        }
+
+    def _connected_catalog(self) -> Catalog:
+        """Return the connected catalog or raise a catalog availability error."""
+        if self._catalog is None:
+            raise CatalogUnavailableError(
+                "glue",
+                cause=ValueError("Catalog not connected; call connect() first."),
+            )
+        return self._catalog
+
+    def create_namespace(
+        self,
+        namespace: str,
+        properties: dict[str, str] | None = None,
+    ) -> None:
+        """Create a namespace in AWS Glue."""
+        catalog = cast(Any, self._connected_catalog())
+        catalog.create_namespace(namespace, properties=properties or {})
+
+    def list_namespaces(self, parent: str | None = None) -> list[str]:
+        """List namespaces in AWS Glue."""
+        catalog = cast(Any, self._connected_catalog())
+        raw_namespaces = (
+            catalog.list_namespaces(tuple(parent.split(".")))
+            if parent
+            else catalog.list_namespaces()
+        )
+        return [".".join(namespace) for namespace in raw_namespaces]
+
+    def delete_namespace(self, namespace: str) -> None:
+        """Delete a namespace from AWS Glue."""
+        catalog = cast(Any, self._connected_catalog())
+        catalog.drop_namespace(namespace)
+
+    def create_table(
+        self,
+        identifier: str,
+        schema: dict[str, Any],
+        location: str | None = None,
+        properties: dict[str, str] | None = None,
+    ) -> None:
+        """Create an Iceberg table in AWS Glue."""
+        kwargs: dict[str, Any] = {}
+        if location is not None:
+            kwargs["location"] = location
+        if properties is not None:
+            kwargs["properties"] = properties
+        catalog = cast(Any, self._connected_catalog())
+        catalog.create_table(identifier, schema, **kwargs)
+
+    def list_tables(self, namespace: str) -> list[str]:
+        """List tables in an AWS Glue namespace."""
+        raw_tables = self._connected_catalog().list_tables(namespace)
+        return [".".join(table) for table in raw_tables]
+
+    def drop_table(self, identifier: str, purge: bool = False) -> None:
+        """Drop an Iceberg table from AWS Glue."""
+        self._connected_catalog().drop_table(identifier, purge=purge)
+
+    def vend_credentials(
+        self,
+        table_path: str,
+        operations: list[str],
+    ) -> dict[str, Any]:
+        """Reject credential vending; Glue access is handled by AWS identity."""
+        raise NotSupportedError(
+            "vend_credentials",
+            "glue",
+            reason="AWS Glue does not vend credentials; use AWS identity or references.",
+        )

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 TRACER_NAME = "floe.catalog.glue"
+KEY_ACCESS_KEY_ID = "accessKeyId"
+KEY_SECRET_ACCESS_KEY = "secretAccessKey"  # pragma: allowlist secret
+KEY_SESSION_TOKEN = "sessionToken"
 
 
 class _GlueCatalogOps(Protocol):
@@ -110,7 +113,11 @@ class GlueCatalogPlugin(CatalogPlugin):
     def connect(self, config: dict[str, Any]) -> Catalog:
         """Connect to AWS Glue using PyIceberg's Glue catalog."""
         catalog_config = self._pyiceberg_config()
-        conflicts = set(catalog_config) & set(config)
+        conflicts = {
+            key
+            for key, value in config.items()
+            if key in catalog_config and catalog_config[key] != value
+        }
         if conflicts:
             msg = f"connect() config conflicts with plugin config: {sorted(conflicts)}"
             raise ValueError(msg)
@@ -196,14 +203,16 @@ class GlueCatalogPlugin(CatalogPlugin):
         """Return secret-free Glue credential references derived from storage."""
         cfg = self._require_config()
         if cfg.credential_mode == "kubernetes-secret":
-            assert cfg.credential_secret_name is not None
+            if cfg.credential_secret_name is None:
+                msg = "kubernetes-secret mode requires credential_secret_name"
+                raise ValueError(msg)
             secret_ref = KubernetesSecretRef(
                 name=cfg.credential_secret_name,
                 namespace=cfg.credential_secret_namespace,
                 keys={
-                    "accessKeyId": cfg.access_key_secret_key,
-                    "secretAccessKey": cfg.secret_key_secret_key,
-                    "sessionToken": cfg.session_token_secret_key,
+                    KEY_ACCESS_KEY_ID: cfg.access_key_secret_key,
+                    KEY_SECRET_ACCESS_KEY: cfg.secret_key_secret_key,
+                    KEY_SESSION_TOKEN: cfg.session_token_secret_key,
                 },
             )
             return {
@@ -215,9 +224,9 @@ class GlueCatalogPlugin(CatalogPlugin):
                 for logical_key, secret_key in secret_ref.keys.items()
             }
         return {
-            "accessKeyId": storage.credentials.as_credential_ref("accessKeyId"),
-            "secretAccessKey": storage.credentials.as_credential_ref("secretAccessKey"),
-            "sessionToken": storage.credentials.as_credential_ref("sessionToken"),
+            KEY_ACCESS_KEY_ID: storage.credentials.as_credential_ref(KEY_ACCESS_KEY_ID),
+            KEY_SECRET_ACCESS_KEY: storage.credentials.as_credential_ref(KEY_SECRET_ACCESS_KEY),
+            KEY_SESSION_TOKEN: storage.credentials.as_credential_ref(KEY_SESSION_TOKEN),
         }
 
     def _connected_catalog(self) -> _GlueCatalogOps:

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from floe_core.composition.models import (
     CredentialMode,
@@ -28,6 +28,34 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 TRACER_NAME = "floe.catalog.glue"
+
+
+class _GlueCatalogOps(Protocol):
+    """PyIceberg catalog operations used by the Glue plugin."""
+
+    def create_namespace(self, namespace: str, properties: dict[str, str]) -> None:
+        """Create a namespace with properties."""
+        ...
+
+    def list_namespaces(self, namespace: tuple[str, ...] | None = None) -> list[tuple[str, ...]]:
+        """List namespaces, optionally below a parent namespace."""
+        ...
+
+    def drop_namespace(self, namespace: str) -> None:
+        """Drop a namespace."""
+        ...
+
+    def create_table(self, identifier: str, schema: dict[str, Any], **kwargs: Any) -> None:
+        """Create an Iceberg table."""
+        ...
+
+    def list_tables(self, namespace: str) -> list[tuple[str, ...]]:
+        """List tables in a namespace."""
+        ...
+
+    def drop_table(self, identifier: str, purge: bool = False) -> None:
+        """Drop a table."""
+        ...
 
 
 class GlueCatalogPlugin(CatalogPlugin):
@@ -82,6 +110,10 @@ class GlueCatalogPlugin(CatalogPlugin):
     def connect(self, config: dict[str, Any]) -> Catalog:
         """Connect to AWS Glue using PyIceberg's Glue catalog."""
         catalog_config = self._pyiceberg_config()
+        conflicts = set(catalog_config) & set(config)
+        if conflicts:
+            msg = f"connect() config conflicts with plugin config: {sorted(conflicts)}"
+            raise ValueError(msg)
         catalog_config.update(config)
         catalog = cast(Catalog, load_catalog("glue", **catalog_config))
         self._catalog = catalog
@@ -164,9 +196,7 @@ class GlueCatalogPlugin(CatalogPlugin):
         """Return secret-free Glue credential references derived from storage."""
         cfg = self._require_config()
         if cfg.credential_mode == "kubernetes-secret":
-            if cfg.credential_secret_name is None:
-                msg = "kubernetes-secret credential_mode requires credential_secret_name"
-                raise ValueError(msg)
+            assert cfg.credential_secret_name is not None
             secret_ref = KubernetesSecretRef(
                 name=cfg.credential_secret_name,
                 namespace=cfg.credential_secret_namespace,
@@ -190,14 +220,14 @@ class GlueCatalogPlugin(CatalogPlugin):
             "sessionToken": storage.credentials.as_credential_ref("sessionToken"),
         }
 
-    def _connected_catalog(self) -> Catalog:
+    def _connected_catalog(self) -> _GlueCatalogOps:
         """Return the connected catalog or raise a catalog availability error."""
         if self._catalog is None:
             raise CatalogUnavailableError(
                 "glue",
                 cause=ValueError("Catalog not connected; call connect() first."),
             )
-        return self._catalog
+        return cast(_GlueCatalogOps, self._catalog)
 
     def create_namespace(
         self,
@@ -205,12 +235,11 @@ class GlueCatalogPlugin(CatalogPlugin):
         properties: dict[str, str] | None = None,
     ) -> None:
         """Create a namespace in AWS Glue."""
-        catalog = cast(Any, self._connected_catalog())
-        catalog.create_namespace(namespace, properties=properties or {})
+        self._connected_catalog().create_namespace(namespace, properties=properties or {})
 
     def list_namespaces(self, parent: str | None = None) -> list[str]:
         """List namespaces in AWS Glue."""
-        catalog = cast(Any, self._connected_catalog())
+        catalog = self._connected_catalog()
         raw_namespaces = (
             catalog.list_namespaces(tuple(parent.split(".")))
             if parent
@@ -220,8 +249,7 @@ class GlueCatalogPlugin(CatalogPlugin):
 
     def delete_namespace(self, namespace: str) -> None:
         """Delete a namespace from AWS Glue."""
-        catalog = cast(Any, self._connected_catalog())
-        catalog.drop_namespace(namespace)
+        self._connected_catalog().drop_namespace(namespace)
 
     def create_table(
         self,
@@ -236,8 +264,7 @@ class GlueCatalogPlugin(CatalogPlugin):
             kwargs["location"] = location
         if properties is not None:
             kwargs["properties"] = properties
-        catalog = cast(Any, self._connected_catalog())
-        catalog.create_table(identifier, schema, **kwargs)
+        self._connected_catalog().create_table(identifier, schema, **kwargs)
 
     def list_tables(self, namespace: str) -> list[str]:
         """List tables in an AWS Glue namespace."""

--- a/plugins/floe-catalog-glue/tests/conftest.py
+++ b/plugins/floe-catalog-glue/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared pytest configuration for floe-catalog-glue tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_SRC))

--- a/plugins/floe-catalog-glue/tests/conftest.py
+++ b/plugins/floe-catalog-glue/tests/conftest.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+# TODO: Remove once floe-catalog-glue is registered in the root workspace.
+# Package-local pytest already uses pyproject.toml pythonpath=["src"], but
+# root-level CI collection needs this explicit source path while registration
+# is deferred to the provider integration branch.
 PACKAGE_SRC = Path(__file__).resolve().parents[1] / "src"
 if str(PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(PACKAGE_SRC))

--- a/plugins/floe-catalog-glue/tests/unit/test_plugin.py
+++ b/plugins/floe-catalog-glue/tests/unit/test_plugin.py
@@ -1,0 +1,345 @@
+"""Unit tests for the native AWS Glue catalog plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import tomllib
+from floe_core.plugin_errors import CatalogUnavailableError, NotSupportedError
+from floe_core.schemas.compiled_artifacts import (
+    DagsterStorageBinding,
+    DbtStorageBinding,
+    StorageCapabilities,
+    StorageCredentialBinding,
+    StorageDeploymentBinding,
+    StorageProvisioningIntent,
+    StorageRuntimeBinding,
+    StorageServiceEndpoint,
+    StorageWarehouse,
+)
+from pydantic import ValidationError
+
+from floe_catalog_glue.config import GlueCatalogConfig
+from floe_catalog_glue.plugin import GlueCatalogPlugin
+
+
+def _s3_storage_binding(
+    *,
+    credential_mode: str = "workload-identity",
+    protocol: str = "s3",
+) -> StorageDeploymentBinding:
+    if credential_mode == "workload-identity":
+        credentials = StorageCredentialBinding(
+            mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+    elif credential_mode == "environment":
+        credentials = StorageCredentialBinding(
+            mode="environment",
+            env_refs={
+                "accessKeyId": "AWS_ACCESS_KEY_ID",
+                "secretAccessKey": "AWS_SECRET_ACCESS_KEY",  # pragma: allowlist secret
+                "sessionToken": "AWS_SESSION_TOKEN",
+            },
+        )
+    else:
+        credentials = StorageCredentialBinding(mode="none")
+
+    return StorageDeploymentBinding(
+        provider="aws-s3",
+        protocol=protocol,
+        endpoint=StorageServiceEndpoint(
+            internal_url="https://s3.ap-southeast-2.amazonaws.com",
+            external_url="https://s3.ap-southeast-2.amazonaws.com",
+            region="ap-southeast-2",
+            warehouse_path="s3://floe-provider-tests/warehouse/",
+            path_style_access=False,
+        ),
+        warehouse=StorageWarehouse(
+            uri="s3://floe-provider-tests/warehouse/",
+            bucket="floe-provider-tests",
+            prefix="warehouse/",
+        ),
+        allowed_locations=["s3://floe-provider-tests/warehouse/"],
+        credentials=credentials,
+        capabilities=StorageCapabilities(
+            protocols=[protocol],
+            credential_modes=[credential_mode],
+            identity_modes=["aws-irsa", "aws-pod-identity"]
+            if credential_mode == "workload-identity"
+            else [],
+            sts_supported=True,
+            path_style_access=False,
+        ),
+        provisioning=StorageProvisioningIntent(
+            enabled=False,
+            mode="external",
+            default_create_policy="must-exist",
+        ),
+        runtime=StorageRuntimeBinding(pyiceberg_properties={"s3.region": "ap-southeast-2"}),
+        dbt=DbtStorageBinding(
+            profile_name="floe",
+            target_name="dev",
+            schema_name="analytics",
+        ),
+        dagster=DagsterStorageBinding(
+            resource_key="aws_s3_storage",
+            asset_io_manager_key="iceberg_io_manager",
+        ),
+    )
+
+
+class TestPluginMetadata:
+    """Test plugin metadata and config schema."""
+
+    def test_plugin_metadata(self) -> None:
+        plugin = GlueCatalogPlugin()
+
+        assert plugin.name == "glue"
+        assert plugin.version.count(".") == 2
+        assert plugin.floe_api_version == "1.0"
+        assert plugin.description == "AWS Glue catalog plugin for Iceberg table management"
+        assert plugin.tracer_name == "floe.catalog.glue"
+
+    def test_get_config_schema_returns_glue_config(self) -> None:
+        assert GlueCatalogPlugin().get_config_schema() is GlueCatalogConfig
+
+
+class TestGlueCatalogConfig:
+    """Test AWS Glue config validation."""
+
+    def test_workload_identity_config_requires_service_account(self) -> None:
+        with pytest.raises(ValidationError, match="service_account_ref"):
+            GlueCatalogConfig(
+                region="ap-southeast-2",
+                credential_mode="workload-identity",
+            )
+
+    def test_kubernetes_secret_config_requires_secret_name(self) -> None:
+        with pytest.raises(ValidationError, match="credential_secret_name"):
+            GlueCatalogConfig(
+                region="ap-southeast-2",
+                credential_mode="kubernetes-secret",
+            )
+
+    def test_environment_config_rejects_credential_refs(self) -> None:
+        with pytest.raises(ValidationError, match="only accepts environment variable names"):
+            GlueCatalogConfig(
+                region="ap-southeast-2",
+                credential_mode="environment",
+                service_account_ref="floe-provider-tests",
+            )
+
+    def test_catalog_id_must_be_aws_account_id(self) -> None:
+        with pytest.raises(ValidationError, match="catalog_id"):
+            GlueCatalogConfig(
+                region="ap-southeast-2",
+                catalog_id="not-an-account",
+                credential_mode="environment",
+            )
+
+    def test_endpoint_override_must_be_http_url(self) -> None:
+        with pytest.raises(ValidationError, match="endpoint_override"):
+            GlueCatalogConfig(
+                region="ap-southeast-2",
+                endpoint_override="glue.ap-southeast-2.amazonaws.com",
+                credential_mode="environment",
+            )
+
+    def test_config_defaults_are_native_aws(self) -> None:
+        config = GlueCatalogConfig(
+            region="ap-southeast-2",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+
+        assert config.warehouse is None
+        assert config.database_prefix is None
+        assert config.skip_archive is True
+        assert config.max_retries is None
+        assert config.retry_mode is None
+
+
+class TestStorageComposition:
+    """Test Glue composition contracts."""
+
+    def test_storage_requirements_for_workload_identity(self) -> None:
+        config = GlueCatalogConfig(
+            region="ap-southeast-2",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+        )
+        requirements = GlueCatalogPlugin(config=config).get_storage_requirements()
+
+        assert requirements.plugin_type == "catalog"
+        assert requirements.plugin_name == "glue"
+        assert requirements.requirements.protocols == ["s3"]
+        assert requirements.requirements.credential_modes == ["workload-identity"]
+        assert requirements.requirements.identity_modes == ["aws-irsa", "aws-pod-identity"]
+        assert requirements.requirements.requires_server_side_storage_access is True
+        assert requirements.requirements.supports_no_sts is False
+        assert requirements.requirements.supports_path_style_access is False
+
+    def test_build_catalog_deployment_uses_storage_warehouse_by_default(self) -> None:
+        config = GlueCatalogConfig(
+            region="ap-southeast-2",
+            catalog_id="278833447053",
+            database_prefix="floe_provider_",
+            credential_mode="workload-identity",
+            service_account_ref="floe-provider-tests",
+            skip_archive=True,
+            max_retries=5,
+            retry_mode="standard",
+        )
+        binding = GlueCatalogPlugin(config=config).build_catalog_deployment(_s3_storage_binding())
+
+        assert binding.provider == "glue"
+        assert binding.glue is not None
+        assert binding.glue.catalog_name == "glue"
+        assert binding.glue.region == "ap-southeast-2"
+        assert binding.glue.warehouse == "s3://floe-provider-tests/warehouse/"
+        assert binding.glue.catalog_id == "278833447053"
+        assert binding.glue.database_prefix == "floe_provider_"
+        assert binding.glue.skip_archive is True
+        assert binding.glue.max_retries == 5
+        assert binding.glue.retry_mode == "standard"
+        assert binding.glue.credential_refs["accessKeyId"].source == "workload-identity"
+        assert binding.glue.credential_refs["accessKeyId"].name == "floe-provider-tests"
+        assert binding.glue.properties == {}
+        assert binding.iceberg_rest is None
+        assert binding.dbt is None
+        assert "AWS_SECRET_ACCESS_KEY" not in binding.model_dump_json()
+        assert "raw-secret-value" not in binding.model_dump_json()
+
+    def test_build_catalog_deployment_honors_warehouse_override(self) -> None:
+        config = GlueCatalogConfig(
+            region="ap-southeast-2",
+            warehouse="s3://custom-warehouse/prefix/",
+            credential_mode="environment",
+        )
+        binding = GlueCatalogPlugin(config=config).build_catalog_deployment(
+            _s3_storage_binding(credential_mode="environment")
+        )
+
+        assert binding.glue is not None
+        assert binding.glue.warehouse == "s3://custom-warehouse/prefix/"
+        assert binding.glue.credential_refs["secretAccessKey"].source == "environment"
+        assert binding.glue.credential_refs["secretAccessKey"].name == "AWS_SECRET_ACCESS_KEY"
+
+    def test_build_catalog_deployment_rejects_non_s3_storage(self) -> None:
+        config = GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        plugin = GlueCatalogPlugin(config=config)
+
+        with pytest.raises(ValueError, match="requires storage protocol 's3'"):
+            plugin.build_catalog_deployment(_s3_storage_binding(protocol="s3-compatible"))
+
+    def test_build_catalog_deployment_rejects_incompatible_credential_mode(self) -> None:
+        config = GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        plugin = GlueCatalogPlugin(config=config)
+
+        with pytest.raises(ValueError, match="requires storage credential mode"):
+            plugin.build_catalog_deployment(_s3_storage_binding(credential_mode="none"))
+
+
+class TestPyIcebergConnection:
+    """Test PyIceberg Glue connection delegation."""
+
+    def test_connect_builds_glue_catalog_config_without_aws_call(self) -> None:
+        config = GlueCatalogConfig(
+            region="ap-southeast-2",
+            warehouse="s3://floe-provider-tests/warehouse/",
+            catalog_id="278833447053",
+            endpoint_override="https://glue.ap-southeast-2.amazonaws.com",
+            credential_mode="environment",
+            skip_archive=False,
+            max_retries=5,
+            retry_mode="standard",
+        )
+        plugin = GlueCatalogPlugin(config=config)
+        catalog = Mock()
+
+        with patch("floe_catalog_glue.plugin.load_catalog", return_value=catalog) as load_catalog:
+            assert plugin.connect({"client.region": "ap-southeast-2"}) is catalog
+
+        load_catalog.assert_called_once_with(
+            "glue",
+            type="glue",
+            warehouse="s3://floe-provider-tests/warehouse/",
+            **{
+                "client.region": "ap-southeast-2",
+                "glue.region": "ap-southeast-2",
+                "glue.id": "278833447053",
+                "glue.endpoint": "https://glue.ap-southeast-2.amazonaws.com",
+                "glue.skip-archive": "false",
+                "glue.max-retries": 5,
+                "glue.retry-mode": "standard",
+            },
+        )
+
+
+class TestCatalogOperations:
+    """Test required CatalogPlugin operations delegate to PyIceberg."""
+
+    @pytest.fixture()
+    def plugin_with_catalog(self) -> GlueCatalogPlugin:
+        plugin = GlueCatalogPlugin(
+            config=GlueCatalogConfig(
+                region="ap-southeast-2",
+                warehouse="s3://floe-provider-tests/warehouse/",
+                credential_mode="environment",
+            )
+        )
+        catalog = Mock()
+        catalog.list_namespaces.return_value = [("bronze",), ("silver", "sales")]
+        catalog.list_tables.return_value = [("bronze", "customers")]
+        plugin._catalog = catalog
+        return plugin
+
+    def test_namespace_and_table_methods_delegate_to_catalog(
+        self, plugin_with_catalog: GlueCatalogPlugin
+    ) -> None:
+        plugin_with_catalog.create_namespace("bronze", {"owner": "data"})
+        assert plugin_with_catalog.list_namespaces() == ["bronze", "silver.sales"]
+        assert plugin_with_catalog.list_tables("bronze") == ["bronze.customers"]
+        plugin_with_catalog.create_table("bronze.customers", {"type": "struct"})
+        plugin_with_catalog.drop_table("bronze.customers", purge=True)
+        plugin_with_catalog.delete_namespace("bronze")
+
+        catalog = plugin_with_catalog._catalog
+        catalog.create_namespace.assert_called_once_with("bronze", properties={"owner": "data"})
+        catalog.list_namespaces.assert_called_once_with()
+        catalog.list_tables.assert_called_once_with("bronze")
+        catalog.create_table.assert_called_once_with("bronze.customers", {"type": "struct"})
+        catalog.drop_table.assert_called_once_with("bronze.customers", purge=True)
+        catalog.drop_namespace.assert_called_once_with("bronze")
+
+    def test_catalog_methods_raise_when_not_connected(self) -> None:
+        plugin = GlueCatalogPlugin(
+            config=GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        )
+
+        with pytest.raises(CatalogUnavailableError, match="call connect"):
+            plugin.list_namespaces()
+
+    def test_vend_credentials_not_supported(self) -> None:
+        plugin = GlueCatalogPlugin(
+            config=GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        )
+
+        with pytest.raises(NotSupportedError, match="does not vend credentials"):
+            plugin.vend_credentials("bronze.customers", ["READ"])
+
+
+class TestPackageMetadata:
+    """Test package metadata without requiring workspace registration."""
+
+    def test_pyproject_declares_floe_catalog_entry_point(self) -> None:
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+        assert pyproject["project"]["name"] == "floe-catalog-glue"
+        assert pyproject["project"]["entry-points"]["floe.catalogs"] == {
+            "glue": "floe_catalog_glue.plugin:GlueCatalogPlugin"
+        }

--- a/plugins/floe-catalog-glue/tests/unit/test_plugin.py
+++ b/plugins/floe-catalog-glue/tests/unit/test_plugin.py
@@ -405,12 +405,49 @@ class TestPyIcebergConnection:
         with pytest.raises(ValueError, match="connect\\(\\) config conflicts"):
             plugin.connect({"type": "rest"})
 
+    @pytest.mark.requirement("CATALOG-GLUE-026")
+    def test_connect_accepts_matching_deployment_derived_config(self) -> None:
+        """connect accepts resolved deployment config when duplicate keys match plugin config."""
+        plugin = GlueCatalogPlugin(
+            config=GlueCatalogConfig(
+                region=TEST_REGION,
+                warehouse=TEST_WAREHOUSE_URI,
+                credential_mode="environment",
+            )
+        )
+        catalog = Mock()
+
+        with patch("floe_catalog_glue.plugin.load_catalog", return_value=catalog) as load_catalog:
+            assert (
+                plugin.connect(
+                    {
+                        "type": "glue",
+                        "glue.region": TEST_REGION,
+                        "warehouse": TEST_WAREHOUSE_URI,
+                        "s3.region": TEST_REGION,
+                    }
+                )
+                is catalog
+            )
+
+        load_catalog.assert_called_once_with(
+            "glue",
+            type="glue",
+            warehouse=TEST_WAREHOUSE_URI,
+            **{
+                "glue.region": TEST_REGION,
+                "glue.skip-archive": "true",
+                "s3.region": TEST_REGION,
+            },
+        )
+
 
 class TestCatalogOperations:
     """Test required CatalogPlugin operations delegate to PyIceberg."""
 
     @pytest.fixture()
     def plugin_with_catalog(self) -> GlueCatalogPlugin:
+        """Return a GlueCatalogPlugin with a mocked PyIceberg catalog attached."""
         plugin = GlueCatalogPlugin(
             config=GlueCatalogConfig(
                 region=TEST_REGION,

--- a/plugins/floe-catalog-glue/tests/unit/test_plugin.py
+++ b/plugins/floe-catalog-glue/tests/unit/test_plugin.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-import tomllib
 from floe_core.plugin_errors import CatalogUnavailableError, NotSupportedError
 from floe_core.schemas.compiled_artifacts import (
     DagsterStorageBinding,
@@ -21,8 +21,21 @@ from floe_core.schemas.compiled_artifacts import (
 )
 from pydantic import ValidationError
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 from floe_catalog_glue.config import GlueCatalogConfig
 from floe_catalog_glue.plugin import GlueCatalogPlugin
+
+TEST_REGION = "ap-southeast-2"
+TEST_BUCKET = "floe-provider-tests"
+TEST_SERVICE_ACCOUNT = "floe-provider-tests"
+TEST_ACCOUNT_ID = "278833447053"
+TEST_WAREHOUSE_URI = f"s3://{TEST_BUCKET}/warehouse/"
+TEST_S3_ENDPOINT = f"https://s3.{TEST_REGION}.amazonaws.com"
+TEST_GLUE_ENDPOINT = f"https://glue.{TEST_REGION}.amazonaws.com"
 
 
 def _s3_storage_binding(
@@ -33,7 +46,7 @@ def _s3_storage_binding(
     if credential_mode == "workload-identity":
         credentials = StorageCredentialBinding(
             mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
     elif credential_mode == "environment":
         credentials = StorageCredentialBinding(
@@ -44,6 +57,21 @@ def _s3_storage_binding(
                 "sessionToken": "AWS_SESSION_TOKEN",
             },
         )
+    elif credential_mode == "kubernetes-secret":
+        from floe_core.schemas.compiled_artifacts import KubernetesSecretRef
+
+        credentials = StorageCredentialBinding(
+            mode="kubernetes-secret",
+            secret_ref=KubernetesSecretRef(
+                name="aws-glue-creds",  # pragma: allowlist secret
+                namespace="data-platform",  # pragma: allowlist secret
+                keys={
+                    "accessKeyId": "accessKeyId",
+                    "secretAccessKey": "secretAccessKey",  # pragma: allowlist secret
+                    "sessionToken": "sessionToken",
+                },
+            ),
+        )
     else:
         credentials = StorageCredentialBinding(mode="none")
 
@@ -51,18 +79,18 @@ def _s3_storage_binding(
         provider="aws-s3",
         protocol=protocol,
         endpoint=StorageServiceEndpoint(
-            internal_url="https://s3.ap-southeast-2.amazonaws.com",
-            external_url="https://s3.ap-southeast-2.amazonaws.com",
-            region="ap-southeast-2",
-            warehouse_path="s3://floe-provider-tests/warehouse/",
+            internal_url=TEST_S3_ENDPOINT,
+            external_url=TEST_S3_ENDPOINT,
+            region=TEST_REGION,
+            warehouse_path=TEST_WAREHOUSE_URI,
             path_style_access=False,
         ),
         warehouse=StorageWarehouse(
-            uri="s3://floe-provider-tests/warehouse/",
-            bucket="floe-provider-tests",
+            uri=TEST_WAREHOUSE_URI,
+            bucket=TEST_BUCKET,
             prefix="warehouse/",
         ),
-        allowed_locations=["s3://floe-provider-tests/warehouse/"],
+        allowed_locations=[TEST_WAREHOUSE_URI],
         credentials=credentials,
         capabilities=StorageCapabilities(
             protocols=[protocol],
@@ -78,7 +106,7 @@ def _s3_storage_binding(
             mode="external",
             default_create_policy="must-exist",
         ),
-        runtime=StorageRuntimeBinding(pyiceberg_properties={"s3.region": "ap-southeast-2"}),
+        runtime=StorageRuntimeBinding(pyiceberg_properties={"s3.region": TEST_REGION}),
         dbt=DbtStorageBinding(
             profile_name="floe",
             target_name="dev",
@@ -94,7 +122,9 @@ def _s3_storage_binding(
 class TestPluginMetadata:
     """Test plugin metadata and config schema."""
 
+    @pytest.mark.requirement("CATALOG-GLUE-001")
     def test_plugin_metadata(self) -> None:
+        """Plugin metadata exposes the stable glue identity and tracer name."""
         plugin = GlueCatalogPlugin()
 
         assert plugin.name == "glue"
@@ -103,56 +133,111 @@ class TestPluginMetadata:
         assert plugin.description == "AWS Glue catalog plugin for Iceberg table management"
         assert plugin.tracer_name == "floe.catalog.glue"
 
+    @pytest.mark.requirement("CATALOG-GLUE-002")
     def test_get_config_schema_returns_glue_config(self) -> None:
+        """Plugin config schema points consumers at the Glue config model."""
         assert GlueCatalogPlugin().get_config_schema() is GlueCatalogConfig
 
 
 class TestGlueCatalogConfig:
     """Test AWS Glue config validation."""
 
+    @pytest.mark.requirement("CATALOG-GLUE-003")
     def test_workload_identity_config_requires_service_account(self) -> None:
+        """Workload-identity mode rejects config without a service account ref."""
         with pytest.raises(ValidationError, match="service_account_ref"):
             GlueCatalogConfig(
-                region="ap-southeast-2",
+                region=TEST_REGION,
                 credential_mode="workload-identity",
             )
 
+    @pytest.mark.requirement("CATALOG-GLUE-004")
     def test_kubernetes_secret_config_requires_secret_name(self) -> None:
+        """Kubernetes-secret mode rejects config without a Secret reference."""
         with pytest.raises(ValidationError, match="credential_secret_name"):
             GlueCatalogConfig(
-                region="ap-southeast-2",
+                region=TEST_REGION,
                 credential_mode="kubernetes-secret",
             )
 
+    @pytest.mark.requirement("CATALOG-GLUE-005")
     def test_environment_config_rejects_credential_refs(self) -> None:
+        """Environment mode rejects identity references to keep credential modes exclusive."""
         with pytest.raises(ValidationError, match="only accepts environment variable names"):
             GlueCatalogConfig(
-                region="ap-southeast-2",
+                region=TEST_REGION,
                 credential_mode="environment",
-                service_account_ref="floe-provider-tests",
+                service_account_ref=TEST_SERVICE_ACCOUNT,
             )
 
+    @pytest.mark.requirement("CATALOG-GLUE-006")
     def test_catalog_id_must_be_aws_account_id(self) -> None:
+        """Catalog IDs must use the AWS 12-digit account ID shape."""
         with pytest.raises(ValidationError, match="catalog_id"):
             GlueCatalogConfig(
-                region="ap-southeast-2",
+                region=TEST_REGION,
                 catalog_id="not-an-account",
                 credential_mode="environment",
             )
 
+    @pytest.mark.requirement("CATALOG-GLUE-007")
     def test_endpoint_override_must_be_http_url(self) -> None:
+        """Glue endpoint overrides must be explicit HTTP URLs."""
         with pytest.raises(ValidationError, match="endpoint_override"):
             GlueCatalogConfig(
-                region="ap-southeast-2",
+                region=TEST_REGION,
                 endpoint_override="glue.ap-southeast-2.amazonaws.com",
                 credential_mode="environment",
             )
 
-    def test_config_defaults_are_native_aws(self) -> None:
+    @pytest.mark.requirement("CATALOG-GLUE-008")
+    def test_config_rejects_raw_aws_credentials(self) -> None:
+        """Raw AWS credential fields are rejected to prevent secret embedding."""
+        with pytest.raises(ValidationError, match="raw AWS credential fields"):
+            GlueCatalogConfig(
+                region=TEST_REGION,
+                credential_mode="environment",
+                access_key_id="AKIAIOSFODNN7EXAMPLE",  # type: ignore[call-arg] # pragma: allowlist secret
+            )
+
+    @pytest.mark.requirement("CATALOG-GLUE-009")
+    def test_config_rejects_raw_secret_access_key(self) -> None:
+        """Raw secret_access_key fields are rejected before config construction."""
+        with pytest.raises(ValidationError, match="raw AWS credential fields"):
+            GlueCatalogConfig(
+                region=TEST_REGION,
+                credential_mode="environment",
+                secret_access_key="raw-secret-value",  # type: ignore[call-arg] # pragma: allowlist secret
+            )
+
+    @pytest.mark.requirement("CATALOG-GLUE-010")
+    def test_warehouse_must_be_s3_uri(self) -> None:
+        """Warehouse overrides must use s3:// because Glue composes with AWS S3."""
+        with pytest.raises(ValidationError, match="s3://"):
+            GlueCatalogConfig(
+                region=TEST_REGION,
+                warehouse="gs://bucket/path/",
+                credential_mode="environment",
+            )
+
+    @pytest.mark.requirement("CATALOG-GLUE-011")
+    def test_warehouse_gets_trailing_slash(self) -> None:
+        """Warehouse overrides are normalized to slash-terminated S3 URIs."""
         config = GlueCatalogConfig(
-            region="ap-southeast-2",
+            region=TEST_REGION,
+            warehouse="s3://bucket/path",
+            credential_mode="environment",
+        )
+
+        assert config.warehouse == "s3://bucket/path/"
+
+    @pytest.mark.requirement("CATALOG-GLUE-012")
+    def test_config_defaults_are_native_aws(self) -> None:
+        """Default Glue config uses AWS-native behavior and no warehouse override."""
+        config = GlueCatalogConfig(
+            region=TEST_REGION,
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
 
         assert config.warehouse is None
@@ -165,11 +250,13 @@ class TestGlueCatalogConfig:
 class TestStorageComposition:
     """Test Glue composition contracts."""
 
+    @pytest.mark.requirement("CATALOG-GLUE-013")
     def test_storage_requirements_for_workload_identity(self) -> None:
+        """Glue requires native S3 and compatible workload identity modes."""
         config = GlueCatalogConfig(
-            region="ap-southeast-2",
+            region=TEST_REGION,
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
         )
         requirements = GlueCatalogPlugin(config=config).get_storage_requirements()
 
@@ -182,13 +269,15 @@ class TestStorageComposition:
         assert requirements.requirements.supports_no_sts is False
         assert requirements.requirements.supports_path_style_access is False
 
+    @pytest.mark.requirement("CATALOG-GLUE-014")
     def test_build_catalog_deployment_uses_storage_warehouse_by_default(self) -> None:
+        """Glue deployment binding derives warehouse and credentials from storage."""
         config = GlueCatalogConfig(
-            region="ap-southeast-2",
-            catalog_id="278833447053",
+            region=TEST_REGION,
+            catalog_id=TEST_ACCOUNT_ID,
             database_prefix="floe_provider_",
             credential_mode="workload-identity",
-            service_account_ref="floe-provider-tests",
+            service_account_ref=TEST_SERVICE_ACCOUNT,
             skip_archive=True,
             max_retries=5,
             retry_mode="standard",
@@ -198,24 +287,26 @@ class TestStorageComposition:
         assert binding.provider == "glue"
         assert binding.glue is not None
         assert binding.glue.catalog_name == "glue"
-        assert binding.glue.region == "ap-southeast-2"
-        assert binding.glue.warehouse == "s3://floe-provider-tests/warehouse/"
-        assert binding.glue.catalog_id == "278833447053"
+        assert binding.glue.region == TEST_REGION
+        assert binding.glue.warehouse == TEST_WAREHOUSE_URI
+        assert binding.glue.catalog_id == TEST_ACCOUNT_ID
         assert binding.glue.database_prefix == "floe_provider_"
         assert binding.glue.skip_archive is True
         assert binding.glue.max_retries == 5
         assert binding.glue.retry_mode == "standard"
         assert binding.glue.credential_refs["accessKeyId"].source == "workload-identity"
-        assert binding.glue.credential_refs["accessKeyId"].name == "floe-provider-tests"
+        assert binding.glue.credential_refs["accessKeyId"].name == TEST_SERVICE_ACCOUNT
         assert binding.glue.properties == {}
         assert binding.iceberg_rest is None
         assert binding.dbt is None
         assert "AWS_SECRET_ACCESS_KEY" not in binding.model_dump_json()
         assert "raw-secret-value" not in binding.model_dump_json()
 
+    @pytest.mark.requirement("CATALOG-GLUE-015")
     def test_build_catalog_deployment_honors_warehouse_override(self) -> None:
+        """Glue warehouse overrides replace the composed storage warehouse URI."""
         config = GlueCatalogConfig(
-            region="ap-southeast-2",
+            region=TEST_REGION,
             warehouse="s3://custom-warehouse/prefix/",
             credential_mode="environment",
         )
@@ -228,15 +319,39 @@ class TestStorageComposition:
         assert binding.glue.credential_refs["secretAccessKey"].source == "environment"
         assert binding.glue.credential_refs["secretAccessKey"].name == "AWS_SECRET_ACCESS_KEY"
 
+    @pytest.mark.requirement("CATALOG-GLUE-016")
+    def test_build_catalog_deployment_with_kubernetes_secret(self) -> None:
+        """Kubernetes-secret mode maps configured Secret keys into CredentialRefs."""
+        config = GlueCatalogConfig(
+            region=TEST_REGION,
+            credential_mode="kubernetes-secret",
+            credential_secret_name="aws-glue-creds",  # pragma: allowlist secret
+            credential_secret_namespace="data-platform",  # pragma: allowlist secret
+        )
+        binding = GlueCatalogPlugin(config=config).build_catalog_deployment(
+            _s3_storage_binding(credential_mode="kubernetes-secret")
+        )
+
+        assert binding.glue is not None
+        assert binding.glue.credential_refs["accessKeyId"].source == "kubernetes-secret"
+        assert binding.glue.credential_refs["accessKeyId"].name == "aws-glue-creds"
+        assert binding.glue.credential_refs["accessKeyId"].key == "accessKeyId"
+        assert binding.glue.credential_refs["secretAccessKey"].key == "secretAccessKey"
+        assert binding.glue.credential_refs["sessionToken"].key == "sessionToken"
+
+    @pytest.mark.requirement("CATALOG-GLUE-017")
     def test_build_catalog_deployment_rejects_non_s3_storage(self) -> None:
-        config = GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        """Glue rejects S3-compatible storage because live AWS Glue requires native S3."""
+        config = GlueCatalogConfig(region=TEST_REGION, credential_mode="environment")
         plugin = GlueCatalogPlugin(config=config)
 
         with pytest.raises(ValueError, match="requires storage protocol 's3'"):
             plugin.build_catalog_deployment(_s3_storage_binding(protocol="s3-compatible"))
 
+    @pytest.mark.requirement("CATALOG-GLUE-018")
     def test_build_catalog_deployment_rejects_incompatible_credential_mode(self) -> None:
-        config = GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+        """Glue rejects storage bindings whose credential mode cannot satisfy Glue."""
+        config = GlueCatalogConfig(region=TEST_REGION, credential_mode="environment")
         plugin = GlueCatalogPlugin(config=config)
 
         with pytest.raises(ValueError, match="requires storage credential mode"):
@@ -246,12 +361,14 @@ class TestStorageComposition:
 class TestPyIcebergConnection:
     """Test PyIceberg Glue connection delegation."""
 
+    @pytest.mark.requirement("CATALOG-GLUE-019")
     def test_connect_builds_glue_catalog_config_without_aws_call(self) -> None:
+        """connect builds PyIceberg Glue config without contacting AWS in tests."""
         config = GlueCatalogConfig(
-            region="ap-southeast-2",
-            warehouse="s3://floe-provider-tests/warehouse/",
-            catalog_id="278833447053",
-            endpoint_override="https://glue.ap-southeast-2.amazonaws.com",
+            region=TEST_REGION,
+            warehouse=TEST_WAREHOUSE_URI,
+            catalog_id=TEST_ACCOUNT_ID,
+            endpoint_override=TEST_GLUE_ENDPOINT,
             credential_mode="environment",
             skip_archive=False,
             max_retries=5,
@@ -261,22 +378,32 @@ class TestPyIcebergConnection:
         catalog = Mock()
 
         with patch("floe_catalog_glue.plugin.load_catalog", return_value=catalog) as load_catalog:
-            assert plugin.connect({"client.region": "ap-southeast-2"}) is catalog
+            assert plugin.connect({"client.region": TEST_REGION}) is catalog
 
         load_catalog.assert_called_once_with(
             "glue",
             type="glue",
-            warehouse="s3://floe-provider-tests/warehouse/",
+            warehouse=TEST_WAREHOUSE_URI,
             **{
-                "client.region": "ap-southeast-2",
-                "glue.region": "ap-southeast-2",
-                "glue.id": "278833447053",
-                "glue.endpoint": "https://glue.ap-southeast-2.amazonaws.com",
+                "client.region": TEST_REGION,
+                "glue.region": TEST_REGION,
+                "glue.id": TEST_ACCOUNT_ID,
+                "glue.endpoint": TEST_GLUE_ENDPOINT,
                 "glue.skip-archive": "false",
                 "glue.max-retries": 5,
                 "glue.retry-mode": "standard",
             },
         )
+
+    @pytest.mark.requirement("CATALOG-GLUE-020")
+    def test_connect_rejects_conflicting_runtime_overrides(self) -> None:
+        """connect rejects overrides for plugin-owned keys so callers cannot change Glue type."""
+        plugin = GlueCatalogPlugin(
+            config=GlueCatalogConfig(region=TEST_REGION, credential_mode="environment")
+        )
+
+        with pytest.raises(ValueError, match="connect\\(\\) config conflicts"):
+            plugin.connect({"type": "rest"})
 
 
 class TestCatalogOperations:
@@ -286,8 +413,8 @@ class TestCatalogOperations:
     def plugin_with_catalog(self) -> GlueCatalogPlugin:
         plugin = GlueCatalogPlugin(
             config=GlueCatalogConfig(
-                region="ap-southeast-2",
-                warehouse="s3://floe-provider-tests/warehouse/",
+                region=TEST_REGION,
+                warehouse=TEST_WAREHOUSE_URI,
                 credential_mode="environment",
             )
         )
@@ -297,9 +424,11 @@ class TestCatalogOperations:
         plugin._catalog = catalog
         return plugin
 
+    @pytest.mark.requirement("CATALOG-GLUE-021")
     def test_namespace_and_table_methods_delegate_to_catalog(
         self, plugin_with_catalog: GlueCatalogPlugin
     ) -> None:
+        """Namespace and table methods delegate to the connected PyIceberg catalog."""
         plugin_with_catalog.create_namespace("bronze", {"owner": "data"})
         assert plugin_with_catalog.list_namespaces() == ["bronze", "silver.sales"]
         assert plugin_with_catalog.list_tables("bronze") == ["bronze.customers"]
@@ -315,17 +444,34 @@ class TestCatalogOperations:
         catalog.drop_table.assert_called_once_with("bronze.customers", purge=True)
         catalog.drop_namespace.assert_called_once_with("bronze")
 
+    @pytest.mark.requirement("CATALOG-GLUE-022")
+    def test_list_namespaces_with_parent_delegates_parent_tuple(
+        self, plugin_with_catalog: GlueCatalogPlugin
+    ) -> None:
+        """Parent namespace listing converts dotted parent names to PyIceberg tuples."""
+        assert plugin_with_catalog.list_namespaces(parent="silver.sales") == [
+            "bronze",
+            "silver.sales",
+        ]
+
+        catalog = plugin_with_catalog._catalog
+        catalog.list_namespaces.assert_called_once_with(("silver", "sales"))
+
+    @pytest.mark.requirement("CATALOG-GLUE-023")
     def test_catalog_methods_raise_when_not_connected(self) -> None:
+        """Catalog operations require connect before delegating to PyIceberg."""
         plugin = GlueCatalogPlugin(
-            config=GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+            config=GlueCatalogConfig(region=TEST_REGION, credential_mode="environment")
         )
 
         with pytest.raises(CatalogUnavailableError, match="call connect"):
             plugin.list_namespaces()
 
+    @pytest.mark.requirement("CATALOG-GLUE-024")
     def test_vend_credentials_not_supported(self) -> None:
+        """Glue rejects credential vending because AWS identity supplies credentials."""
         plugin = GlueCatalogPlugin(
-            config=GlueCatalogConfig(region="ap-southeast-2", credential_mode="environment")
+            config=GlueCatalogConfig(region=TEST_REGION, credential_mode="environment")
         )
 
         with pytest.raises(NotSupportedError, match="does not vend credentials"):
@@ -335,7 +481,9 @@ class TestCatalogOperations:
 class TestPackageMetadata:
     """Test package metadata without requiring workspace registration."""
 
+    @pytest.mark.requirement("CATALOG-GLUE-025")
     def test_pyproject_declares_floe_catalog_entry_point(self) -> None:
+        """Package metadata declares the glue catalog plugin entry point."""
         pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
         pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary

Adds the native AWS Glue catalog plugin package as an isolated provider-plugin slice.

This introduces `plugins/floe-catalog-glue` with:
- secret-free AWS Glue catalog configuration
- `glue` entry point for `floe.catalogs`
- storage composition requirements for native AWS S3
- `CatalogDeploymentBinding` emission using the merged typed Glue binding
- support for environment, workload identity, and Kubernetes Secret credential reference modes
- PyIceberg Glue catalog delegation without embedding AWS credential values
- package-local tests that can run both package-scoped and under root pytest collection

The branch intentionally does not register the package in root workspace metadata. That belongs in the later integration/live-validation branch after S3 and Glue plugin PRs land.

## Validation

- `uv run pytest plugins/floe-catalog-glue/tests/unit/test_plugin.py -q`
- `uv run pytest packages/floe-core/tests/unit/test_runtime_catalog_connection.py packages/floe-iceberg/tests/unit/test_runtime_catalog.py -q`
- `PYTHONPATH=plugins/floe-catalog-glue/src:packages/floe-core/src uv run ruff check plugins/floe-catalog-glue`
- `PYTHONPATH=plugins/floe-catalog-glue/src:packages/floe-core/src uv run mypy plugins/floe-catalog-glue/src/floe_catalog_glue`
- normal pre-push hooks passed: ruff, ruff format, mypy, dbt version requirements, bandit, uv-secure, unit tests, contract tests, no hardcoded sleep, requirement traceability, docs content validation, helm lint

Note: the first Glue push attempt hit an empty local Helm cache index for `floe-minio`; refreshing the cache resolved it, and the final normal pre-push hook run passed.
