### PR TITLE
Harden AWS provider live validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,10 @@ DEVPOD_REMOTE_RUN_ROOT=/tmp/floe-devpod-e2e
 DEVPOD_REMOTE_E2E_TIMEOUT=7200
 DEVPOD_REMOTE_POLL_INTERVAL=20
 DEVPOD_REMOTE_POLL_FAILURE_LIMIT=30
+# Optional allowlist for env vars uploaded into the detached remote E2E run.
+# Values are sent over DevPod SSH stdin to a 0600 file inside the run directory.
+# make devpod-test-aws-provider sets the AWS live-test allowlist automatically.
+DEVPOD_REMOTE_ENV_ALLOWLIST=
 DEVPOD_UP_RECOVERY_TIMEOUT=600
 DEVPOD_UP_RECOVERY_INTERVAL=15
 # Set to 1 to skip automatic Kind/platform setup in the Hetzner postStart hook.
@@ -67,6 +71,18 @@ FLOE_DEVPOD_SKIP_POSTSTART_SETUP=0
 # Remote E2E runs inside the DevPod workspace network and skips host service
 # tunnels by default. Set to 1 only when you also need local browser/API access.
 DEVPOD_ENABLE_REMOTE_TUNNELS=0
+
+# Live AWS S3 + Glue provider validation.
+# These are normally generated from infra/aws-provider-tests OpenTofu outputs.
+# Export short-lived AWS credentials before running remote live validation, e.g.:
+#   eval "$(aws configure export-credentials --profile floe-aws-bootstrap --format env)"
+FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=0
+FLOE_PROVIDER_SPIKE_RUN=
+FLOE_AWS_REGION=
+FLOE_AWS_TEST_BUCKET=
+FLOE_AWS_TEST_PREFIX=runs/
+FLOE_AWS_GLUE_DATABASE_PREFIX=
+
 # Optional manifest override for local/test runners; defaults to demo/manifest.yaml
 FLOE_MANIFEST_PATH=
 # Optional demo image repository override for local/Kind validation

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help: ## Show this help message
 	@echo "  make test-integration Run integration tests (requires K8s)"
 	@echo "  make test-e2e        Run E2E tests in-cluster (auto-detects Kind/DevPod)"
 	@echo "  make test-e2e-full   Run standard + destructive E2E suites sequentially"
+	@echo "  make test-aws-provider-live Run opt-in live AWS S3 + Glue provider tests"
 	@echo "  make test-e2e-host   Run E2E tests via host port-forwards (legacy)"
 	@echo ""
 	@echo "Cluster Management:"
@@ -62,6 +63,7 @@ help: ## Show this help message
 	@echo "Contributor Remote Validation (DevPod + Hetzner):"
 	@echo "  make devpod-setup    One-time Hetzner provider setup from .env"
 	@echo "  make devpod-test     Run contributor E2E validation on DevPod"
+	@echo "  make devpod-test-aws-provider Run live AWS S3 + Glue provider tests on DevPod"
 	@echo "  make devpod-delete   Delete DevPod workspace (stops billing)"
 	@echo "  make devpod-status   Show workspace status, tunnels, and cluster health"
 	@echo "  make devpod-up       Create/start contributor DevPod workspace"
@@ -143,6 +145,11 @@ test-e2e: ## Run E2E tests in-cluster as K8s Job (auto-detects Kind/DevPod)
 test-e2e-full: ## Run standard + destructive E2E suites sequentially
 	@echo "Running full E2E test suite..."
 	@./testing/ci/test-e2e-full.sh
+
+.PHONY: test-aws-provider-live
+test-aws-provider-live: ## Run opt-in live AWS S3 + Glue provider tests
+	@echo "Running live AWS provider tests..."
+	@uv run pytest tests/integration/test_aws_provider_live.py -q
 
 .PHONY: test-e2e-host
 test-e2e-host: ## Run E2E tests via host port-forwards (legacy, requires running services)
@@ -733,6 +740,16 @@ devpod-setup: devpod-check ## One-time Hetzner provider setup from .env
 .PHONY: devpod-test
 devpod-test: devpod-check ## Run contributor E2E validation on DevPod
 	@bash scripts/devpod-test.sh
+
+.PHONY: devpod-test-aws-provider
+devpod-test-aws-provider: devpod-check ## Run live AWS S3 + Glue provider tests on DevPod
+	@FLOE_PROVIDER_SPIKE_RUN="$${FLOE_PROVIDER_SPIKE_RUN:-floe-provider-$$(date -u +%Y%m%dT%H%M%SZ)}"; \
+	export FLOE_PROVIDER_SPIKE_RUN; \
+	export FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1; \
+	export DEVPOD_REMOTE_E2E_MAKE_TARGET=test-aws-provider-live; \
+	export DEVPOD_REMOTE_ENV_ALLOWLIST="FLOE_RUN_LIVE_AWS_PROVIDER_TESTS FLOE_PROVIDER_SPIKE_RUN FLOE_AWS_REGION FLOE_AWS_TEST_BUCKET FLOE_AWS_TEST_PREFIX FLOE_AWS_GLUE_DATABASE_PREFIX AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGION AWS_DEFAULT_REGION"; \
+	echo "Running DevPod live AWS provider validation with FLOE_PROVIDER_SPIKE_RUN=$${FLOE_PROVIDER_SPIKE_RUN}"; \
+	bash scripts/devpod-test.sh
 
 .PHONY: devpod-delete
 devpod-delete: devpod-check ## Delete DevPod workspace (stops billing)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-e2e-full: ## Run standard + destructive E2E suites sequentially
 .PHONY: test-aws-provider-live
 test-aws-provider-live: ## Run opt-in live AWS S3 + Glue provider tests
 	@echo "Running live AWS provider tests..."
