### PR TITLE
[codex] Harden provider validation lanes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,10 +7,14 @@
 # Python environments and caches
 .venv/
 __pycache__/
+**/__pycache__/
 *.pyc
 .mypy_cache/
+**/.mypy_cache/
 .pytest_cache/
+**/.pytest_cache/
 .ruff_cache/
+**/.ruff_cache/
 
 # IDE and editor
 .vscode/
@@ -19,6 +23,12 @@ __pycache__/
 # Project tooling (not needed in images)
 .specwright/
 .claude/
+
+# Local IaC state and provider caches (never needed in Docker build contexts)
+**/.terraform/
+**/*.tfstate*
+**/tfplan
+**/terraform.tfvars
 
 # Node (if any)
 node_modules/

--- a/charts/floe-platform/templates/tests/_test-job.tpl
+++ b/charts/floe-platform/templates/tests/_test-job.tpl
@@ -25,9 +25,8 @@ Fields:
                     `test-type` label, and the OTel service name suffix.
                     Use "e2e" for the non-destructive runner,
                     "e2e-destructive" for the destructive runner.
-  pytestMarker    — Value for `pytest -m`. Use "not destructive" to
-                    exclude destructive tests; "destructive" to include
-                    only destructive tests.
+  pytestMarker    — Legacy marker label for callers that have not yet moved
+                    to tests.pytestArgs.
   serviceAccount  — Rendered ServiceAccount name. Callers resolve the
                     helper themselves so the template can stay agnostic
                     about which SA a given suite uses.
@@ -85,6 +84,11 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
           args:
+            {{- if $context.Values.tests.pytestArgs }}
+            {{- range $arg := $context.Values.tests.pytestArgs }}
+            - {{ $arg | quote }}
+            {{- end }}
+            {{- else }}
             - "--tb=short"
             - "-v"
             - "--color=yes"
@@ -97,6 +101,7 @@ spec:
             - "--json-report"
             - "--json-report-file=/artifacts/{{ $artifactPrefix }}-report.json"
             - "--log-cli-level=INFO"
+            {{- end }}
           env:
             - name: INTEGRATION_TEST_HOST
               value: "k8s"

--- a/charts/floe-platform/values-demo.yaml
+++ b/charts/floe-platform/values-demo.yaml
@@ -64,10 +64,10 @@ dagster:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 768Mi
       limits:
         cpu: "1"
-        memory: 1536Mi
+        memory: 2Gi
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "http://floe-platform-otel:4317"
@@ -87,10 +87,10 @@ dagster:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 768Mi
       limits:
         cpu: "1"
-        memory: 1536Mi
+        memory: 2Gi
     # Demo scheduling: 10-minute intervals
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -262,12 +262,12 @@ postgresql:
   enabled: true
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 250m
+      memory: 512Mi
       ephemeral-storage: 256Mi
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 1000m
+      memory: 1Gi
       ephemeral-storage: 1Gi
   persistence:
     enabled: true

--- a/charts/floe-platform/values-test.yaml
+++ b/charts/floe-platform/values-test.yaml
@@ -97,10 +97,10 @@ dagster:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 768Mi
       limits:
         cpu: "1"
-        memory: 1536Mi
+        memory: 2Gi
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "http://floe-platform-otel:4317"
@@ -117,10 +117,10 @@ dagster:
     resources:
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 768Mi
       limits:
         cpu: "1"
-        memory: 1536Mi
+        memory: 2Gi
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: "http://floe-platform-otel:4317"
@@ -318,11 +318,11 @@ postgresql:
           GRANT ALL PRIVILEGES ON DATABASE polaris TO floe;
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
+        cpu: 250m
         memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
 
 # =============================================================================
 # MinIO Configuration (Object Storage)
@@ -527,6 +527,7 @@ tests:
     pvcName: test-artifacts
     storageSize: 1Gi
     storageClass: ""
+  pytestArgs: []
   resources:
     requests:
       cpu: 500m

--- a/charts/floe-platform/values.yaml
+++ b/charts/floe-platform/values.yaml
@@ -1092,6 +1092,11 @@ tests:
     pvcName: test-artifacts
     storageSize: 1Gi
     storageClass: ""
+  # Optional pytest arguments for targeted in-cluster reruns.
+  # Empty means the chart uses the suite defaults from the test Job template.
+  # Non-empty values replace the entire default pytest argument block, so callers
+  # must include any reporting, formatting, marker, or artifact flags they need.
+  pytestArgs: []
   # Destructive E2E runner settings. The destructive Role scopes secrets
   # update/delete to Helm release secrets by resourceName. helmRevisionWindow
   # is the number of consecutive `sh.helm.release.v1.{{ .Release.Name }}.vN`

--- a/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
+++ b/plugins/floe-catalog-glue/src/floe_catalog_glue/plugin.py
@@ -56,8 +56,12 @@ class _GlueCatalogOps(Protocol):
         """List tables in a namespace."""
         ...
 
-    def drop_table(self, identifier: str, purge: bool = False) -> None:
+    def drop_table(self, identifier: str) -> None:
         """Drop a table."""
+        ...
+
+    def purge_table(self, identifier: str) -> None:
+        """Drop a table and delete underlying files."""
         ...
 
 
@@ -282,7 +286,11 @@ class GlueCatalogPlugin(CatalogPlugin):
 
     def drop_table(self, identifier: str, purge: bool = False) -> None:
         """Drop an Iceberg table from AWS Glue."""
