### PR TITLE
Scrub DevPod remote AWS env file after sourcing

### DIFF
--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -347,6 +347,17 @@ upload_remote_env_file() {
     return 1
 }
 
+delete_remote_env_file() {
+    local remote_env_q
+
+    if [[ -z "${REMOTE_ENV_FILE}" ]]; then
+        return 0
+    fi
+
+    remote_env_q="$(shell_quote "${REMOTE_ENV_FILE}")"
+    devpod_remote_bash "rm -f ${remote_env_q}" >/dev/null 2>&1 || true
+}
+
 start_remote_e2e_run() {
     local run_dir_q
     local workdir_q
@@ -386,6 +397,12 @@ cat > "\${run_dir}/run.sh" <<'REMOTE_RUN'
 #!/usr/bin/env bash
 set +e
 mkdir -p "\${FLOE_REMOTE_RUN_DIR}/artifacts"
+cleanup_remote_env_file() {
+    if [[ -n "\${FLOE_REMOTE_ENV_FILE:-}" ]]; then
+        rm -f "\${FLOE_REMOTE_ENV_FILE}" 2>/dev/null || true
+    fi
+}
+trap cleanup_remote_env_file EXIT
 resolve_flux_ref_commit() {
     local ref_type="\${1:?ref type required}"
     local ref_name="\${2:?ref name required}"
@@ -528,6 +545,7 @@ wait_for_flux_settlement() {
         echo "[remote-e2e] sourcing remote env allowlist"
         # shellcheck disable=SC1091
         source "\${FLOE_REMOTE_ENV_FILE}"
+        cleanup_remote_env_file
     fi
     SKIP_MONITORING=\${SKIP_MONITORING:-true} make kind-up
     wait_for_flux_settlement
@@ -686,7 +704,10 @@ run_remote_e2e_detached() {
     upload_remote_env_file || return 1
 
     log "Starting detached remote E2E run in ${REMOTE_RUN_DIR}..."
-    remote_dir="$(start_remote_e2e_run)" || return 1
+    remote_dir="$(start_remote_e2e_run)" || {
+        delete_remote_env_file
+        return 1
+    }
     log "Remote E2E started: ${remote_dir}"
 
     exit_code="$(poll_remote_e2e_run)"

--- a/tests/unit/test_devpod_aws_provider_remote_validation.py
+++ b/tests/unit/test_devpod_aws_provider_remote_validation.py
@@ -34,6 +34,10 @@ def test_devpod_wrapper_uploads_allowlisted_remote_env_without_echoing_values() 
     assert 'REMOTE_ENV_FILE="${REMOTE_RUN_DIR}.remote-env.sh"' in script
     assert "FLOE_REMOTE_ENV_FILE=${remote_env_file_q}" in script
     assert 'source "\\${FLOE_REMOTE_ENV_FILE}"' in script
+    assert "cleanup_remote_env_file()" in script
+    assert "trap cleanup_remote_env_file EXIT" in script
+    assert 'rm -f "\\${FLOE_REMOTE_ENV_FILE}"' in script
+    assert "delete_remote_env_file()" in script
     assert 'source "\\${FLOE_REMOTE_RUN_DIR}/remote-env.sh"' not in script
     assert 'echo "${!env_name}"' not in script
 


### PR DESCRIPTION
## Summary

- removes the uploaded DevPod remote AWS env file immediately after the remote run sources it
- adds an EXIT trap in the remote run script as a second cleanup path
- adds best-effort remote cleanup if detached run startup fails
- extends structural coverage for the security-sensitive remote env path

## Context

Follow-up to PR #336 after a late review comment noted that moving the env file outside the artifact directory prevents artifact exposure, but still leaves credentials on disk if workspace teardown fails.

## Validation

- `bash -n scripts/devpod-test.sh`
- `uv run pytest tests/unit/test_devpod_aws_provider_remote_validation.py tests/unit/test_e2e_runner_devpod_path.py -q`
- `uv run ruff check tests/unit/test_devpod_aws_provider_remote_validation.py`
- `uv run ruff format --check tests/unit/test_devpod_aws_provider_remote_validation.py`
- `uv run mypy --strict tests/unit/test_devpod_aws_provider_remote_validation.py tests/integration/test_aws_provider_live.py`
- pre-push gate passed: lint, format, strict mypy, dbt requirements, Bandit, uv-secure, unit coverage, contract tests, no-hardcoded-sleep, requirement traceability, docs validation, Helm lint