-	@uv run pytest tests/integration/test_aws_provider_live.py -q
+	@FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1 uv run pytest tests/integration/test_aws_provider_live.py -q
 
 .PHONY: test-e2e-host
 test-e2e-host: ## Run E2E tests via host port-forwards (legacy, requires running services)

--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -44,6 +44,11 @@
 #                        after HelmReleases settle.
 #   DEVPOD_REMOTE_FLUX_STATEFULSETS Space-separated StatefulSets to wait for
 #                        after HelmReleases settle.
+#   DEVPOD_REMOTE_ENV_ALLOWLIST Space-separated local environment variable names
+#                        to upload into the detached remote E2E run. Values are
+#                        written through DevPod SSH stdin to a 0600 file and
+#                        sourced by the remote run script. Use for opt-in live
+#                        provider validation only.
 #   DEVPOD_UP_RECOVERY_TIMEOUT Seconds to poll workspace status after a
 #                        transport-level `devpod up` failure (default: 600).
 #   DEVPOD_ENABLE_REMOTE_TUNNELS Set to 1 to establish host service tunnels
@@ -85,12 +90,15 @@ DEVPOD_REMOTE_FLUX_SOURCE_NAMESPACE="${DEVPOD_REMOTE_FLUX_SOURCE_NAMESPACE:-flux
 DEVPOD_REMOTE_FLUX_HELMRELEASES="${DEVPOD_REMOTE_FLUX_HELMRELEASES:-floe-platform floe-jobs-test}"
 DEVPOD_REMOTE_FLUX_DEPLOYMENTS="${DEVPOD_REMOTE_FLUX_DEPLOYMENTS:-floe-platform-dagster-webserver floe-platform-polaris floe-platform-minio floe-platform-jaeger floe-platform-marquez floe-platform-otel}"
 DEVPOD_REMOTE_FLUX_STATEFULSETS="${DEVPOD_REMOTE_FLUX_STATEFULSETS:-floe-platform-postgresql}"
+DEVPOD_REMOTE_ENV_ALLOWLIST="${DEVPOD_REMOTE_ENV_ALLOWLIST:-}"
 DEVPOD_UP_RECOVERY_TIMEOUT="${DEVPOD_UP_RECOVERY_TIMEOUT:-600}"
 DEVPOD_UP_RECOVERY_INTERVAL="${DEVPOD_UP_RECOVERY_INTERVAL:-15}"
 DEVPOD_ENABLE_REMOTE_TUNNELS="${DEVPOD_ENABLE_REMOTE_TUNNELS:-0}"
 REMOTE_RUN_ID="run-$(date -u '+%Y%m%dT%H%M%SZ')-$$"
 REMOTE_RUN_DIR="${DEVPOD_REMOTE_RUN_ROOT}/${REMOTE_RUN_ID}"
 LOCAL_REMOTE_ARTIFACTS_DIR="${PROJECT_ROOT}/test-artifacts/devpod-${REMOTE_RUN_ID}"
+REMOTE_ENV_FILE="${REMOTE_RUN_DIR}/remote-env.sh"
+LOCAL_REMOTE_ENV_FILE=""
 
 # Track whether we created the workspace (for cleanup decisions)
 WORKSPACE_CREATED=false