-        self._connected_catalog().drop_table(identifier, purge=purge)
+        catalog = self._connected_catalog()
+        if purge:
+            catalog.purge_table(identifier)
+            return
+        catalog.drop_table(identifier)
 
     def vend_credentials(
         self,

--- a/plugins/floe-catalog-glue/tests/unit/test_plugin.py
+++ b/plugins/floe-catalog-glue/tests/unit/test_plugin.py
@@ -470,6 +470,7 @@ class TestCatalogOperations:
         assert plugin_with_catalog.list_namespaces() == ["bronze", "silver.sales"]
         assert plugin_with_catalog.list_tables("bronze") == ["bronze.customers"]
         plugin_with_catalog.create_table("bronze.customers", {"type": "struct"})
+        plugin_with_catalog.drop_table("bronze.customers_archive")
         plugin_with_catalog.drop_table("bronze.customers", purge=True)
         plugin_with_catalog.delete_namespace("bronze")
 
@@ -478,7 +479,8 @@ class TestCatalogOperations:
         catalog.list_namespaces.assert_called_once_with()
         catalog.list_tables.assert_called_once_with("bronze")
         catalog.create_table.assert_called_once_with("bronze.customers", {"type": "struct"})
-        catalog.drop_table.assert_called_once_with("bronze.customers", purge=True)
+        catalog.drop_table.assert_called_once_with("bronze.customers_archive")
+        catalog.purge_table.assert_called_once_with("bronze.customers")
         catalog.drop_namespace.assert_called_once_with("bronze")
 
     @pytest.mark.requirement("CATALOG-GLUE-022")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ dependencies = [
     "floe-alert-webhook",
     # Storage plugins
     "floe-storage-minio",
+    "floe-storage-aws-s3",
+    # Catalog plugins
+    "floe-catalog-glue",
 ]
 
 [project.optional-dependencies]
@@ -138,6 +141,8 @@ floe-alert-slack = { path = "plugins/floe-alert-slack", editable = true }
 floe-alert-email = { path = "plugins/floe-alert-email", editable = true }
 floe-alert-alertmanager = { path = "plugins/floe-alert-alertmanager", editable = true }
 floe-alert-webhook = { path = "plugins/floe-alert-webhook", editable = true }
+floe-storage-aws-s3 = { path = "plugins/floe-storage-aws-s3", editable = true }
+floe-catalog-glue = { path = "plugins/floe-catalog-glue", editable = true }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -164,6 +169,8 @@ pythonpath = [
     "plugins/floe-alert-email/src",
     "plugins/floe-alert-alertmanager/src",
     "plugins/floe-alert-webhook/src",
+    "plugins/floe-storage-aws-s3/src",
+    "plugins/floe-catalog-glue/src",
     "tests/e2e",
     ".",
 ]
@@ -183,6 +190,7 @@ markers = [
     "platform_blackbox: Marks in-cluster product validation",
     "developer_workflow: Marks repo-aware host validation",
     "requires_sts: Marks tests requiring STS-enabled storage backend (MinIO with STS)",
+    "live_aws: Marks tests that require the live AWS provider test account",
     "benchmark: Marks performance benchmark tests (CodSpeed)",
 ]
 # Suppress deprecation warnings from third-party dependencies

--- a/testing/ci/common.sh
+++ b/testing/ci/common.sh
@@ -162,6 +162,16 @@ floe_render_test_job() {
         return 2
     fi
     floe_ensure_chart_dependencies || return 1
+    if [[ -n "${FLOE_TEST_PYTEST_ARGS_JSON:-}" ]]; then
+        helm template "${FLOE_RELEASE_NAME}" "${FLOE_CHART_DIR}" \
+            -f "${FLOE_VALUES_FILE}" \
+            --set tests.enabled=true \
+            --set-json "tests.pytestArgs=${FLOE_TEST_PYTEST_ARGS_JSON}" \
+            --namespace "${FLOE_NAMESPACE}" \
+            -s "templates/${template}"
+        return
+    fi
+
     helm template "${FLOE_RELEASE_NAME}" "${FLOE_CHART_DIR}" \
         -f "${FLOE_VALUES_FILE}" \
         --set tests.enabled=true \

--- a/testing/ci/test-integration.sh
+++ b/testing/ci/test-integration.sh
@@ -69,6 +69,11 @@ echo "Job: ${JOB_NAME}"
 echo "Namespace: ${TEST_NAMESPACE}"
 echo "Kind cluster: ${FLOE_KIND_CLUSTER}"
 echo "Timeout: ${WAIT_TIMEOUT}s"
+if [[ "$#" -gt 0 ]]; then
+    FLOE_TEST_PYTEST_ARGS_JSON="$(python -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "$@")"
+    export FLOE_TEST_PYTEST_ARGS_JSON
+    echo "Pytest args: $*"
+fi
 echo ""
 
 # Check prerequisites

--- a/testing/fixtures/__init__.py
+++ b/testing/fixtures/__init__.py
@@ -12,6 +12,7 @@ Fixtures:
 
 Utilities:
     wait_for_condition: Poll until condition is true or timeout
+    wait_for_delay: Wait for an intentional retry backoff delay
     wait_for_service: Wait for service to become healthy
     generate_unique_namespace: Create isolated namespace for test
 
@@ -28,6 +29,8 @@ Example:
 """
 
 from __future__ import annotations
+
+from testing.fixtures import dagster_retry
 
 # Catalog plugin fixtures
 from testing.fixtures.catalog import (
@@ -170,6 +173,7 @@ from testing.fixtures.polling import (
     PollingConfig,
     PollingTimeoutError,
     wait_for_condition,
+    wait_for_delay,
     wait_for_service,
 )
 from testing.fixtures.postgres import (
@@ -218,6 +222,7 @@ __all__ = [
     "PollingConfig",
     "PollingTimeoutError",
     "wait_for_condition",
+    "wait_for_delay",
     "wait_for_service",
     # Namespace utilities
     "InvalidNamespaceError",
@@ -278,6 +283,7 @@ __all__ = [
     "materialize_asset",
     "materialize_to_memory",
     "wait_for_run_completion",
+    "dagster_retry",
     # Governance fixtures
     "create_api_token_finding",
     "create_aws_key_finding",

--- a/testing/fixtures/dagster_retry.py
+++ b/testing/fixtures/dagster_retry.py
@@ -1,0 +1,67 @@
+"""Dagster GraphQL retry helpers for validation tests."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from testing.fixtures.polling import wait_for_delay
+
+DAGSTER_STORAGE_RETRY_DELAY_SECONDS = float(
+    os.environ.get("FLOE_E2E_DAGSTER_STORAGE_RETRY_DELAY_SECONDS", "10")
+)
+DAGSTER_STORAGE_ERROR_MARKERS = (
+    "psycopg2.operationalerror",
+    "sqlalchemy.exc.operationalerror",
+)
+
+
+def is_transient_dagster_storage_launch_error(
+    status_code: int,
+    payload: dict[str, Any],
+) -> bool:
+    """Identify Dagster launch failures caused by transient metadata DB loss."""
+    if status_code != 500:
+        return False
+
+    launch_result = payload.get("data", {}).get("launchRun", {})
+    if launch_result.get("__typename") != "PythonError":
+        return False
+
+    message = str(launch_result.get("message", "")).lower()
+    return "server closed the connection unexpectedly" in message and any(
+        marker in message for marker in DAGSTER_STORAGE_ERROR_MARKERS
+    )
+
+
+def launch_dagster_run_with_storage_retry(
+    dagster_url: str,
+    mutation: str,
+    variables: dict[str, Any],
+    *,
+    attempts: int = 2,
+) -> httpx.Response:
+    """Launch a Dagster run, retrying only the known metadata-store transient."""
+    response: httpx.Response | None = None
+    for attempt in range(attempts):
+        response = httpx.post(
+            f"{dagster_url}/graphql",
+            json={"query": mutation, "variables": variables},
+            timeout=30.0,
+        )
+        try:
+            payload = response.json()
+        except ValueError:
+            return response
+        if not is_transient_dagster_storage_launch_error(response.status_code, payload):
+            return response
+        if attempt < attempts - 1:
+            wait_for_delay(
+                DAGSTER_STORAGE_RETRY_DELAY_SECONDS,
+                description="Dagster metadata storage retry backoff",
+            )
+
+    assert response is not None
+    return response

--- a/testing/fixtures/kubernetes.py
+++ b/testing/fixtures/kubernetes.py
@@ -148,6 +148,9 @@ def _ensure_helm_chart_dependencies(
     timeout: int,
 ) -> subprocess.CompletedProcess[str] | None:
     """Add chart-declared Helm repos and build dependencies before rendering."""
+    if _vendored_helm_chart_dependencies_available(chart_path):
+        return None
+
     for repo_name, repository in _chart_dependency_repositories(chart_path):
         repo_result = run_helm(
             ["repo", "add", repo_name, repository, "--force-update"],
@@ -160,6 +163,64 @@ def _ensure_helm_chart_dependencies(
     if dependency_result.returncode != 0:
         return dependency_result
     return None
+
+
+def _vendored_helm_chart_dependencies_available(chart_path: Path) -> bool:
+    """Return True when all Chart.yaml dependencies are vendored at declared versions."""
+    chart_yaml = chart_path / "Chart.yaml"
+    if not chart_yaml.exists():
+        return False
+
+    raw_chart: Any = yaml.safe_load(chart_yaml.read_text()) or {}
+    if not isinstance(raw_chart, dict):
+        return False
+
+    raw_dependencies = raw_chart.get("dependencies", [])
+    if not isinstance(raw_dependencies, list) or not raw_dependencies:
+        return False
+
+    vendored_dir = chart_path / "charts"
+    if not vendored_dir.is_dir():
+        return False
+
+    for dependency in raw_dependencies:
+        if not isinstance(dependency, dict):
+            continue
+        name = dependency.get("name")
+        version = dependency.get("version")
+        alias = dependency.get("alias")
+        if not isinstance(name, str) or not isinstance(version, str):
+            return False
+
+        candidate_names = [name]
+        if isinstance(alias, str) and alias:
+            candidate_names.insert(0, alias)
+
+        if any(
+            _vendored_chart_directory_matches_version(vendored_dir / candidate, version)
+            for candidate in candidate_names
+        ):
+            continue
+        if any(
+            (vendored_dir / f"{candidate}-{version}.tgz").is_file() for candidate in candidate_names
+        ):
+            continue
+        return False
+
+    return True
+
+
+def _vendored_chart_directory_matches_version(chart_dir: Path, expected_version: str) -> bool:
+    """Return True when an unpacked vendored subchart declares the expected version."""
+    chart_yaml = chart_dir / "Chart.yaml"
+    if not chart_yaml.is_file():
+        return False
+
+    raw_chart: Any = yaml.safe_load(chart_yaml.read_text()) or {}
+    if not isinstance(raw_chart, dict):
+        return False
+
+    return raw_chart.get("version") == expected_version
 
 
 def run_helm_template(

--- a/testing/fixtures/polling.py
+++ b/testing/fixtures/polling.py
@@ -5,6 +5,7 @@ in test code, ensuring reliable and efficient waiting for async operations.
 
 Functions:
     wait_for_condition: Poll until a condition is true or timeout
+    wait_for_delay: Wait for a fixed delay with an explicit test-infra name
     wait_for_service: Wait for a K8s service to become ready
 
 Example:
@@ -153,6 +154,38 @@ def wait_for_condition(
         sleep_time = min(interval, remaining)
         if sleep_time > 0:
             time.sleep(sleep_time)
+
+
+def wait_for_delay(
+    seconds: float,
+    *,
+    description: str = "delay",
+    interval: float = 0.5,
+) -> None:
+    """Wait for a fixed delay through the shared test polling utility.
+
+    Use this for intentional retry backoff in tests. Most test waits should
+    poll an external condition with ``wait_for_condition`` instead.
+
+    Args:
+        seconds: Delay duration in seconds.
+        description: Description for timeout errors.
+        interval: Poll interval while waiting.
+    """
+    if seconds <= 0:
+        return
+
+    ready_at = time.monotonic() + seconds
+
+    def delay_elapsed() -> bool:
+        return time.monotonic() >= ready_at
+
+    wait_for_condition(
+        delay_elapsed,
+        timeout=seconds + interval,
+        interval=interval,
+        description=description,
+    )
 
 
 def wait_for_service(

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -79,11 +79,19 @@ REQUIRED_DOCKERIGNORE_EXCLUSIONS: list[str] = [
     ".git",
     ".venv",
     "__pycache__",
+    "**/__pycache__",
     ".mypy_cache",
+    "**/.mypy_cache",
     ".pytest_cache",
+    "**/.pytest_cache",
     ".ruff_cache",
+    "**/.ruff_cache",
     ".specwright",
     ".claude",
+    "**/.terraform",
+    "**/*.tfstate*",
+    "**/tfplan",
+    "**/terraform.tfvars",
 ]
 
 
@@ -1979,6 +1987,59 @@ class TestHelmValuesImageOverride:
                 f"values-demo.yaml dagster.{component}.resources.limits.memory must match "
                 "the E2E profile used by values-test.yaml."
             )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_e2e_dagster_daemon_memory_budget_handles_live_suite(self) -> None:
+        """Verify the E2E daemon memory budget covers full live validation runs.
+
+        The full E2E suite loads all demo code locations and launches multiple
+        Dagster runs. The daemon must not use the smaller local-development
+        budget that OOMs under that workload.
+        """
+        values = _load_values_yaml(VALUES_TEST)
+        daemon_resources = values.get("dagster", {}).get("dagsterDaemon", {}).get("resources", {})
+
+        assert daemon_resources.get("requests", {}).get("memory") == "768Mi", (
+            "values-test.yaml dagster.dagsterDaemon.resources.requests.memory "
+            "must reserve enough memory for the full E2E profile."
+        )
+        assert daemon_resources.get("limits", {}).get("memory") == "2Gi", (
+            "values-test.yaml dagster.dagsterDaemon.resources.limits.memory must "
+            "prevent OOMKills during full live validation."
+        )
+
+    @pytest.mark.requirement("WU11-AC3")
+    def test_e2e_postgresql_budget_handles_dagster_metadata_writes(self) -> None:
+        """Verify the E2E metadata database budget covers concurrent Dagster writes.
+
+        Full live validation launches repeated Dagster runs while Marquez and
+        Polaris also use PostgreSQL. Keep the E2E database above the minimal
+        local-development budget that rejects connections under that workload.
+        """
+        values = _load_values_yaml(VALUES_TEST)
+        primary_resources = values.get("postgresql", {}).get("primary", {}).get("resources", {})
+        demo_resources = _load_values_yaml(VALUES_DEMO).get("postgresql", {}).get("resources", {})
+
+        assert primary_resources.get("requests", {}).get("cpu") == "250m", (
+            "values-test.yaml postgresql.primary.resources.requests.cpu must "
+            "reserve enough CPU for live E2E metadata writes."
+        )
+        assert primary_resources.get("requests", {}).get("memory") == "512Mi", (
+            "values-test.yaml postgresql.primary.resources.requests.memory must "
+            "reserve enough memory for live E2E metadata writes."
+        )
+        assert primary_resources.get("limits", {}).get("memory") == "1Gi", (
+            "values-test.yaml postgresql.primary.resources.limits.memory must "
+            "avoid transient connection loss during full live validation."
+        )
+        assert demo_resources.get("requests", {}).get("cpu") == "250m", (
+            "values-demo.yaml postgresql.resources.requests.cpu must stay aligned "
+            "with the validated E2E metadata database profile."
+        )
+        assert demo_resources.get("limits", {}).get("memory") == "1Gi", (
+            "values-demo.yaml postgresql.resources.limits.memory must stay aligned "
+            "with the validated E2E metadata database profile."
+        )
 
     @pytest.mark.requirement("WU11-AC3")
     def test_values_demo_run_launcher_keeps_base_memory_limit(self) -> None:

--- a/testing/tests/unit/test_polling.py
+++ b/testing/tests/unit/test_polling.py
@@ -15,6 +15,7 @@ from testing.fixtures.polling import (
     PollingConfig,
     PollingTimeoutError,
     wait_for_condition,
+    wait_for_delay,
     wait_for_http_status,
     wait_for_service,
 )
@@ -131,6 +132,33 @@ class TestWaitForCondition:
 
         assert exc_info.value.last_error is not None
         assert "Test error" in str(exc_info.value.last_error)
+
+
+class TestWaitForDelay:
+    """Tests for fixed-delay retry backoff helper."""
+
+    @pytest.mark.requirement("9c-FR-015")
+    def test_returns_immediately_for_zero_or_negative_delay(self) -> None:
+        """Non-positive delays should not call the polling loop."""
+        with patch("testing.fixtures.polling.wait_for_condition") as mock_wait:
+            wait_for_delay(0)
+            wait_for_delay(-1)
+
+        mock_wait.assert_not_called()
+
+    @pytest.mark.requirement("9c-FR-015")
+    def test_uses_shared_polling_loop_for_positive_delay(self) -> None:
+        """Positive delays should route through wait_for_condition."""
+        with (
+            patch("testing.fixtures.polling.time.monotonic", return_value=100.0),
+            patch("testing.fixtures.polling.wait_for_condition") as mock_wait,
+        ):
+            wait_for_delay(2.0, description="retry backoff", interval=0.25)
+
+        _, kwargs = mock_wait.call_args
+        assert kwargs["timeout"] == pytest.approx(2.25)
+        assert kwargs["interval"] == pytest.approx(0.25)
+        assert kwargs["description"] == "retry backoff"
 
 
 class TestWaitForService:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ Note:
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -167,3 +168,24 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "requirement(id): Mark test as covering a specific requirement",
     )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect live-cloud tests unless the live AWS provider lane is enabled."""
+    if os.environ.get("FLOE_RUN_LIVE_AWS_PROVIDER_TESTS") == "1":
+        return
+
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+    for item in items:
+        marker_names = {marker.name for marker in item.iter_markers()}
+        if "live_aws" in marker_names:
+            deselected.append(item)
+        else:
+            selected.append(item)
+
+    if not deselected:
+        return
+
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected

--- a/tests/contract/test_plugin_instrumentation_contract.py
+++ b/tests/contract/test_plugin_instrumentation_contract.py
@@ -6,7 +6,7 @@ that tracer names follow the ``floe.{category}.{implementation}`` convention.
 
 Requirements:
     FR-022: All plugins discoverable via entry points
-    SC-001: 19 of 21 plugins have non-None tracer_name
+    SC-001: 22 of 24 plugins have non-None tracer_name
 """
 
 from __future__ import annotations
@@ -32,8 +32,8 @@ _EXCLUDED_GROUPS: frozenset[str] = frozenset(
 _TRACER_NAME_PATTERN = re.compile(r"^floe\.[a-z]+\.[a-z][a-z0-9_]*$")
 
 # Expected counts
-_EXPECTED_TOTAL_PLUGINS = 22
-_EXPECTED_INSTRUMENTED_PLUGINS = 20
+_EXPECTED_TOTAL_PLUGINS = 24
+_EXPECTED_INSTRUMENTED_PLUGINS = 22
 
 
 @pytest.mark.requirement("FR-022")
@@ -42,7 +42,7 @@ class TestPluginInstrumentationContract:
     """Contract tests for plugin OTel instrumentation."""
 
     def test_total_registered_plugins(self) -> None:
-        """All 21 plugins are discoverable via entry points."""
+        """All first-party plugins are discoverable via entry points."""
         total = 0
         for group in _PLUGIN_GROUPS:
             eps = entry_points(group=group)
@@ -53,7 +53,7 @@ class TestPluginInstrumentationContract:
         )
 
     def test_instrumented_plugin_count(self) -> None:
-        """19 of 21 plugins have non-None tracer_name."""
+        """All non-telemetry plugins have non-None tracer_name."""
         instrumented = 0
         uninstrumented: list[str] = []
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -370,8 +370,10 @@ def _recover_suspended_flux() -> None:
     previous E2E test run crashed mid-test while Flux reconciliation was
     temporarily suspended.
 
-    If a release is found suspended, issues ``flux resume helmrelease`` to
-    restore normal reconciliation before the new test suite starts.
+    If a release is found suspended, resumes reconciliation before the new
+    test suite starts. Uses the Flux CLI when available and falls back to a
+    kubectl patch because the in-cluster test runner intentionally keeps its
+    toolchain small.
 
     No-op when:
     - kubectl is not available or returns non-zero (no Flux CRDs installed).
@@ -391,20 +393,34 @@ def _recover_suspended_flux() -> None:
         if result.stdout.strip() == "true":
             logger.warning(
                 "HelmRelease %s is suspended (likely from a prior crashed run) — "
-                "running flux resume helmrelease to restore reconciliation",
+                "restoring reconciliation",
                 name,
             )
-            # Resume: flux resume helmrelease <name> -n <ns>
+            if shutil.which("flux"):
+                resume_cmd = ["flux", "resume", "helmrelease", name, "-n", ns]
+            else:
+                resume_cmd = [
+                    "kubectl",
+                    "patch",
+                    "helmrelease",
+                    name,
+                    "-n",
+                    ns,
+                    "--type=merge",
+                    "-p",
+                    '{"spec":{"suspend":false}}',
+                ]
             resume_result = subprocess.run(
-                ["flux", "resume", "helmrelease", name, "-n", ns],
+                resume_cmd,
                 capture_output=True,
                 text=True,
                 check=False,
             )
             if resume_result.returncode != 0:
                 logger.warning(
-                    "flux resume helmrelease %s failed: returncode=%d stderr=%s",
+                    "HelmRelease resume failed for %s: cmd=%s returncode=%d stderr=%s",
                     name,
+                    resume_cmd,
                     resume_result.returncode,
                     resume_result.stderr,
                 )
@@ -1030,7 +1046,15 @@ query RunStatus($runId: ID!) {
 
 _COMPLETED_MARQUEZ_STATE = "COMPLETED"
 _DAGSTER_LAUNCH_RUN_TIMEOUT_SECONDS = 30.0
-_DAGSTER_LAUNCH_TIMEOUT_MARQUEZ_GRACE_SECONDS = 180.0
+_DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS = float(
+    os.environ.get("FLOE_E2E_DAGSTER_RUN_TIMEOUT_SECONDS", "360")
+)
+_DAGSTER_LAUNCH_TIMEOUT_MARQUEZ_GRACE_SECONDS = float(
+    os.environ.get("FLOE_E2E_DAGSTER_LAUNCH_MARQUEZ_GRACE_SECONDS", "360")
+)
+_MARQUEZ_FRESH_RUN_TIMEOUT_SECONDS = float(
+    os.environ.get("FLOE_E2E_MARQUEZ_FRESH_RUN_TIMEOUT_SECONDS", "120")
+)
 
 
 def _marquez_job_runs(
@@ -1120,7 +1144,7 @@ def _wait_for_fresh_completed_marquez_run(
     namespace: str,
     job_name: str,
     before_run_ids: set[str],
-    timeout: float = 60.0,
+    timeout: float = _MARQUEZ_FRESH_RUN_TIMEOUT_SECONDS,
 ) -> bool:
     """Wait until Marquez ingests a fresh COMPLETED run for the expected job."""
 
@@ -1385,15 +1409,16 @@ def _trigger_lineage_run(
 
     completed = wait_for_condition(
         _run_complete,
-        timeout=180.0,
+        timeout=_DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS,
         interval=5.0,
         description=f"Dagster lineage run {run_id} to complete",
         raise_on_timeout=False,
     )
     if not completed:
         logger.warning(
-            "seed_observability: lineage run %s did not complete within 180s; continuing",
+            "seed_observability: lineage run %s did not complete within %.0fs; continuing",
             run_id,
+            _DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS,
         )
         return
 
@@ -1442,9 +1467,10 @@ def _trigger_lineage_run(
     if not ingested:
         logger.warning(
             "seed_observability: fresh COMPLETED Marquez run for %s/%s not confirmed "
-            "within 60s; continuing",
+            "within %.0fs; continuing",
             expected_namespace,
             expected_job_name,
+            _MARQUEZ_FRESH_RUN_TIMEOUT_SECONDS,
         )
     else:
         logger.info(

--- a/tests/e2e/test_compile_deploy_materialize_e2e.py
+++ b/tests/e2e/test_compile_deploy_materialize_e2e.py
@@ -24,18 +24,30 @@ from __future__ import annotations
 
 import os
 import re
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
 
+from testing.fixtures.dagster_retry import launch_dagster_run_with_storage_retry
+from testing.fixtures.polling import wait_for_condition
 from testing.fixtures.services import ServiceEndpoint
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-
+_DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS = float(
+    os.environ.get("FLOE_E2E_DAGSTER_RUN_TIMEOUT_SECONDS", "360")
+)
+_RUN_STATUS_QUERY = """
+query RunStatus($runId: ID!) {
+    runOrError(runId: $runId) {
+        ... on Run { status }
+    }
+}
+"""
 # Demo product paths relative to project root
 DEMO_PRODUCTS = {
     "customer-360": "demo/customer-360/floe.yaml",
@@ -124,6 +136,103 @@ def _discover_repository_for_asset(
         f"Asset matching '{search_term}' not found in Dagster assetNodes. "
         f"Available asset key paths: {available}"
     )
+
+
+def _dagster_run_status(dagster_url: str, run_id: str) -> str | None:
+    """Return the current Dagster status for a run."""
+    response = httpx.post(
+        f"{dagster_url}/graphql",
+        json={"query": _RUN_STATUS_QUERY, "variables": {"runId": run_id}},
+        timeout=10.0,
+    )
+    if response.status_code != 200:
+        return None
+    return response.json().get("data", {}).get("runOrError", {}).get("status")
+
+
+@pytest.fixture(scope="class")
+def customer_360_materialization_run(
+    wait_for_service: Callable[..., None],
+) -> str:
+    """Launch and wait for one complete Customer 360 materialization run."""
+    dagster_url = os.environ.get("DAGSTER_URL", ServiceEndpoint("dagster-webserver").url)
+    wait_for_service(
+        f"{dagster_url}/server_info",
+        timeout=60,
+        description="Dagster webserver",
+    )
+
+    mutation = """
+    mutation LaunchRun($executionParams: ExecutionParams!) {
+        launchRun(executionParams: $executionParams) {
+            __typename
+            ... on LaunchRunSuccess {
+                run {
+                    runId
+                    status
+                }
+            }
+            ... on PipelineNotFoundError {
+                message
+            }
+            ... on PythonError {
+                message
+            }
+            ... on RunConfigValidationInvalid {
+                errors { message }
+            }
+        }
+    }
+    """
+
+    repo_name, location_name, _asset_path, job_name = _discover_repository_for_asset(
+        dagster_url, "stg_crm_customers"
+    )
+    variables = {
+        "executionParams": {
+            "selector": {
+                "repositoryName": repo_name,
+                "repositoryLocationName": location_name,
+                "pipelineName": job_name,
+            },
+            "mode": "default",
+        },
+    }
+
+    response = launch_dagster_run_with_storage_retry(dagster_url, mutation, variables)
+    assert response.status_code == 200, (
+        f"Dagster GraphQL returned {response.status_code}: {response.text}"
+    )
+
+    launch_result = response.json().get("data", {}).get("launchRun", {})
+    launch_typename = launch_result.get("__typename", "unknown")
+    if launch_typename != "LaunchRunSuccess":
+        if launch_typename == "RunConfigValidationInvalid":
+            errs = [e.get("message", "") for e in launch_result.get("errors", [])]
+            error_msg = "; ".join(errs) or str(launch_result)
+        else:
+            error_msg = launch_result.get("message", str(launch_result))
+        pytest.fail(f"launchRun returned {launch_typename}: {error_msg}")
+
+    run_id = launch_result.get("run", {}).get("runId")
+    assert run_id, "No runId returned from LaunchRunSuccess"
+
+    completed = wait_for_condition(
+        lambda: _dagster_run_status(dagster_url, run_id) in ("SUCCESS", "FAILURE", "CANCELED"),
+        timeout=_DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS,
+        interval=5.0,
+        description="customer-360 materialization run to complete",
+        raise_on_timeout=False,
+    )
+    final_status = _dagster_run_status(dagster_url, run_id)
+    assert completed, (
+        f"Materialization run {run_id} did not complete within "
+        f"{_DAGSTER_RUN_COMPLETION_TIMEOUT_SECONDS:.0f}s; last status was {final_status!r}"
+    )
+    assert final_status == "SUCCESS", (
+        f"Materialization run {run_id} ended with status {final_status}"
+    )
+    return run_id
 
 
 @pytest.mark.e2e
@@ -496,145 +605,16 @@ class TestCompileDeployMaterialize:
     @pytest.mark.requirement("AC-2.2")
     def test_trigger_asset_materialization(
         self,
-        wait_for_service: Callable[..., None],
+        customer_360_materialization_run: str,
     ) -> None:
-        """Trigger asset materialization via Dagster GraphQL API.
-
-        Uses launchRun mutation to materialize a single asset (stg_customers)
-        and polls for run completion. Validates the deploy → materialize step
-        of the full lifecycle.
-        """
-        from testing.fixtures.polling import wait_for_condition
-
-        dagster_url = os.environ.get("DAGSTER_URL", ServiceEndpoint("dagster-webserver").url)
-        wait_for_service(
-            f"{dagster_url}/server_info",
-            timeout=60,
-            description="Dagster webserver",
-        )
-
-        # Launch materialization for stg_crm_customers asset
-        mutation = """
-        mutation LaunchRun($executionParams: ExecutionParams!) {
-            launchRun(executionParams: $executionParams) {
-                __typename
-                ... on LaunchRunSuccess {
-                    run {
-                        runId
-                        status
-                    }
-                }
-                ... on PipelineNotFoundError {
-                    message
-                }
-                ... on PythonError {
-                    message
-                }
-                ... on RunConfigValidationInvalid {
-                    errors { message }
-                }
-            }
-        }
-        """
-
-        # Discover repository context for the target asset (AC-16.1)
-        repo_name, location_name, _asset_path, job_name = _discover_repository_for_asset(
-            dagster_url, "stg_crm_customers"
-        )
-
-        # Materialize ALL assets in the job (seeds → staging → marts).
-        # Previously used assetSelection to target only stg_crm_customers,
-        # but @dbt_assets maps each dbt node to a separate asset — selecting
-        # only the staging model skips seed dependencies (main_raw schema).
-        variables = {
-            "executionParams": {
-                "selector": {
-                    "repositoryName": repo_name,
-                    "repositoryLocationName": location_name,
-                    "pipelineName": job_name,
-                },
-                "mode": "default",
-            },
-        }
-
-        response = httpx.post(
-            f"{dagster_url}/graphql",
-            json={"query": mutation, "variables": variables},
-            timeout=30.0,
-        )
-        assert response.status_code == 200, (
-            f"Dagster GraphQL returned {response.status_code}: {response.text}"
-        )
-
-        data = response.json()
-        launch_result = data.get("data", {}).get("launchRun", {})
-
-        # Dagster launchRun is a GraphQL union: LaunchRunSuccess | error types.
-        # Error types have __typename + message but no "run" key.
-        launch_typename = launch_result.get("__typename", "unknown")
-        if launch_typename != "LaunchRunSuccess":
-            if launch_typename == "RunConfigValidationInvalid":
-                errs = [e.get("message", "") for e in launch_result.get("errors", [])]
-                error_msg = "; ".join(errs) or str(launch_result)
-            else:
-                error_msg = launch_result.get("message", str(launch_result))
-            pytest.fail(f"launchRun returned {launch_typename}: {error_msg}")
-
-        run_id = launch_result.get("run", {}).get("runId")
-        assert run_id, "No runId returned from LaunchRunSuccess"
-
-        # Poll for run completion
-        def check_run_complete() -> bool:
-            """Check if materialization run has completed."""
-            status_query = """
-            query RunStatus($runId: ID!) {
-                runOrError(runId: $runId) {
-                    ... on Run {
-                        status
-                    }
-                }
-            }
-            """
-            resp = httpx.post(
-                f"{dagster_url}/graphql",
-                json={"query": status_query, "variables": {"runId": run_id}},
-                timeout=10.0,
-            )
-            if resp.status_code != 200:
-                return False
-            status = resp.json().get("data", {}).get("runOrError", {}).get("status")
-            return status in ("SUCCESS", "FAILURE", "CANCELED")
-
-        completed = wait_for_condition(
-            check_run_complete,
-            timeout=120.0,
-            interval=5.0,
-            description="materialization run to complete",
-            raise_on_timeout=False,
-        )
-        assert completed, f"Materialization run {run_id} did not complete within 120s"
-
-        # Verify final status is SUCCESS
-        status_query = """
-        query RunStatus($runId: ID!) {
-            runOrError(runId: $runId) {
-                ... on Run { status }
-            }
-        }
-        """
-        final_resp = httpx.post(
-            f"{dagster_url}/graphql",
-            json={"query": status_query, "variables": {"runId": run_id}},
-            timeout=10.0,
-        )
-        final_status = final_resp.json().get("data", {}).get("runOrError", {}).get("status")
-        assert final_status == "SUCCESS", (
-            f"Materialization run {run_id} ended with status {final_status}"
-        )
+        """Verify the shared materialization fixture completed a Dagster run."""
+        # Fixture performs launch and wait; body validates the fixture resolved.
+        assert str(uuid.UUID(customer_360_materialization_run)) == customer_360_materialization_run
 
     @pytest.mark.requirement("AC-2.2")
     def test_iceberg_tables_exist_after_materialization(
         self,
+        customer_360_materialization_run: str,
         polaris_client: Any,
     ) -> None:
         """Verify Iceberg tables exist in Polaris after materialization.
@@ -643,6 +623,8 @@ class TestCompileDeployMaterialize:
         at least one Iceberg table with expected schema columns. Validates
         the materialize → validate step of the full lifecycle.
         """
+        assert str(uuid.UUID(customer_360_materialization_run)) == customer_360_materialization_run
+
         # List tables in the customer-360 namespace
         # The namespace may be "customer_360" or "customer-360" depending on
         # how Dagster normalizes the product name

--- a/tests/e2e/test_platform_deployment_e2e.py
+++ b/tests/e2e/test_platform_deployment_e2e.py
@@ -48,16 +48,22 @@ pytestmark = [
 NAMESPACE = os.environ.get("FLOE_E2E_NAMESPACE", "floe-test")
 VALUES_TEST = Path(__file__).resolve().parents[2] / "charts" / "floe-platform" / "values-test.yaml"
 
-# Expected core services that MUST be deployed
-EXPECTED_COMPONENTS = frozenset(
-    {
-        "postgresql",
-        "polaris",
-        "dagster",
-        "minio",
-        "otel",
-    }
-)
+# Expected core Helm-managed resources that MUST be deployed. Most components
+# render a single service/deployment name; Dagster renders split webserver and
+# daemon resources.
+EXPECTED_RESOURCE_GROUPS = {
+    "postgresql": frozenset({"floe-platform-postgresql"}),
+    "polaris": frozenset({"floe-platform-polaris"}),
+    "dagster": frozenset(
+        {
+            "floe-platform-dagster-webserver",
+            "floe-platform-dagster-daemon",
+        },
+    ),
+    "minio": frozenset({"floe-platform-minio"}),
+    "otel": frozenset({"floe-platform-otel"}),
+}
+EXPECTED_COMPONENTS = frozenset(EXPECTED_RESOURCE_GROUPS)
 
 
 def _cube_store_enabled_in_test_values() -> bool:
@@ -81,6 +87,50 @@ def _get_cube_store_pods() -> list[dict[str, object]]:
     assert result.returncode == 0, f"kubectl failed: {result.stderr}"
     pods = json.loads(result.stdout)
     return pods.get("items", [])
+
+
+def _assert_helm_managed_platform_resources_deployed(
+    *,
+    helm_stderr: str,
+    helmrelease_stderr: str,
+) -> None:
+    """Validate direct-Helm deployments without granting release-secret access."""
+    result = run_kubectl(
+        [
+            "get",
+            "deployments,services",
+            "-l",
+            "app.kubernetes.io/instance=floe-platform,app.kubernetes.io/managed-by=Helm",
+            "-o",
+            "json",
+        ],
+        namespace=NAMESPACE,
+    )
+    assert result.returncode == 0, (
+        "Helm status is blocked by least-privilege test-runner RBAC, "
+        "Flux HelmRelease status could not be read, and Helm-managed resource "
+        "evidence could not be queried.\n"
+        f"helm stderr: {helm_stderr}\n"
+        f"helmrelease stderr: {helmrelease_stderr}\n"
+        f"kubectl stderr: {result.stderr}"
+    )
+
+    resources = json.loads(result.stdout)
+    items = resources.get("items", [])
+    resource_names = {
+        str(item.get("metadata", {}).get("name", "")) for item in items if isinstance(item, dict)
+    }
+    missing = {
+        component
+        for component, expected_names in EXPECTED_RESOURCE_GROUPS.items()
+        if not expected_names.issubset(resource_names)
+    }
+    assert not missing, (
+        "Direct-Helm deployment evidence is incomplete. Expected core "
+        "Helm-managed resources were not found.\n"
+        f"missing: {sorted(missing)}\n"
+        f"found: {sorted(resource_names)}"
+    )
 
 
 def _assert_cube_store_rollback_state() -> None:
@@ -117,6 +167,13 @@ class TestPlatformDeployment:
                 ["get", "helmrelease", "floe-platform", "-o", "json"],
                 namespace=NAMESPACE,
             )
+            if helmrelease.returncode != 0 and "resource type" in helmrelease.stderr:
+                _assert_helm_managed_platform_resources_deployed(
+                    helm_stderr=result.stderr,
+                    helmrelease_stderr=helmrelease.stderr,
+                )
+                return
+
             assert helmrelease.returncode == 0, (
                 "Helm status is blocked by least-privilege test-runner RBAC, "
                 "and Flux HelmRelease status could not be read.\n"

--- a/tests/integration/test_aws_provider_live.py
+++ b/tests/integration/test_aws_provider_live.py
@@ -1,0 +1,161 @@
+"""Live AWS provider validation for S3 storage plus Glue catalog composition."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import Mapping
+
+import pytest
+from floe_catalog_glue.config import GlueCatalogConfig
+from floe_catalog_glue.plugin import GlueCatalogPlugin
+from floe_core.runtime_catalog_connection import build_runtime_catalog_connection
+from floe_iceberg.runtime_catalog import runtime_catalog_connection_to_pyiceberg_config
+from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
+from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
+from pyiceberg.exceptions import NamespaceAlreadyExistsError, NoSuchNamespaceError
+from pyiceberg.schema import Schema
+from pyiceberg.types import NestedField, StringType
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live_aws,
+    pytest.mark.requirement("LIVE-VALIDATION"),
+]
+
+LOGGER = logging.getLogger(__name__)
+
+RUN_ID_PATTERN = re.compile(r"^floe-provider-[0-9]{8}T[0-9]{6}Z$")
+REQUIRED_ENV = (
+    "FLOE_AWS_REGION",
+    "FLOE_AWS_TEST_BUCKET",
+    "FLOE_AWS_TEST_PREFIX",
+    "FLOE_AWS_GLUE_DATABASE_PREFIX",
+    "FLOE_PROVIDER_SPIKE_RUN",
+)
+
+
+def _require_live_aws_env() -> dict[str, str]:
+    if os.environ.get("FLOE_RUN_LIVE_AWS_PROVIDER_TESTS") != "1":
+        pytest.fail("set FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1 to run live AWS provider tests")
+
+    missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
+    if missing:
+        pytest.fail(f"missing live AWS provider test env vars: {', '.join(missing)}")
+
+    env = {name: os.environ[name] for name in REQUIRED_ENV}
+    if not RUN_ID_PATTERN.fullmatch(env["FLOE_PROVIDER_SPIKE_RUN"]):
+        pytest.fail("FLOE_PROVIDER_SPIKE_RUN must match floe-provider-YYYYMMDDTHHMMSSZ")
+    if not env["FLOE_AWS_TEST_PREFIX"].endswith("/"):
+        pytest.fail("FLOE_AWS_TEST_PREFIX must end with /")
+    if not env["FLOE_AWS_GLUE_DATABASE_PREFIX"].endswith("_"):
+        pytest.fail("FLOE_AWS_GLUE_DATABASE_PREFIX must end with _")
+    return env
+
+
+def _run_database_name(env: Mapping[str, str]) -> str:
+    return (
+        f"{env['FLOE_AWS_GLUE_DATABASE_PREFIX']}{env['FLOE_PROVIDER_SPIKE_RUN'].replace('-', '_')}"
+    )
+
+
+def _assert_secret_values_are_not_embedded(payload: str) -> None:
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            assert value not in payload
+
+
+def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validate the real AWS S3 and Glue path through resolved deployment bindings."""
+    env = _require_live_aws_env()
+    region = env["FLOE_AWS_REGION"]
+    bucket = env["FLOE_AWS_TEST_BUCKET"]
+    run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
+    run_prefix = f"{env['FLOE_AWS_TEST_PREFIX']}{run_id}/"
+    requested_namespace = _run_database_name(env)
+    # AWS Glue stores database names in lowercase even when callers provide
+    # mixed-case run identifiers, so follow its canonical catalog shape after
+    # proving create_namespace accepts the requested Floe cleanup target.
+    catalog_namespace = requested_namespace.lower()
+    table_identifier = f"{catalog_namespace}.provider_validation"
+    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_validation"
+    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-validation.txt"
+
+    monkeypatch.setenv("AWS_REGION", region)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", region)
+
+    storage_plugin = AwsS3ObjectStorePlugin(
+        AwsS3ObjectStoreConfig(
+            bucket=bucket,
+            warehouse_prefix=f"{run_prefix}warehouse/",
+            artifact_prefix=f"{run_prefix}artifacts/",
+            region=region,
+            credential_mode="environment",
+        )
+    )
+    storage_binding = storage_plugin.get_deployment_binding()
+
+    catalog_plugin = GlueCatalogPlugin(
+        GlueCatalogConfig(
+            region=region,
+            warehouse=storage_binding.warehouse.uri,
+            database_prefix=env["FLOE_AWS_GLUE_DATABASE_PREFIX"],
+            credential_mode="environment",
+        )
+    )
+    catalog_binding = catalog_plugin.build_catalog_deployment(storage_binding)
+    runtime_connection = build_runtime_catalog_connection(
+        storage=storage_binding,
+        catalog=catalog_binding,
+    )
+    pyiceberg_config = runtime_catalog_connection_to_pyiceberg_config(runtime_connection)
+
+    assert pyiceberg_config["type"] == "glue"
+    assert pyiceberg_config["warehouse"] == storage_binding.warehouse.uri
+    assert pyiceberg_config["glue.region"] == region
+    assert pyiceberg_config["s3.region"] == region
+    assert storage_binding.credentials.mode == "environment"
+    assert catalog_binding.glue is not None
+    assert catalog_binding.glue.credential_refs["accessKeyId"].source == "environment"
+
+    _assert_secret_values_are_not_embedded(storage_binding.model_dump_json())
+    _assert_secret_values_are_not_embedded(catalog_binding.model_dump_json())
+    _assert_secret_values_are_not_embedded(runtime_connection.model_dump_json())
+    _assert_secret_values_are_not_embedded(repr(pyiceberg_config))
+
+    fileio = storage_plugin.get_pyiceberg_fileio()
+    expected_payload = f"floe live provider validation: {run_id}\n".encode()
+    with fileio.new_output(object_location).create(overwrite=True) as output:
+        output.write(expected_payload)
+    with fileio.new_input(object_location).open() as input_file:
+        assert input_file.read() == expected_payload
+
+    catalog_plugin.connect(pyiceberg_config)
+    try:
+        try:
+            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+        except NamespaceAlreadyExistsError:
+            catalog_plugin.delete_namespace(catalog_namespace)
+            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+
+        assert catalog_namespace in catalog_plugin.list_namespaces()
+
+        schema = Schema(NestedField(1, "run_id", StringType(), required=True))
+        catalog_plugin.create_table(
+            table_identifier,
+            schema,  # type: ignore[arg-type]
+            location=table_location,
+            properties={"floe.provider.test.run": run_id},
+        )
+        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+    finally:
+        try:
+            catalog_plugin.drop_table(table_identifier, purge=True)
+        except Exception:  # noqa: BLE001
+            LOGGER.warning("Best-effort AWS Glue table cleanup failed", exc_info=True)
+        try:
+            catalog_plugin.delete_namespace(catalog_namespace)
+        except NoSuchNamespaceError:
+            pass

--- a/tests/unit/test_dagster_launch_retry.py
+++ b/tests/unit/test_dagster_launch_retry.py
@@ -1,0 +1,132 @@
+"""Unit coverage for Dagster launch retry classification."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import testing.fixtures.dagster_retry as dagster_retry
+
+pytestmark = pytest.mark.requirement("LIVE-VALIDATION")
+
+
+def test_launch_retry_classifies_dagster_postgres_connection_reset() -> None:
+    """Dagster launch HTTP 500 caused by PostgreSQL connection loss is infra-transient."""
+    assert dagster_retry.is_transient_dagster_storage_launch_error(
+        500,
+        {
+            "data": {
+                "launchRun": {
+                    "__typename": "PythonError",
+                    "message": (
+                        "sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) "
+                        "server closed the connection unexpectedly"
+                    ),
+                }
+            }
+        },
+    )
+
+
+def test_launch_retry_rejects_non_postgres_python_errors() -> None:
+    """Product Python errors must not be retried as infrastructure failures."""
+    assert not dagster_retry.is_transient_dagster_storage_launch_error(
+        500,
+        {
+            "data": {
+                "launchRun": {
+                    "__typename": "PythonError",
+                    "message": "dbt failed to compile model stg_crm_customers",
+                }
+            }
+        },
+    )
+
+
+def test_launch_retry_rejects_non_500_responses() -> None:
+    """Only Dagster launch HTTP 500 metadata-store failures are retryable."""
+    assert not dagster_retry.is_transient_dagster_storage_launch_error(
+        400,
+        {
+            "data": {
+                "launchRun": {
+                    "__typename": "PythonError",
+                    "message": "server closed the connection unexpectedly",
+                }
+            }
+        },
+    )
+
+
+def test_launch_retry_attempts_once_after_transient_storage_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launch helper retries once after the narrow Dagster/PostgreSQL failure."""
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+            self.status_code = status_code
+            self._payload = payload
+            self.text = str(payload)
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    responses = iter(
+        [
+            FakeResponse(
+                500,
+                {
+                    "data": {
+                        "launchRun": {
+                            "__typename": "PythonError",
+                            "message": (
+                                "psycopg2.OperationalError: server closed the connection "
+                                "unexpectedly"
+                            ),
+                        }
+                    }
+                },
+            ),
+            FakeResponse(
+                200,
+                {
+                    "data": {
+                        "launchRun": {
+                            "__typename": "LaunchRunSuccess",
+                            "run": {"runId": "run-123", "status": "STARTING"},
+                        }
+                    }
+                },
+            ),
+        ]
+    )
+
+    def fake_post(*_args: Any, **kwargs: Any) -> FakeResponse:
+        calls.append(kwargs)
+        return next(responses)
+
+    waits: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def fake_wait_for_delay(*args: Any, **kwargs: Any) -> None:
+        waits.append((args, kwargs))
+
+    monkeypatch.setattr(dagster_retry.httpx, "post", fake_post)
+    monkeypatch.setattr(dagster_retry, "wait_for_delay", fake_wait_for_delay)
+
+    response = dagster_retry.launch_dagster_run_with_storage_retry(
+        "http://dagster",
+        "mutation",
+        {"executionParams": {}},
+    )
+
+    assert response.status_code == 200
+    assert len(calls) == 2
+    assert waits == [
+        (
+            (dagster_retry.DAGSTER_STORAGE_RETRY_DELAY_SECONDS,),
+            {"description": "Dagster metadata storage retry backoff"},
+        )
+    ]

--- a/tests/unit/test_e2e_runner_chart_contract.py
+++ b/tests/unit/test_e2e_runner_chart_contract.py
@@ -56,6 +56,47 @@ def test_rendered_e2e_job_uses_if_not_present_for_test_runner() -> None:
     assert "imagePullPolicy: IfNotPresent" in result.stdout
 
 
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_rendered_e2e_job_accepts_targeted_pytest_args_override() -> None:
+    """Targeted live reruns must be able to replace the default pytest selection."""
+    result = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            "source testing/ci/common.sh && "
+            "FLOE_TEST_PYTEST_ARGS_JSON='["
+            '"tests/e2e/test_observability.py::TestObservability::'
+            'test_openlineage_events_in_marquez",'
+            '"-q"]\' '
+            "floe_render_test_job tests/job-e2e.yaml",
+        ],
+        cwd=_REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "Failed to render the E2E Job with targeted pytest args.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    assert (
+        '"tests/e2e/test_observability.py::TestObservability::test_openlineage_events_in_marquez"'
+    ) in result.stdout
+    assert '"-q"' in result.stdout
+    assert '"platform_blackbox and not destructive"' not in result.stdout
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_integration_runner_exports_pytest_args_override() -> None:
+    """The documented runner arguments must flow into the rendered test Job."""
+    script = (_REPO_ROOT / "testing" / "ci" / "test-integration.sh").read_text()
+
+    assert "FLOE_TEST_PYTEST_ARGS_JSON=" in script
+    assert "json.dumps(sys.argv[1:])" in script
+    assert "export FLOE_TEST_PYTEST_ARGS_JSON" in script
+
+
 @pytest.mark.requirement("AC-DevPod-Remote-E2E")
 def test_test_runner_image_installs_dbt_installer_prerequisites() -> None:
     """The test-runner image must not rely on installer fallback downloads."""

--- a/tests/unit/test_flux_conftest.py
+++ b/tests/unit/test_flux_conftest.py
@@ -265,10 +265,11 @@ class TestRecoverSuspendedFluxStructural:
         )
 
     @pytest.mark.requirement("AC-3")
-    def test_uses_flux_resume_command(self) -> None:
-        """_recover_suspended_flux uses 'flux resume helmrelease' to unsuspend.
+    def test_uses_flux_resume_with_kubectl_patch_fallback(self) -> None:
+        """_recover_suspended_flux can unsuspend without requiring the flux CLI.
 
-        Must use the flux CLI resume command, not kubectl patch.
+        The in-cluster E2E runner has kubectl but does not ship the flux CLI.
+        Recovery must still work there.
         """
         source = _conftest_source()
         recover_fn_match = re.search(
@@ -283,6 +284,10 @@ class TestRecoverSuspendedFluxStructural:
         assert re.search(r"flux.*resume.*helmrelease", fn_body), (
             "_recover_suspended_flux must use 'flux resume helmrelease' command. "
             "Found no matching pattern in the function body."
+        )
+        assert all(token in fn_body for token in ['"kubectl"', '"patch"', '"helmrelease"']), (
+            "_recover_suspended_flux must fall back to 'kubectl patch helmrelease' "
+            "when the flux CLI is unavailable."
         )
 
 
@@ -343,6 +348,7 @@ class TestRecoverSuspendedFluxBehavioral:
     def test_resumes_when_suspend_is_true(
         self,
         mock_subprocess: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Runs flux resume when kubectl reports suspend=true.
 
@@ -362,6 +368,7 @@ class TestRecoverSuspendedFluxBehavioral:
             return _make_completed_process(returncode=0)
 
         mock_subprocess.side_effect = _kubectl_side_effect
+        monkeypatch.setattr("tests.e2e.conftest.shutil.which", lambda command: "/usr/bin/flux")
 
         _recover_suspended_flux()
 
@@ -380,6 +387,7 @@ class TestRecoverSuspendedFluxBehavioral:
     def test_resumes_both_releases_when_both_suspended(
         self,
         mock_subprocess: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Resumes BOTH floe-platform and floe-jobs-test when both are suspended.
 
@@ -398,6 +406,7 @@ class TestRecoverSuspendedFluxBehavioral:
             return _make_completed_process(returncode=0)
 
         mock_subprocess.side_effect = _kubectl_side_effect
+        monkeypatch.setattr("tests.e2e.conftest.shutil.which", lambda command: "/usr/bin/flux")
 
         _recover_suspended_flux()
 
@@ -501,6 +510,7 @@ class TestRecoverSuspendedFluxBehavioral:
         self,
         mock_subprocess: MagicMock,
         caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Logs a WARNING when resuming a suspended HelmRelease.
 
@@ -520,6 +530,7 @@ class TestRecoverSuspendedFluxBehavioral:
             return _make_completed_process(returncode=0)
 
         mock_subprocess.side_effect = _kubectl_side_effect
+        monkeypatch.setattr("tests.e2e.conftest.shutil.which", lambda command: "/usr/bin/flux")
 
         with caplog.at_level(logging.WARNING):
             _recover_suspended_flux()
@@ -541,6 +552,7 @@ class TestRecoverSuspendedFluxBehavioral:
     def test_selective_resume_only_suspended_release(
         self,
         mock_subprocess: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Only resumes the release that is actually suspended, not both.
 
@@ -567,6 +579,7 @@ class TestRecoverSuspendedFluxBehavioral:
             return _make_completed_process(returncode=0)
 
         mock_subprocess.side_effect = _kubectl_side_effect
+        monkeypatch.setattr("tests.e2e.conftest.shutil.which", lambda command: "/usr/bin/flux")
 
         _recover_suspended_flux()
 
@@ -592,6 +605,52 @@ class TestRecoverSuspendedFluxBehavioral:
             f"Must NOT resume {_RELEASE_JOBS} when it is not suspended. "
             "Only suspended releases should be resumed."
         )
+
+    @pytest.mark.requirement("AC-3")
+    def test_falls_back_to_kubectl_patch_when_flux_cli_missing(
+        self,
+        mock_subprocess: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Uses kubectl patch when a suspended HelmRelease is detected without flux CLI."""
+        from tests.e2e.conftest import _recover_suspended_flux
+
+        monkeypatch.setattr("tests.e2e.conftest.shutil.which", lambda command: None)
+
+        def _kubectl_side_effect(
+            cmd: list[str], **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            """floe-platform is suspended, patch succeeds."""
+            if "kubectl" in cmd and "get" in cmd and "helmrelease" in cmd:
+                if _RELEASE_PLATFORM in cmd:
+                    return _make_completed_process(returncode=0, stdout="true")
+                return _make_completed_process(returncode=0, stdout="false")
+            if "kubectl" in cmd and "patch" in cmd and "helmrelease" in cmd:
+                return _make_completed_process(returncode=0)
+            return _make_completed_process(returncode=1, stderr="unexpected command")
+
+        mock_subprocess.side_effect = _kubectl_side_effect
+
+        _recover_suspended_flux()
+
+        patch_calls = [
+            c[0][0]
+            for c in mock_subprocess.call_args_list
+            if isinstance(c[0][0], list) and "patch" in c[0][0]
+        ]
+        assert patch_calls == [
+            [
+                "kubectl",
+                "patch",
+                "helmrelease",
+                _RELEASE_PLATFORM,
+                "-n",
+                "floe-test",
+                "--type=merge",
+                "-p",
+                '{"spec":{"suspend":false}}',
+            ]
+        ]
 
 
 # ===========================================================================

--- a/tests/unit/test_pod_recovery.py
+++ b/tests/unit/test_pod_recovery.py
@@ -353,6 +353,137 @@ dependencies:
         ]
 
     @pytest.mark.requirement("AC-2.7")
+    def test_uses_vendored_dependencies_without_network_repo_setup(
+        self,
+        tmp_path: Path,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """Vendored subcharts should avoid live repository access in E2E renders."""
+        chart_path = tmp_path / "chart"
+        vendored_path = chart_path / "charts"
+        vendored_path.mkdir(parents=True)
+        (chart_path / "Chart.yaml").write_text(
+            """
+apiVersion: v2
+name: test-chart
+version: 0.1.0
+dependencies:
+  - name: minio
+    version: 14.10.5
+    repository: https://charts.bitnami.com/bitnami
+  - name: opentelemetry-collector
+    alias: otel
+    version: 0.108.0
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  - name: cube
+    version: 0.1.0
+""",
+        )
+        (vendored_path / "minio-14.10.5.tgz").write_text("vendored")
+        (vendored_path / "otel-0.108.0.tgz").write_text("vendored")
+        (vendored_path / "cube").mkdir()
+        (vendored_path / "cube" / "Chart.yaml").write_text(
+            """
+apiVersion: v2
+name: cube
+version: 0.1.0
+""",
+        )
+        mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="rendered", stderr=""
+        )
+
+        result = run_helm_template("test-release", chart_path, timeout=60)
+
+        assert result.returncode == 0
+        commands = [call.args[0] for call in mock_subprocess.call_args_list]
+        assert commands == [["helm", "template", "test-release", str(chart_path)]]
+
+    @pytest.mark.requirement("AC-2.7")
+    def test_builds_dependencies_when_vendored_directory_version_is_stale(
+        self,
+        tmp_path: Path,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """Stale unpacked subcharts must not bypass Helm dependency build."""
+        chart_path = tmp_path / "chart"
+        vendored_path = chart_path / "charts"
+        vendored_path.mkdir(parents=True)
+        (chart_path / "Chart.yaml").write_text(
+            """
+apiVersion: v2
+name: test-chart
+version: 0.1.0
+dependencies:
+  - name: cube
+    version: 0.2.0
+""",
+        )
+        (vendored_path / "cube").mkdir()
+        (vendored_path / "cube" / "Chart.yaml").write_text(
+            """
+apiVersion: v2
+name: cube
+version: 0.1.0
+""",
+        )
+        mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="rendered", stderr=""
+        )
+
+        result = run_helm_template("test-release", chart_path, timeout=60)
+
+        assert result.returncode == 0
+        commands = [call.args[0] for call in mock_subprocess.call_args_list]
+        assert commands == [
+            ["helm", "dependency", "build", str(chart_path)],
+            ["helm", "template", "test-release", str(chart_path)],
+        ]
+
+    @pytest.mark.requirement("AC-2.7")
+    def test_builds_dependencies_when_vendored_archive_version_is_stale(
+        self,
+        tmp_path: Path,
+        mock_subprocess: MagicMock,
+    ) -> None:
+        """Stale chart archives must not satisfy newer Chart.yaml dependencies."""
+        chart_path = tmp_path / "chart"
+        vendored_path = chart_path / "charts"
+        vendored_path.mkdir(parents=True)
+        (chart_path / "Chart.yaml").write_text(
+            """
+apiVersion: v2
+name: test-chart
+version: 0.1.0
+dependencies:
+  - name: minio
+    version: 14.10.5
+    repository: https://charts.bitnami.com/bitnami
+""",
+        )
+        (vendored_path / "minio-14.10.4.tgz").write_text("stale")
+        mock_subprocess.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="rendered", stderr=""
+        )
+
+        result = run_helm_template("test-release", chart_path, timeout=60)
+
+        assert result.returncode == 0
+        commands = [call.args[0] for call in mock_subprocess.call_args_list]
+        assert commands == [
+            [
+                "helm",
+                "repo",
+                "add",
+                "minio",
+                "https://charts.bitnami.com/bitnami",
+                "--force-update",
+            ],
+            ["helm", "dependency", "build", str(chart_path)],
+            ["helm", "template", "test-release", str(chart_path)],
+        ]
+
+    @pytest.mark.requirement("AC-2.7")
     def test_returns_repo_add_failure_before_rendering(
         self,
         tmp_path: Path,

--- a/tests/unit/test_validation_boundary_markers.py
+++ b/tests/unit/test_validation_boundary_markers.py
@@ -10,6 +10,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 E2E_CONFTEST_PATH = REPO_ROOT / "tests" / "e2e" / "conftest.py"
+ROOT_CONFTEST_PATH = REPO_ROOT / "tests" / "conftest.py"
 
 pytestmark = pytest.mark.requirement("VAL-LANE-MARKERS")
 
@@ -19,6 +20,19 @@ def _load_e2e_conftest() -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         "tests.e2e.conftest_for_validation_markers",
         E2E_CONFTEST_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_root_conftest() -> ModuleType:
+    """Load the root tests conftest module lazily for structural tests."""
+    spec = importlib.util.spec_from_file_location(
+        "tests.conftest_for_validation_markers",
+        ROOT_CONFTEST_PATH,
     )
     assert spec is not None
     assert spec.loader is not None
@@ -57,9 +71,14 @@ class _FakeConfig:
     def __init__(self) -> None:
         self.lines: list[tuple[str, str]] = []
         self.option = SimpleNamespace(reruns=0, reruns_delay=0, fail_on_flaky=False, only_rerun=[])
+        self.hook = SimpleNamespace(pytest_deselected=self._record_deselected)
+        self.deselected_items: list[_FakeItem] = []
 
     def addinivalue_line(self, section: str, value: str) -> None:
         self.lines.append((section, value))
+
+    def _record_deselected(self, items: list[_FakeItem]) -> None:
+        self.deselected_items.extend(items)
 
 
 class _FakeItem:
@@ -135,6 +154,41 @@ def test_pytest_collection_modifyitems_defaults_unmarked_e2e_paths() -> None:
     assert items[1].marker_names == []
 
 
+def test_root_collection_deselects_live_aws_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default test collection should keep live AWS validation opt-in."""
+    monkeypatch.delenv("FLOE_RUN_LIVE_AWS_PROVIDER_TESTS", raising=False)
+    config = _FakeConfig()
+    items = [
+        _FakeItem("tests/integration/test_aws_provider_live.py::test_live", ["live_aws"]),
+        _FakeItem("tests/integration/test_other.py::test_other", ["integration"]),
+    ]
+
+    _load_root_conftest().pytest_collection_modifyitems(config, items)
+
+    assert [item.nodeid for item in items] == ["tests/integration/test_other.py::test_other"]
+    assert [item.nodeid for item in config.deselected_items] == [
+        "tests/integration/test_aws_provider_live.py::test_live"
+    ]
+
+
+def test_root_collection_keeps_live_aws_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit live AWS lanes should collect tests and enforce their prerequisites."""
+    monkeypatch.setenv("FLOE_RUN_LIVE_AWS_PROVIDER_TESTS", "1")
+    config = _FakeConfig()
+    items = [
+        _FakeItem("tests/integration/test_aws_provider_live.py::test_live", ["live_aws"]),
+        _FakeItem("tests/integration/test_other.py::test_other", ["integration"]),
+    ]
+
+    _load_root_conftest().pytest_collection_modifyitems(config, items)
+
+    assert [item.nodeid for item in items] == [
+        "tests/integration/test_aws_provider_live.py::test_live",
+        "tests/integration/test_other.py::test_other",
+    ]
+    assert config.deselected_items == []
+
+
 def test_selected_items_require_smoke_check_for_platform_blackbox() -> None:
     """Platform-blackbox selections should trigger the smoke check."""
     items = [
@@ -199,6 +253,19 @@ def test_platform_runtime_modules_are_explicitly_marked_platform_blackbox() -> N
 
     assert "pytest.mark.platform_blackbox" in platform_bootstrap
     assert "pytest.mark.platform_blackbox" in platform_deployment
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_direct_helm_status_fallback_respects_standard_runner_rbac() -> None:
+    """Direct-Helm fallback should only query resources allowed to standard E2E."""
+    platform_deployment = (
+        REPO_ROOT / "tests" / "e2e" / "test_platform_deployment_e2e.py"
+    ).read_text()
+
+    assert '"deployments,services"' in platform_deployment
+    assert '"deployments,statefulsets,services"' not in platform_deployment
+    assert '"floe-platform-dagster-webserver"' in platform_deployment
+    assert '"floe-platform-dagster-daemon"' in platform_deployment
 
 
 def test_developer_workflow_outliers_are_explicitly_marked() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1623,6 +1623,27 @@ requires-dist = [
 ]
 
 [[package]]
+name = "floe-catalog-glue"
+version = "0.1.0"
+source = { editable = "plugins/floe-catalog-glue" }
+dependencies = [
+    { name = "floe-core" },
+    { name = "pydantic" },
+    { name = "pyiceberg", extra = ["glue"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "floe-core", specifier = ">=0.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "pydantic", specifier = ">=2.0,<3.0" },
+    { name = "pyiceberg", extras = ["glue"], specifier = ">=0.11.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
+]
+
+[[package]]
 name = "floe-catalog-polaris"
 version = "0.1.0"
 source = { editable = "plugins/floe-catalog-polaris" }
@@ -2091,6 +2112,27 @@ requires-dist = [
 ]
 
 [[package]]
+name = "floe-storage-aws-s3"
+version = "0.1.0"
+source = { editable = "plugins/floe-storage-aws-s3" }
+dependencies = [
+    { name = "floe-core" },
+    { name = "pydantic" },
+    { name = "pyiceberg", extra = ["s3fs"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "floe-core", specifier = ">=0.1.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
+    { name = "pydantic", specifier = ">=2.0,<3.0" },
+    { name = "pyiceberg", extras = ["s3fs"], specifier = ">=0.11.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3" },
+]
+
+[[package]]
 name = "floe-storage-minio"
 version = "0.1.0"
 source = { editable = "plugins/floe-storage-minio" }
@@ -2164,6 +2206,7 @@ dependencies = [
     { name = "floe-alert-email" },
     { name = "floe-alert-slack" },
     { name = "floe-alert-webhook" },
+    { name = "floe-catalog-glue" },
     { name = "floe-catalog-polaris" },
     { name = "floe-compute-duckdb" },
     { name = "floe-core" },
@@ -2181,6 +2224,7 @@ dependencies = [
     { name = "floe-secrets-infisical" },
     { name = "floe-secrets-k8s" },
     { name = "floe-semantic-cube" },
+    { name = "floe-storage-aws-s3" },
     { name = "floe-storage-minio" },
     { name = "floe-telemetry-console" },
     { name = "floe-telemetry-jaeger" },
@@ -2230,6 +2274,7 @@ requires-dist = [
     { name = "floe-alert-email", editable = "plugins/floe-alert-email" },
     { name = "floe-alert-slack", editable = "plugins/floe-alert-slack" },
     { name = "floe-alert-webhook", editable = "plugins/floe-alert-webhook" },
+    { name = "floe-catalog-glue", editable = "plugins/floe-catalog-glue" },
     { name = "floe-catalog-polaris", editable = "plugins/floe-catalog-polaris" },
     { name = "floe-compute-duckdb", editable = "plugins/floe-compute-duckdb" },
     { name = "floe-core", editable = "packages/floe-core" },
@@ -2247,6 +2292,7 @@ requires-dist = [
     { name = "floe-secrets-infisical", editable = "plugins/floe-secrets-infisical" },
     { name = "floe-secrets-k8s", editable = "plugins/floe-secrets-k8s" },
     { name = "floe-semantic-cube", editable = "plugins/floe-semantic-cube" },
+    { name = "floe-storage-aws-s3", editable = "plugins/floe-storage-aws-s3" },
     { name = "floe-storage-minio", editable = "plugins/floe-storage-minio" },
     { name = "floe-telemetry-console", editable = "plugins/floe-telemetry-console" },
     { name = "floe-telemetry-jaeger", editable = "plugins/floe-telemetry-jaeger" },
@@ -4992,6 +5038,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+glue = [
+    { name = "boto3" },
+]
 s3fs = [
     { name = "s3fs" },
 ]


### PR DESCRIPTION
## Summary

- add live AWS provider validation for S3 storage + Glue catalog composition, including secret-free deployment/runtime binding checks and real S3/Glue cleanup paths
- fix the Glue catalog purge path uncovered by live validation and add regression coverage
- harden the in-cluster validation lanes: Dagster launch retry for narrow metadata-store transients, stronger materialization fixture isolation, RBAC-aware platform checks, configurable pytest args, vendored chart dependency handling, resource budgets, and Docker context exclusions
- update plugin instrumentation contract counts now that AWS S3 and Glue are first-party workspace plugins

## Validation

- `make test-unit` -> 10593 passed, 1 skipped, 1 xfailed, 6 warnings; coverage 87.64%
- `SKIP_BUILD=true WAIT_TIMEOUT=3600 make test-integration` -> 261 passed, 86 deselected, 7 warnings
- `SKIP_BUILD=true IMAGE_LOAD_METHOD=skip WAIT_TIMEOUT=3600 TEST_SUITE=e2e-destructive ./testing/ci/test-e2e-cluster.sh` -> 7 passed, 340 deselected
- live AWS provider test against account `278833447053` passed; post-run inventory verified 0 S3 objects under `runs/` and 0 `floe_provider_` Glue databases
- pre-push hooks passed: ruff, ruff format, mypy strict, dbt version requirements, bandit, uv-secure, unit tests + coverage, contract tests, hardcoded sleep guard, requirement traceability, docs validation, helm lint

## Notes

The product issue found during live validation was the Glue purge API path. The other failures were validation-infra confidence gaps: local Docker context size, direct-Helm/Flux mismatch, test runner RBAC visibility, and resource pressure under full Dagster/Postgres load.