@@ -151,6 +159,10 @@ cleanup() {
             error "Failed to delete workspace '${WORKSPACE}'!"
             error "MANUAL ACTION REQUIRED: Run 'devpod delete ${WORKSPACE} --force' or delete the VM in Hetzner Cloud Console."
         fi
+    fi
+
+    if [[ -n "${LOCAL_REMOTE_ENV_FILE}" ]]; then
+        rm -f "${LOCAL_REMOTE_ENV_FILE}" 2>/dev/null || true
     fi
 
     # Propagate the test exit code, not the cleanup exit code
@@ -225,6 +237,13 @@ if [[ -z "${DEVPOD_REMOTE_E2E_MAKE_TARGET}" ]]; then
     exit 1
 fi
 
+for env_name in ${DEVPOD_REMOTE_ENV_ALLOWLIST}; do
+    if [[ ! "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        error "Invalid DEVPOD_REMOTE_ENV_ALLOWLIST entry '${env_name}'"
+        exit 1
+    fi
+done
+
 for kube_name in "${DEVPOD_REMOTE_FLUX_GITREPOSITORY}" "${DEVPOD_REMOTE_FLUX_SOURCE_NAMESPACE}"; do
     if [[ ! "${kube_name}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
         error "Invalid Flux resource name '${kube_name}'"
@@ -272,6 +291,60 @@ provision_workspace() {
     fi
 
     recover_workspace_after_up_failure
+}
+
+prepare_remote_run_dir() {
+    local run_dir_q
+    run_dir_q="$(shell_quote "${REMOTE_RUN_DIR}")"
+    devpod_remote_bash "mkdir -p ${run_dir_q}/artifacts && chmod 700 ${run_dir_q}"
+}
+
+build_local_remote_env_file() {
+    local env_file
+    local env_name
+    local uploaded_names=()
+
+    if [[ -z "${DEVPOD_REMOTE_ENV_ALLOWLIST}" ]]; then
+        return 0
+    fi
+
+    env_file="$(mktemp "${TMPDIR:-/tmp}/floe-devpod-remote-env.XXXXXX")"
+    chmod 600 "${env_file}"
+
+    for env_name in ${DEVPOD_REMOTE_ENV_ALLOWLIST}; do
+        if [[ -v "${env_name}" ]]; then
+            printf 'export %s=%q\n' "${env_name}" "${!env_name}" >> "${env_file}"
+            uploaded_names+=("${env_name}")
+        else
+            log "  Remote env allowlist entry '${env_name}' is unset locally; skipping"
+        fi
+    done
+
+    if [[ "${#uploaded_names[@]}" -eq 0 ]]; then
+        rm -f "${env_file}"
+        error "DEVPOD_REMOTE_ENV_ALLOWLIST was set but no listed variables were present locally"
+        return 1
+    fi
+
+    LOCAL_REMOTE_ENV_FILE="${env_file}"
+    log "  Remote env upload prepared for: ${uploaded_names[*]}"
+}
+
+upload_remote_env_file() {
+    local remote_env_q
+
+    if [[ -z "${LOCAL_REMOTE_ENV_FILE}" ]]; then
+        return 0
+    fi
+
+    remote_env_q="$(shell_quote "${REMOTE_ENV_FILE}")"
+    if devpod_remote_bash "umask 077 && cat > ${remote_env_q} && chmod 600 ${remote_env_q}" < "${LOCAL_REMOTE_ENV_FILE}"; then
+        log "  Remote env allowlist uploaded to ${REMOTE_ENV_FILE}"
+        return 0
+    fi
+
+    error "Failed to upload remote env allowlist"
+    return 1
 }
 
 start_remote_e2e_run() {
@@ -449,6 +522,11 @@ wait_for_flux_settlement() {
     echo "[remote-e2e] started at \$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     echo "[remote-e2e] workdir=\${FLOE_REMOTE_WORKDIR}"
     cd "\${FLOE_REMOTE_WORKDIR}"
+    if [[ -f "\${FLOE_REMOTE_RUN_DIR}/remote-env.sh" ]]; then
+        echo "[remote-e2e] sourcing remote env allowlist"
+        # shellcheck disable=SC1091
+        source "\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"
+    fi
     SKIP_MONITORING=\${SKIP_MONITORING:-true} make kind-up
     wait_for_flux_settlement
     flux_rc=\$?
@@ -599,6 +677,10 @@ run_remote_e2e_detached() {
     local remote_dir=""
     local exit_code=""
     local poll_status=0
+
+    prepare_remote_run_dir || return 1
+    build_local_remote_env_file || return 1
+    upload_remote_env_file || return 1
 
     log "Starting detached remote E2E run in ${REMOTE_RUN_DIR}..."
     remote_dir="$(start_remote_e2e_run)" || return 1

--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -97,7 +97,7 @@ DEVPOD_ENABLE_REMOTE_TUNNELS="${DEVPOD_ENABLE_REMOTE_TUNNELS:-0}"
 REMOTE_RUN_ID="run-$(date -u '+%Y%m%dT%H%M%SZ')-$$"
 REMOTE_RUN_DIR="${DEVPOD_REMOTE_RUN_ROOT}/${REMOTE_RUN_ID}"
 LOCAL_REMOTE_ARTIFACTS_DIR="${PROJECT_ROOT}/test-artifacts/devpod-${REMOTE_RUN_ID}"
-REMOTE_ENV_FILE="${REMOTE_RUN_DIR}/remote-env.sh"
+REMOTE_ENV_FILE="${REMOTE_RUN_DIR}.remote-env.sh"
 LOCAL_REMOTE_ENV_FILE=""
 
 # Track whether we created the workspace (for cleanup decisions)
@@ -358,6 +358,7 @@ start_remote_e2e_run() {
     local flux_helmreleases_q
     local flux_deployments_q
     local flux_statefulsets_q
+    local remote_env_file_q
     local remote_script
     local start_output=""
     local start_status=0
@@ -372,6 +373,7 @@ start_remote_e2e_run() {
     flux_helmreleases_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_HELMRELEASES}")"
     flux_deployments_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_DEPLOYMENTS}")"
     flux_statefulsets_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_STATEFULSETS}")"
+    remote_env_file_q="$(shell_quote "${REMOTE_ENV_FILE}")"
 
     remote_script=$(cat <<REMOTE_SCRIPT
 set -euo pipefail
@@ -522,10 +524,10 @@ wait_for_flux_settlement() {
     echo "[remote-e2e] started at \$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     echo "[remote-e2e] workdir=\${FLOE_REMOTE_WORKDIR}"
     cd "\${FLOE_REMOTE_WORKDIR}"
-    if [[ -f "\${FLOE_REMOTE_RUN_DIR}/remote-env.sh" ]]; then
+    if [[ -n "\${FLOE_REMOTE_ENV_FILE:-}" && -f "\${FLOE_REMOTE_ENV_FILE}" ]]; then
         echo "[remote-e2e] sourcing remote env allowlist"
         # shellcheck disable=SC1091
-        source "\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"
+        source "\${FLOE_REMOTE_ENV_FILE}"
     fi
     SKIP_MONITORING=\${SKIP_MONITORING:-true} make kind-up
     wait_for_flux_settlement
@@ -545,6 +547,7 @@ exit 0
 REMOTE_RUN
 chmod +x "\${run_dir}/run.sh"
 FLOE_REMOTE_WORKDIR="\${workdir}" FLOE_REMOTE_RUN_DIR="\${run_dir}" FLOE_REMOTE_E2E_MAKE_TARGET="\${make_target}" \
+    FLOE_REMOTE_ENV_FILE=${remote_env_file_q} \
     FLOE_REMOTE_FLUX_SETTLEMENT_TIMEOUT=${flux_settlement_timeout_q} \
     FLOE_REMOTE_FLUX_SETTLEMENT_INTERVAL=${flux_settlement_interval_q} \
     FLOE_REMOTE_FLUX_GITREPOSITORY=${flux_gitrepository_q} \

--- a/tests/integration/test_aws_provider_live.py
+++ b/tests/integration/test_aws_provider_live.py
@@ -14,7 +14,11 @@ from floe_core.runtime_catalog_connection import build_runtime_catalog_connectio
 from floe_iceberg.runtime_catalog import runtime_catalog_connection_to_pyiceberg_config
 from floe_storage_aws_s3.config import AwsS3ObjectStoreConfig
 from floe_storage_aws_s3.plugin import AwsS3ObjectStorePlugin
-from pyiceberg.exceptions import NamespaceAlreadyExistsError, NoSuchNamespaceError
+from pyiceberg.exceptions import (
+    NamespaceAlreadyExistsError,
+    NoSuchNamespaceError,
+    TableAlreadyExistsError,
+)
 from pyiceberg.schema import Schema
 from pyiceberg.types import NestedField, StringType
 
@@ -67,21 +71,22 @@ def _assert_secret_values_are_not_embedded(payload: str) -> None:
             assert value not in payload
 
 
-def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Validate the real AWS S3 and Glue path through resolved deployment bindings."""
+def _live_aws_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[
+    dict[str, str],
+    AwsS3ObjectStorePlugin,
+    GlueCatalogPlugin,
+    str,
+    str,
+    dict[str, object],
+]:
     env = _require_live_aws_env()
     region = env["FLOE_AWS_REGION"]
     bucket = env["FLOE_AWS_TEST_BUCKET"]
     run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
     run_prefix = f"{env['FLOE_AWS_TEST_PREFIX']}{run_id}/"
     requested_namespace = _run_database_name(env)
-    # AWS Glue stores database names in lowercase even when callers provide
-    # mixed-case run identifiers, so follow its canonical catalog shape after
-    # proving create_namespace accepts the requested Floe cleanup target.
-    catalog_namespace = requested_namespace.lower()
-    table_identifier = f"{catalog_namespace}.provider_validation"
-    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_validation"
-    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-validation.txt"
 
     monkeypatch.setenv("AWS_REGION", region)
     monkeypatch.setenv("AWS_DEFAULT_REGION", region)
@@ -96,6 +101,7 @@ def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.Monk
         )
     )
     storage_binding = storage_plugin.get_deployment_binding()
+    assert storage_binding.warehouse is not None
 
     catalog_plugin = GlueCatalogPlugin(
         GlueCatalogConfig(
@@ -125,6 +131,36 @@ def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.Monk
     _assert_secret_values_are_not_embedded(runtime_connection.model_dump_json())
     _assert_secret_values_are_not_embedded(repr(pyiceberg_config))
 
+    return env, storage_plugin, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config
+
+
+def _cleanup_glue_namespace(catalog_plugin: GlueCatalogPlugin, catalog_namespace: str) -> None:
+    try:
+        for table_identifier in catalog_plugin.list_tables(catalog_namespace):
+            try:
+                catalog_plugin.drop_table(table_identifier, purge=True)
+            except Exception:  # noqa: BLE001
+                LOGGER.warning("Best-effort AWS Glue table cleanup failed", exc_info=True)
+        catalog_plugin.delete_namespace(catalog_namespace)
+    except NoSuchNamespaceError:
+        pass
+
+
+def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validate the real AWS S3 and Glue path through resolved deployment bindings."""
+    env, storage_plugin, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config = (
+        _live_aws_context(monkeypatch)
+    )
+    bucket = env["FLOE_AWS_TEST_BUCKET"]
+    run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
+    # AWS Glue stores database names in lowercase even when callers provide
+    # mixed-case run identifiers, so follow its canonical catalog shape after
+    # proving create_namespace accepts the requested Floe cleanup target.
+    catalog_namespace = requested_namespace.lower()
+    table_identifier = f"{catalog_namespace}.provider_validation"
+    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_validation"
+    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-validation.txt"
+
     fileio = storage_plugin.get_pyiceberg_fileio()
     expected_payload = f"floe live provider validation: {run_id}\n".encode()
     with fileio.new_output(object_location).create(overwrite=True) as output:
@@ -151,11 +187,84 @@ def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.Monk
         )
         assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
     finally:
+        _cleanup_glue_namespace(catalog_plugin, catalog_namespace)
+
+
+def test_live_aws_s3_fileio_overwrite_mutates_existing_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validate S3 object mutation and overwrite semantics through PyIceberg FileIO."""
+    env, storage_plugin, _, run_prefix, _, _ = _live_aws_context(monkeypatch)
+    bucket = env["FLOE_AWS_TEST_BUCKET"]
+    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-mutation.txt"
+    fileio = storage_plugin.get_pyiceberg_fileio()
+
+    with fileio.new_output(object_location).create(overwrite=True) as output:
+        output.write(b"initial payload\n")
+    with fileio.new_input(object_location).open() as input_file:
+        assert input_file.read() == b"initial payload\n"
+
+    with pytest.raises(FileExistsError):
+        with fileio.new_output(object_location).create(overwrite=False) as output:
+            output.write(b"unexpected payload\n")
+
+    with fileio.new_output(object_location).create(overwrite=True) as output:
+        output.write(b"mutated payload\n")
+    with fileio.new_input(object_location).open() as input_file:
+        assert input_file.read() == b"mutated payload\n"
+
+
+def test_live_aws_glue_table_lifecycle_edges_and_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validate Glue duplicate-table edge behavior plus drop/recreate lifecycle mutation."""
+    env, _, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config = _live_aws_context(
+        monkeypatch
+    )
+    bucket = env["FLOE_AWS_TEST_BUCKET"]
+    run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
+    catalog_namespace = requested_namespace.lower()
+    table_identifier = f"{catalog_namespace}.provider_lifecycle"
+    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_lifecycle"
+    schema_v1 = Schema(NestedField(1, "run_id", StringType(), required=True))
+    schema_v2 = Schema(
+        NestedField(1, "run_id", StringType(), required=True),
+        NestedField(2, "mutation_id", StringType(), required=False),
+    )
+
+    catalog_plugin.connect(pyiceberg_config)
+    try:
         try:
-            catalog_plugin.drop_table(table_identifier, purge=True)
-        except Exception:  # noqa: BLE001
-            LOGGER.warning("Best-effort AWS Glue table cleanup failed", exc_info=True)
-        try:
-            catalog_plugin.delete_namespace(catalog_namespace)
-        except NoSuchNamespaceError:
-            pass
+            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+        except NamespaceAlreadyExistsError:
+            _cleanup_glue_namespace(catalog_plugin, catalog_namespace)
+            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+
+        catalog_plugin.create_table(
+            table_identifier,
+            schema_v1,  # type: ignore[arg-type]
+            location=table_location,
+            properties={"floe.provider.test.run": run_id, "floe.provider.test.phase": "initial"},
+        )
+        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+
+        with pytest.raises(TableAlreadyExistsError):
+            catalog_plugin.create_table(
+                table_identifier,
+                schema_v1,  # type: ignore[arg-type]
+                location=table_location,
+                properties={"floe.provider.test.phase": "duplicate"},
+            )
+
+        catalog_plugin.drop_table(table_identifier, purge=True)
+        assert table_identifier not in catalog_plugin.list_tables(catalog_namespace)
+
+        catalog_plugin.create_table(
+            table_identifier,
+            schema_v2,  # type: ignore[arg-type]
+            location=table_location,
+            properties={"floe.provider.test.run": run_id, "floe.provider.test.phase": "mutated"},
+        )
+        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+    finally:
+        _cleanup_glue_namespace(catalog_plugin, catalog_namespace)

--- a/tests/integration/test_aws_provider_live.py
+++ b/tests/integration/test_aws_provider_live.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 import pytest
 from floe_catalog_glue.config import GlueCatalogConfig
@@ -38,6 +39,17 @@ REQUIRED_ENV = (
     "FLOE_AWS_GLUE_DATABASE_PREFIX",
     "FLOE_PROVIDER_SPIKE_RUN",
 )
+AWS_SECRET_ENV_NAME_MARKERS = ("ACCESS_KEY", "SECRET", "SESSION_TOKEN", "SECURITY_TOKEN")
+
+
+@dataclass(frozen=True)
+class LiveAwsContext:
+    env: dict[str, str]
+    storage_plugin: AwsS3ObjectStorePlugin
+    catalog_plugin: GlueCatalogPlugin
+    run_prefix: str
+    requested_namespace: str
+    pyiceberg_config: dict[str, object]
 
 
 def _require_live_aws_env() -> dict[str, str]:
@@ -65,7 +77,12 @@ def _run_database_name(env: Mapping[str, str]) -> str:
 
 
 def _assert_secret_values_are_not_embedded(payload: str) -> None:
-    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+    secret_env_names = [
+        name
+        for name in os.environ
+        if name.startswith("AWS_") and any(marker in name for marker in AWS_SECRET_ENV_NAME_MARKERS)
+    ]
+    for name in secret_env_names:
         value = os.environ.get(name)
         if value:
             assert value not in payload
@@ -73,14 +90,7 @@ def _assert_secret_values_are_not_embedded(payload: str) -> None:
 
 def _live_aws_context(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[
-    dict[str, str],
-    AwsS3ObjectStorePlugin,
-    GlueCatalogPlugin,
-    str,
-    str,
-    dict[str, object],
-]:
+) -> LiveAwsContext:
     env = _require_live_aws_env()
     region = env["FLOE_AWS_REGION"]
     bucket = env["FLOE_AWS_TEST_BUCKET"]
@@ -131,7 +141,14 @@ def _live_aws_context(
     _assert_secret_values_are_not_embedded(runtime_connection.model_dump_json())
     _assert_secret_values_are_not_embedded(repr(pyiceberg_config))
 
-    return env, storage_plugin, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config
+    return LiveAwsContext(
+        env=env,
+        storage_plugin=storage_plugin,
+        catalog_plugin=catalog_plugin,
+        run_prefix=run_prefix,
+        requested_namespace=requested_namespace,
+        pyiceberg_config=pyiceberg_config,
+    )
 
 
 def _cleanup_glue_namespace(catalog_plugin: GlueCatalogPlugin, catalog_namespace: str) -> None:
@@ -148,56 +165,60 @@ def _cleanup_glue_namespace(catalog_plugin: GlueCatalogPlugin, catalog_namespace
 
 def test_live_aws_s3_glue_runtime_composition_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
     """Validate the real AWS S3 and Glue path through resolved deployment bindings."""
-    env, storage_plugin, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config = (
-        _live_aws_context(monkeypatch)
-    )
-    bucket = env["FLOE_AWS_TEST_BUCKET"]
-    run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
+    context = _live_aws_context(monkeypatch)
+    bucket = context.env["FLOE_AWS_TEST_BUCKET"]
+    run_id = context.env["FLOE_PROVIDER_SPIKE_RUN"]
     # AWS Glue stores database names in lowercase even when callers provide
     # mixed-case run identifiers, so follow its canonical catalog shape after
     # proving create_namespace accepts the requested Floe cleanup target.
-    catalog_namespace = requested_namespace.lower()
+    catalog_namespace = context.requested_namespace.lower()
     table_identifier = f"{catalog_namespace}.provider_validation"
-    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_validation"
-    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-validation.txt"
+    table_location = f"s3://{bucket}/{context.run_prefix}warehouse/provider_validation"
+    object_location = f"s3://{bucket}/{context.run_prefix}artifacts/provider-validation.txt"
 
-    fileio = storage_plugin.get_pyiceberg_fileio()
+    fileio = context.storage_plugin.get_pyiceberg_fileio()
     expected_payload = f"floe live provider validation: {run_id}\n".encode()
     with fileio.new_output(object_location).create(overwrite=True) as output:
         output.write(expected_payload)
     with fileio.new_input(object_location).open() as input_file:
         assert input_file.read() == expected_payload
 
-    catalog_plugin.connect(pyiceberg_config)
+    context.catalog_plugin.connect(context.pyiceberg_config)
     try:
         try:
-            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+            context.catalog_plugin.create_namespace(
+                context.requested_namespace,
+                {"floe.provider.test.run": run_id},
+            )
         except NamespaceAlreadyExistsError:
-            catalog_plugin.delete_namespace(catalog_namespace)
-            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+            context.catalog_plugin.delete_namespace(catalog_namespace)
+            context.catalog_plugin.create_namespace(
+                context.requested_namespace,
+                {"floe.provider.test.run": run_id},
+            )
 
-        assert catalog_namespace in catalog_plugin.list_namespaces()
+        assert catalog_namespace in context.catalog_plugin.list_namespaces()
 
         schema = Schema(NestedField(1, "run_id", StringType(), required=True))
-        catalog_plugin.create_table(
+        context.catalog_plugin.create_table(
             table_identifier,
             schema,  # type: ignore[arg-type]
             location=table_location,
             properties={"floe.provider.test.run": run_id},
         )
-        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+        assert table_identifier in context.catalog_plugin.list_tables(catalog_namespace)
     finally:
-        _cleanup_glue_namespace(catalog_plugin, catalog_namespace)
+        _cleanup_glue_namespace(context.catalog_plugin, catalog_namespace)
 
 
 def test_live_aws_s3_fileio_overwrite_mutates_existing_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Validate S3 object mutation and overwrite semantics through PyIceberg FileIO."""
-    env, storage_plugin, _, run_prefix, _, _ = _live_aws_context(monkeypatch)
-    bucket = env["FLOE_AWS_TEST_BUCKET"]
-    object_location = f"s3://{bucket}/{run_prefix}artifacts/provider-mutation.txt"
-    fileio = storage_plugin.get_pyiceberg_fileio()
+    context = _live_aws_context(monkeypatch)
+    bucket = context.env["FLOE_AWS_TEST_BUCKET"]
+    object_location = f"s3://{bucket}/{context.run_prefix}artifacts/provider-mutation.txt"
+    fileio = context.storage_plugin.get_pyiceberg_fileio()
 
     with fileio.new_output(object_location).create(overwrite=True) as output:
         output.write(b"initial payload\n")
@@ -218,53 +239,57 @@ def test_live_aws_glue_table_lifecycle_edges_and_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Validate Glue duplicate-table edge behavior plus drop/recreate lifecycle mutation."""
-    env, _, catalog_plugin, run_prefix, requested_namespace, pyiceberg_config = _live_aws_context(
-        monkeypatch
-    )
-    bucket = env["FLOE_AWS_TEST_BUCKET"]
-    run_id = env["FLOE_PROVIDER_SPIKE_RUN"]
-    catalog_namespace = requested_namespace.lower()
+    context = _live_aws_context(monkeypatch)
+    bucket = context.env["FLOE_AWS_TEST_BUCKET"]
+    run_id = context.env["FLOE_PROVIDER_SPIKE_RUN"]
+    catalog_namespace = context.requested_namespace.lower()
     table_identifier = f"{catalog_namespace}.provider_lifecycle"
-    table_location = f"s3://{bucket}/{run_prefix}warehouse/provider_lifecycle"
+    table_location = f"s3://{bucket}/{context.run_prefix}warehouse/provider_lifecycle"
     schema_v1 = Schema(NestedField(1, "run_id", StringType(), required=True))
     schema_v2 = Schema(
         NestedField(1, "run_id", StringType(), required=True),
         NestedField(2, "mutation_id", StringType(), required=False),
     )
 
-    catalog_plugin.connect(pyiceberg_config)
+    context.catalog_plugin.connect(context.pyiceberg_config)
     try:
         try:
-            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+            context.catalog_plugin.create_namespace(
+                context.requested_namespace,
+                {"floe.provider.test.run": run_id},
+            )
         except NamespaceAlreadyExistsError:
-            _cleanup_glue_namespace(catalog_plugin, catalog_namespace)
-            catalog_plugin.create_namespace(requested_namespace, {"floe.provider.test.run": run_id})
+            _cleanup_glue_namespace(context.catalog_plugin, catalog_namespace)
+            context.catalog_plugin.create_namespace(
+                context.requested_namespace,
+                {"floe.provider.test.run": run_id},
+            )
 
-        catalog_plugin.create_table(
+        context.catalog_plugin.create_table(
             table_identifier,
             schema_v1,  # type: ignore[arg-type]
             location=table_location,
             properties={"floe.provider.test.run": run_id, "floe.provider.test.phase": "initial"},
         )
-        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+        assert table_identifier in context.catalog_plugin.list_tables(catalog_namespace)
 
         with pytest.raises(TableAlreadyExistsError):
-            catalog_plugin.create_table(
+            context.catalog_plugin.create_table(
                 table_identifier,
                 schema_v1,  # type: ignore[arg-type]
                 location=table_location,
                 properties={"floe.provider.test.phase": "duplicate"},
             )
 
-        catalog_plugin.drop_table(table_identifier, purge=True)
-        assert table_identifier not in catalog_plugin.list_tables(catalog_namespace)
+        context.catalog_plugin.drop_table(table_identifier, purge=True)
+        assert table_identifier not in context.catalog_plugin.list_tables(catalog_namespace)
 
-        catalog_plugin.create_table(
+        context.catalog_plugin.create_table(
             table_identifier,
             schema_v2,  # type: ignore[arg-type]
             location=table_location,
             properties={"floe.provider.test.run": run_id, "floe.provider.test.phase": "mutated"},
         )
-        assert table_identifier in catalog_plugin.list_tables(catalog_namespace)
+        assert table_identifier in context.catalog_plugin.list_tables(catalog_namespace)
     finally:
-        _cleanup_glue_namespace(catalog_plugin, catalog_namespace)
+        _cleanup_glue_namespace(context.catalog_plugin, catalog_namespace)

--- a/tests/unit/test_devpod_aws_provider_remote_validation.py
+++ b/tests/unit/test_devpod_aws_provider_remote_validation.py
@@ -31,7 +31,10 @@ def test_devpod_wrapper_uploads_allowlisted_remote_env_without_echoing_values() 
     assert 'printf \'export %s=%q\\n\' "${env_name}" "${!env_name}"' in script
     assert 'devpod_remote_bash "umask 077 && cat > ${remote_env_q}' in script
     assert 'chmod 600 ${remote_env_q}" < "${LOCAL_REMOTE_ENV_FILE}"' in script
-    assert 'source "\\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"' in script
+    assert 'REMOTE_ENV_FILE="${REMOTE_RUN_DIR}.remote-env.sh"' in script
+    assert "FLOE_REMOTE_ENV_FILE=${remote_env_file_q}" in script
+    assert 'source "\\${FLOE_REMOTE_ENV_FILE}"' in script
+    assert 'source "\\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"' not in script
     assert 'echo "${!env_name}"' not in script
 
 
@@ -51,7 +54,11 @@ def test_makefile_exposes_devpod_aws_provider_live_target() -> None:
     makefile = _read_makefile()
 
     assert ".PHONY: test-aws-provider-live" in makefile
-    assert "uv run pytest tests/integration/test_aws_provider_live.py -q" in makefile
+    local_target = (
+        "FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1 "
+        "uv run pytest tests/integration/test_aws_provider_live.py -q"
+    )
+    assert local_target in makefile
     assert ".PHONY: devpod-test-aws-provider" in makefile
     target_env = "DEVPOD_REMOTE_E2E_MAKE_TARGET=" + "test-aws-provider-live"
     assert target_env in makefile

--- a/tests/unit/test_devpod_aws_provider_remote_validation.py
+++ b/tests/unit/test_devpod_aws_provider_remote_validation.py
@@ -1,0 +1,73 @@
+"""Structural coverage for DevPod-hosted live AWS provider validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEVPOD_SCRIPT_PATH = _REPO_ROOT / "scripts" / "devpod-test.sh"
+_MAKEFILE_PATH = _REPO_ROOT / "Makefile"
+_ENV_EXAMPLE_PATH = _REPO_ROOT / ".env.example"
+
+
+def _read_devpod_script() -> str:
+    """Return the DevPod validation wrapper contents."""
+    return _DEVPOD_SCRIPT_PATH.read_text()
+
+
+def _read_makefile() -> str:
+    """Return the current Makefile contents."""
+    return _MAKEFILE_PATH.read_text()
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_devpod_wrapper_uploads_allowlisted_remote_env_without_echoing_values() -> None:
+    """Remote live provider runs must receive secrets through a private env file."""
+    script = _read_devpod_script()
+
+    assert "DEVPOD_REMOTE_ENV_ALLOWLIST" in script
+    assert 'printf \'export %s=%q\\n\' "${env_name}" "${!env_name}"' in script
+    assert 'devpod_remote_bash "umask 077 && cat > ${remote_env_q}' in script
+    assert 'chmod 600 ${remote_env_q}" < "${LOCAL_REMOTE_ENV_FILE}"' in script
+    assert 'source "\\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"' in script
+    assert 'echo "${!env_name}"' not in script
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_devpod_wrapper_validates_remote_env_allowlist_names() -> None:
+    """The env allowlist must reject shell metacharacters before any remote command."""
+    script = _read_devpod_script()
+
+    assert "for env_name in ${DEVPOD_REMOTE_ENV_ALLOWLIST}; do" in script
+    assert '[[ ! "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]' in script
+    assert "Invalid DEVPOD_REMOTE_ENV_ALLOWLIST entry" in script
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_makefile_exposes_devpod_aws_provider_live_target() -> None:
+    """AWS S3 + Glue live validation must be runnable from the DevPod lifecycle."""
+    makefile = _read_makefile()
+
+    assert ".PHONY: test-aws-provider-live" in makefile
+    assert "uv run pytest tests/integration/test_aws_provider_live.py -q" in makefile
+    assert ".PHONY: devpod-test-aws-provider" in makefile
+    target_env = "DEVPOD_REMOTE_E2E_MAKE_TARGET=" + "test-aws-provider-live"
+    assert target_env in makefile
+    assert "FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1" in makefile
+    assert "AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN" in makefile
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_env_example_documents_remote_aws_live_validation_inputs() -> None:
+    """Contributor setup must make the remote AWS live-test controls discoverable."""
+    env_example = _ENV_EXAMPLE_PATH.read_text()
+
+    assert "DEVPOD_REMOTE_ENV_ALLOWLIST=" in env_example
+    assert "make devpod-test-aws-provider sets the AWS live-test allowlist" in env_example
+    assert (
+        "aws configure export-credentials --profile floe-aws-bootstrap --format env" in env_example
+    )
+    assert "FLOE_AWS_TEST_BUCKET=" in env_example
+    assert "FLOE_AWS_GLUE_DATABASE_PREFIX=" in env_example


### PR DESCRIPTION
## Summary

- expands live AWS S3 + Glue provider validation from a single round trip to happy-path, overwrite/mutation, duplicate-table, drop, and recreate lifecycle coverage
- adds `make test-aws-provider-live` plus `make devpod-test-aws-provider` so the live AWS provider suite runs from the DevPod + Hetzner lifecycle
- adds a DevPod remote env allowlist that uploads selected env vars over SSH stdin to a 0600 `remote-env.sh`, avoiding log-based credential exposure
- documents the remote AWS live-test inputs in `.env.example`

## Validation

- `uv run ruff check tests/unit/test_devpod_aws_provider_remote_validation.py tests/integration/test_aws_provider_live.py && uv run ruff format --check tests/unit/test_devpod_aws_provider_remote_validation.py tests/integration/test_aws_provider_live.py`
- `uv run mypy --strict tests/unit/test_devpod_aws_provider_remote_validation.py tests/integration/test_aws_provider_live.py`
- `uv run pytest tests/unit/test_devpod_aws_provider_remote_validation.py tests/unit/test_e2e_runner_devpod_path.py -q`
- `FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1 uv run pytest tests/integration/test_aws_provider_live.py --collect-only -q`
- local live AWS run before DevPod uplift: `AWS_PROFILE=floe-aws-bootstrap FLOE_RUN_LIVE_AWS_PROVIDER_TESTS=1 uv run pytest tests/integration/test_aws_provider_live.py -q` -> `3 passed in 10.61s`
- DevPod + Hetzner trunk validation: `DEVPOD_WORKSPACE=floe-provider-20260512234548 DEVPOD_GIT_REF=main DEVPOD_REMOTE_E2E_MAKE_TARGET=test-e2e-full make devpod-test` -> bootstrap/platform/developer/destructive all passed; artifacts: `test-artifacts/devpod-run-20260512T234548Z-8607`
- DevPod + Hetzner AWS live validation: `DEVPOD_WORKSPACE=floe-aws-provider-20260513003028 DEVPOD_GIT_REF=feat/aws-live-validation-uplift make devpod-test-aws-provider` -> Flux settled at `a5b15765dbf44a04c127aae494e60b068fcaaebd`; `tests/integration/test_aws_provider_live.py ... [100%]`; `3 passed in 43.98s`; artifacts: `test-artifacts/devpod-run-20260513T003028Z-57642`

## Cleanup

- `scripts/aws-provider-test-cleanup.sh` cleared `runs/floe-provider-20260513T003028Z/` and verified no Glue database remains
- `devpod list` is empty after both remote runs
- direct Hetzner API inventory found no matching servers, volumes, SSH keys, load balancers, or floating IPs for `floe-provider-20260512234548`, `floe-provi-7d406`, `floe-aws-provider-20260513003028`, or `floe-aws-p-e875c`
