### PR TITLE
Automate alpha release gate before tagging

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -9,10 +9,12 @@ validates that manifest before release-specific workflows publish artifacts.
 | Trigger | Workflow | Purpose |
 |---|---|---|
 | Pull request | `ci.yml` | Fast PR confidence plus release manifest structure |
-| `merge_group` / pull request label `run-e2e` / infra path / manual | `e2e.yml` | Full E2E validation |
-| Tag `v*.*.*` | `release.yml` and `pypi-publish.yml` | Manifest validation, integration, release, package build/publish |
+| `merge_group` / pull request label `run-e2e` / infra path / manual | `e2e.yml` | Opt-in full E2E validation |
+| Manual | `prepare-release.yml` | Runs all release gates, creates tag and GitHub Release only on success |
+| Successful Prepare Release | `pypi-publish.yml` | Builds and publishes the manifest package set |
+| Manual | `release.yml` | Release-validation smoke only; does not create tags or GitHub Releases |
 | Tag `helm-v*` / `charts-v*` / manual | `helm-release.yaml` | Helm chart release when manifest policy allows |
-| Schedule | `weekly.yml`, `security.yml`, `codspeed.yml` | Drift, security, performance maintenance |
+| Schedule / manual | `weekly.yml`, `security.yml`, `codspeed.yml` | Drift, security, performance maintenance |
 
 `helm-ci.yaml` remains the merge-confidence chart lane for pull requests and
 pushes to `main`; it validates chart linting, rendering, schema, unit, diff,
@@ -47,12 +49,28 @@ platform change:
 Failures should be classified as product, infrastructure, credential/setup, or
 cleanup failures before deciding whether to rerun or block the release.
 
+## Prepare Release
+
+`prepare-release.yml` is the release authority. Maintainers dispatch it with a
+version. The workflow runs static gates, package build dry-run, Kind
+integration, full DevPod+Hetzner E2E, AWS S3+Glue live validation, cleanup
+verification, and evidence generation. It creates the tag and GitHub Release
+only after all gates pass.
+
+Dry runs execute the same gates without creating a tag, GitHub Release, or PyPI
+publication. Real runs use `dry_run=false`; that successful workflow run uploads
+the release metadata consumed by `pypi-publish.yml`.
+
+If a release gate fails, the workflow creates or updates a GitHub issue and
+records which outputs were skipped. Product, infrastructure, credential/setup,
+and cleanup failures must remain separate in triage.
+
 ## Release Confidence
 
-`release.yml`, `pypi-publish.yml`, and `helm-release.yaml` form the release
-confidence lanes. They should fail before publishing when the release manifest,
-package cutline, artifact counts, version normalization, Helm policy, or release
-evidence is invalid.
+`prepare-release.yml`, `pypi-publish.yml`, and `helm-release.yaml` form the
+release confidence lanes. They should fail before publishing when the release
+manifest, package cutline, artifact counts, version normalization, Helm policy,
+or release evidence is invalid.
 
 For the alpha Helm lane, `release/floe-release.yaml` is the publish contract:
 `helm.alpha_policy` must be `publish`, `release.helm_version` supplies the
@@ -62,9 +80,14 @@ not replace the manifest-declared chart list or policy. Chart metadata is live
 release input for `helm-release.yaml`, while `helm-ci.yaml` remains the
 merge-confidence lane for validating chart changes before they reach release.
 
+`release.yml` remains a manual release-validation smoke workflow for maintainers
+who want a narrower integration check. It does not create release tags, GitHub
+Releases, or PyPI publications.
+
 `weekly.yml`, `security.yml`, and `codspeed.yml` remain scheduled or manual
 maintenance lanes. They provide drift, security, and performance signal without
-turning every PR into an expensive live-validation run.
+turning every PR into an expensive live-validation run. Weekly long-running
+validation failures create or update GitHub issues.
 
 ## Local Checks
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,547 @@
+name: Prepare Release
+
+run-name: Prepare Release ${{ inputs.version }} dry_run=${{ inputs.dry_run }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to prepare, for example v0.1.0-alpha.1"
+        required: true
+        type: string
+      dry_run:
+        description: "Run gates without creating tag, GitHub Release, or PyPI publication"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: prepare-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION_DEFAULT: "3.10"
+  UV_CACHE_DIR: /tmp/.uv-cache
+
+jobs:
+  resolve-candidate:
+    name: Resolve Candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_sha: ${{ steps.sha.outputs.release_sha }}
+      version: ${{ inputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve release SHA and existing tags
+        id: sha
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags --force
+          release_sha="$(git rev-parse origin/main)"
+          echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
+          git tag --list > existing-tags.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Validate release candidate
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r tag; do
+            args+=(--existing-tag "$tag")
+          done < existing-tags.txt
+          uv run python -m testing.release.cli candidate \
+            --manifest release/floe-release.yaml \
+            --version "${{ inputs.version }}" \
+            --release-sha "${{ steps.sha.outputs.release_sha }}" \
+            "${args[@]}"
+
+  static-and-contract-gates:
+    name: Static And Contract Gates
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run static and contract gates
+        run: |
+          set -euo pipefail
+          uv run ruff check .
+          uv run ruff format --check .
+          uv run mypy --strict packages/ testing/
+          uv run pytest tests/contract/ packages/*/tests/contract/ -q
+          uv run python -m testing.release.cli validate \
+            --manifest release/floe-release.yaml \
+            --tag "${{ inputs.version }}"
+
+  package-build-dry-run:
+    name: Package Build Dry Run
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build manifest packages
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli build \
+            --manifest release/floe-release.yaml \
+            --dist-dir dist
+
+      - name: Upload package dry-run artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package-build-dry-run
+          path: dist/
+          if-no-files-found: error
+
+  kind-integration:
+    name: Kind Integration
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Create Kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: floe-release
+          config: testing/k8s/kind-config.yaml
+
+      - name: Run integration tests
+        run: ./testing/ci/test-integration.sh
+        env:
+          TEST_NAMESPACE: floe-test
+          KIND_CLUSTER_NAME: floe-release
+
+      - name: Collect logs on failure
+        if: failure()
+        run: ./testing/ci/collect-logs.sh floe-test
+
+      - name: Cleanup Kind
+        if: always()
+        run: kind delete cluster --name floe-release || true
+
+  full-e2e:
+    name: Full DevPod E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Install DevPod
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-amd64 \
+            -o /tmp/devpod
+          sudo install -m 0755 /tmp/devpod /usr/local/bin/devpod
+          devpod version
+
+      - name: Configure DevPod Hetzner provider
+        run: |
+          set -euo pipefail
+          {
+            printf 'DEVPOD_HETZNER_TOKEN=%s\n' "${DEVPOD_HETZNER_TOKEN}"
+            printf 'DEVPOD_MACHINE_TYPE=%s\n' "${DEVPOD_MACHINE_TYPE}"
+            printf 'DEVPOD_REGION=%s\n' "${DEVPOD_REGION}"
+          } > .env
+          make devpod-setup
+        env:
+          DEVPOD_HETZNER_TOKEN: ${{ secrets.DEVPOD_HETZNER_TOKEN }}
+          DEVPOD_MACHINE_TYPE: ${{ vars.DEVPOD_MACHINE_TYPE || 'ccx33' }}
+          DEVPOD_REGION: ${{ vars.DEVPOD_REGION || 'sin' }}
+
+      - name: Run full E2E on DevPod and Hetzner
+        run: make devpod-test
+        env:
+          DEVPOD_SOURCE: git:https://github.com/Obsidian-Owl/floe@${{ needs.resolve-candidate.outputs.release_sha }}
+          DEVPOD_WORKSPACE: floe-release-e2e-${{ github.run_id }}
+          DEVPOD_REMOTE_E2E_MAKE_TARGET: test-e2e-full
+          DEVPOD_REMOTE_E2E_TIMEOUT: "10800"
+
+      - name: Upload DevPod artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: devpod-full-e2e
+          path: test-artifacts/devpod-*
+          if-no-files-found: warn
+
+  aws-live:
+    name: AWS S3 And Glue Live
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Install DevPod
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/loft-sh/devpod/releases/latest/download/devpod-linux-amd64 \
+            -o /tmp/devpod
+          sudo install -m 0755 /tmp/devpod /usr/local/bin/devpod
+          devpod version
+
+      - name: Configure DevPod Hetzner provider
+        run: |
+          set -euo pipefail
+          {
+            printf 'DEVPOD_HETZNER_TOKEN=%s\n' "${DEVPOD_HETZNER_TOKEN}"
+            printf 'DEVPOD_MACHINE_TYPE=%s\n' "${DEVPOD_MACHINE_TYPE}"
+            printf 'DEVPOD_REGION=%s\n' "${DEVPOD_REGION}"
+          } > .env
+          make devpod-setup
+        env:
+          DEVPOD_HETZNER_TOKEN: ${{ secrets.DEVPOD_HETZNER_TOKEN }}
+          DEVPOD_MACHINE_TYPE: ${{ vars.DEVPOD_MACHINE_TYPE || 'ccx33' }}
+          DEVPOD_REGION: ${{ vars.DEVPOD_REGION || 'sin' }}
+
+      - name: Run AWS live provider tests on DevPod
+        run: make devpod-test-aws-provider
+        env:
+          DEVPOD_SOURCE: git:https://github.com/Obsidian-Owl/floe@${{ needs.resolve-candidate.outputs.release_sha }}
+          DEVPOD_WORKSPACE: floe-release-aws-${{ github.run_id }}
+          FLOE_PROVIDER_SPIKE_RUN: release-${{ inputs.version }}-${{ github.run_id }}
+          FLOE_AWS_REGION: ${{ vars.FLOE_AWS_REGION }}
+          FLOE_AWS_TEST_BUCKET: ${{ vars.FLOE_AWS_TEST_BUCKET }}
+          FLOE_AWS_TEST_PREFIX: ${{ vars.FLOE_AWS_TEST_PREFIX }}
+          FLOE_AWS_GLUE_DATABASE_PREFIX: ${{ vars.FLOE_AWS_GLUE_DATABASE_PREFIX }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.FLOE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.FLOE_AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.FLOE_AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ vars.FLOE_AWS_REGION }}
+          AWS_DEFAULT_REGION: ${{ vars.FLOE_AWS_REGION }}
+
+      - name: Upload AWS provider artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: aws-provider-live
+          path: test-artifacts/devpod-*
+          if-no-files-found: warn
+
+  cleanup-verify:
+    name: Cleanup Verify
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, full-e2e, aws-live]
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    outputs:
+      cleanup_status: ${{ steps.summary.outputs.cleanup_status }}
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Summarize cleanup
+        id: summary
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli cleanup-summary \
+            --devpod passed \
+            --hetzner passed \
+            --aws passed > cleanup-summary.json
+          status="$(python -c 'import json; print(json.load(open("cleanup-summary.json"))["status"])')"
+          echo "cleanup_status=${status}" >> "$GITHUB_OUTPUT"
+          test "${status}" = "passed"
+
+      - name: Upload cleanup summary
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cleanup-summary
+          path: cleanup-summary.json
+          if-no-files-found: warn
+
+  release-evidence:
+    name: Release Evidence
+    runs-on: ubuntu-latest
+    needs:
+      - resolve-candidate
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Write evidence
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli evidence-summary \
+            --release-sha "${{ needs.resolve-candidate.outputs.release_sha }}" \
+            --manifest release/floe-release.yaml \
+            --devpod-artifact "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --aws-live-result passed \
+            --cleanup-result "${{ needs.cleanup-verify.outputs.cleanup_status }}" \
+            --output release-evidence.md
+
+      - name: Upload release evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-evidence
+          path: release-evidence.md
+          if-no-files-found: error
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: ${{ success() && inputs.dry_run == false }}
+    needs:
+      - resolve-candidate
+      - static-and-contract-gates
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+      - release-evidence
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+          fetch-depth: 0
+
+      - name: Download release evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-evidence
+
+      - name: Write release metadata
+        run: |
+          set -euo pipefail
+          mkdir -p release-metadata
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          metadata = {
+              "tag": os.environ["RELEASE_TAG"],
+              "sha": os.environ["RELEASE_SHA"],
+              "version": os.environ["RELEASE_VERSION"],
+          }
+          Path("release-metadata/release-metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+        env:
+          RELEASE_TAG: ${{ inputs.version }}
+          RELEASE_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
+          RELEASE_VERSION: ${{ inputs.version }}
+
+      - name: Upload release metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-metadata
+          path: release-metadata/release-metadata.json
+          if-no-files-found: error
+
+      - name: Create annotated tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.version }}" \
+            -m "Release ${{ inputs.version }}" \
+            "${{ needs.resolve-candidate.outputs.release_sha }}"
+          git push origin "${{ inputs.version }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: Release ${{ inputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(inputs.version, '-') }}
+          files: release-evidence.md
+
+  failure-issue:
+    name: Failure Issue
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - resolve-candidate
+      - static-and-contract-gates
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+      - release-evidence
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build issue content
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli failure-issue \
+            --lane release-gate \
+            --version "${{ inputs.version }}" \
+            --gate unknown \
+            --classification release-tooling \
+            --sha "${{ needs.resolve-candidate.outputs.release_sha || github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --log-excerpt "See workflow artifacts and failed job logs." \
+            --cleanup-status "${{ needs.cleanup-verify.outputs.cleanup_status || 'not-run' }}" \
+            --skipped-output tag \
+            --skipped-output github-release \
+            --skipped-output pypi \
+            --output issue.json
+
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="$(python -c 'import json; print(json.load(open("issue.json"))["title"])')"
+          body="$(python -c 'import json; print(json.load(open("issue.json"))["body"])')"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "$title" \
+              --body "$body" \
+              --label ci-failure \
+              --label release-gate \
+              --label release-tooling-failure
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,20 +31,30 @@ jobs:
       contents: read
     outputs:
       release_sha: ${{ steps.sha.outputs.release_sha }}
+      python_version: ${{ steps.candidate.outputs.python_version }}
+      helm_version: ${{ steps.candidate.outputs.helm_version }}
       version: ${{ inputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Resolve release SHA and existing tags
+      - name: Resolve dispatch SHA and existing tags
         id: sha
         run: |
           set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "::error::Prepare Release must be dispatched from main; got ${GITHUB_REF_NAME}."
+            exit 1
+          fi
           git fetch origin main --tags --force
-          release_sha="$(git rev-parse origin/main)"
+          release_sha="$(git rev-parse HEAD)"
+          if [[ "${release_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::Checked-out release SHA ${release_sha} does not match dispatch SHA ${GITHUB_SHA}."
+            exit 1
+          fi
           echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
           git tag --list > existing-tags.txt
 
@@ -63,6 +73,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Validate release candidate
+        id: candidate
         run: |
           set -euo pipefail
           args=()
@@ -73,7 +84,18 @@ jobs:
             --manifest release/floe-release.yaml \
             --version "${{ inputs.version }}" \
             --release-sha "${{ steps.sha.outputs.release_sha }}" \
-            "${args[@]}"
+            "${args[@]}" > candidate.json
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          candidate = json.loads(Path("candidate.json").read_text(encoding="utf-8"))
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"python_version={candidate['python_version']}\n")
+              output.write(f"helm_version={candidate['helm_version']}\n")
+              output.write(f"publish_count={candidate['publish_count']}\n")
+          PY
 
   static-and-contract-gates:
     name: Static And Contract Gates
@@ -222,11 +244,26 @@ jobs:
       - name: Configure DevPod Hetzner provider
         run: |
           set -euo pipefail
+          case "${DEVPOD_HETZNER_TOKEN}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::DEVPOD_HETZNER_TOKEN must be a single-line token."
+              exit 1
+              ;;
+          esac
+          if [[ ! "${DEVPOD_MACHINE_TYPE}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid DEVPOD_MACHINE_TYPE."
+            exit 1
+          fi
+          if [[ ! "${DEVPOD_REGION}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid DEVPOD_REGION."
+            exit 1
+          fi
           {
             printf 'DEVPOD_HETZNER_TOKEN=%s\n' "${DEVPOD_HETZNER_TOKEN}"
             printf 'DEVPOD_MACHINE_TYPE=%s\n' "${DEVPOD_MACHINE_TYPE}"
             printf 'DEVPOD_REGION=%s\n' "${DEVPOD_REGION}"
           } > .env
+          chmod 0600 .env
           make devpod-setup
         env:
           DEVPOD_HETZNER_TOKEN: ${{ secrets.DEVPOD_HETZNER_TOKEN }}
@@ -273,11 +310,26 @@ jobs:
       - name: Configure DevPod Hetzner provider
         run: |
           set -euo pipefail
+          case "${DEVPOD_HETZNER_TOKEN}" in
+            *$'\n'*|*$'\r'*)
+              echo "::error::DEVPOD_HETZNER_TOKEN must be a single-line token."
+              exit 1
+              ;;
+          esac
+          if [[ ! "${DEVPOD_MACHINE_TYPE}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid DEVPOD_MACHINE_TYPE."
+            exit 1
+          fi
+          if [[ ! "${DEVPOD_REGION}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid DEVPOD_REGION."
+            exit 1
+          fi
           {
             printf 'DEVPOD_HETZNER_TOKEN=%s\n' "${DEVPOD_HETZNER_TOKEN}"
             printf 'DEVPOD_MACHINE_TYPE=%s\n' "${DEVPOD_MACHINE_TYPE}"
             printf 'DEVPOD_REGION=%s\n' "${DEVPOD_REGION}"
           } > .env
+          chmod 0600 .env
           make devpod-setup
         env:
           DEVPOD_HETZNER_TOKEN: ${{ secrets.DEVPOD_HETZNER_TOKEN }}
@@ -338,13 +390,26 @@ jobs:
         id: summary
         run: |
           set -euo pipefail
+          devpod_status="passed"
+          hetzner_status="passed"
+          aws_status="passed"
+          if [[ "${FULL_E2E_RESULT}" != "success" ]]; then
+            devpod_status="failed: full-e2e job ${FULL_E2E_RESULT}"
+            hetzner_status="failed: full-e2e job ${FULL_E2E_RESULT}"
+          fi
+          if [[ "${AWS_LIVE_RESULT}" != "success" ]]; then
+            aws_status="failed: aws-live job ${AWS_LIVE_RESULT}"
+          fi
           uv run python -m testing.release.cli cleanup-summary \
-            --devpod passed \
-            --hetzner passed \
-            --aws passed > cleanup-summary.json
+            --devpod "${devpod_status}" \
+            --hetzner "${hetzner_status}" \
+            --aws "${aws_status}" > cleanup-summary.json
           status="$(python -c 'import json; print(json.load(open("cleanup-summary.json"))["status"])')"
           echo "cleanup_status=${status}" >> "$GITHUB_OUTPUT"
           test "${status}" = "passed"
+        env:
+          FULL_E2E_RESULT: ${{ needs.full-e2e.result }}
+          AWS_LIVE_RESULT: ${{ needs.aws-live.result }}
 
       - name: Upload cleanup summary
         if: always()
@@ -386,13 +451,20 @@ jobs:
       - name: Write evidence
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2153
+          aws_live_result="failed: aws-live job ${AWS_LIVE_RESULT}"
+          if [[ "${AWS_LIVE_RESULT}" == "success" ]]; then
+            aws_live_result="passed"
+          fi
           uv run python -m testing.release.cli evidence-summary \
             --release-sha "${{ needs.resolve-candidate.outputs.release_sha }}" \
             --manifest release/floe-release.yaml \
             --devpod-artifact "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --aws-live-result passed \
+            --aws-live-result "${aws_live_result}" \
             --cleanup-result "${{ needs.cleanup-verify.outputs.cleanup_status }}" \
             --output release-evidence.md
+        env:
+          AWS_LIVE_RESULT: ${{ needs.aws-live.result }}
 
       - name: Upload release evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -450,7 +522,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.version }}
           RELEASE_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_VERSION: ${{ needs.resolve-candidate.outputs.python_version }}
 
       - name: Upload release metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -513,19 +585,60 @@ jobs:
       - name: Build issue content
         run: |
           set -euo pipefail
+          failed_gate="unknown"
+          failed_result="failure"
+          for gate in \
+            static-and-contract-gates="${STATIC_AND_CONTRACT_GATES_RESULT}" \
+            package-build-dry-run="${PACKAGE_BUILD_DRY_RUN_RESULT}" \
+            kind-integration="${KIND_INTEGRATION_RESULT}" \
+            full-e2e="${FULL_E2E_RESULT}" \
+            aws-live="${AWS_LIVE_RESULT}" \
+            cleanup-verify="${CLEANUP_VERIFY_RESULT}" \
+            release-evidence="${RELEASE_EVIDENCE_RESULT}"; do
+            name="${gate%%=*}"
+            result="${gate#*=}"
+            if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
+              failed_gate="${name}"
+              failed_result="${result}"
+              break
+            fi
+          done
+          classification="release-tooling"
+          case "${failed_gate}" in
+            aws-live)
+              classification="credential-setup"
+              ;;
+            full-e2e|kind-integration)
+              classification="infrastructure"
+              ;;
+            cleanup-verify)
+              classification="cleanup"
+              ;;
+            static-and-contract-gates|package-build-dry-run|release-evidence)
+              classification="product"
+              ;;
+          esac
           uv run python -m testing.release.cli failure-issue \
             --lane release-gate \
             --version "${{ inputs.version }}" \
-            --gate unknown \
-            --classification release-tooling \
+            --gate "${failed_gate}" \
+            --classification "${classification}" \
             --sha "${{ needs.resolve-candidate.outputs.release_sha || github.sha }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --log-excerpt "See workflow artifacts and failed job logs." \
+            --log-excerpt "Gate ${failed_gate} completed with result ${failed_result}. See workflow artifacts and failed job logs." \
             --cleanup-status "${{ needs.cleanup-verify.outputs.cleanup_status || 'not-run' }}" \
             --skipped-output tag \
             --skipped-output github-release \
             --skipped-output pypi \
             --output issue.json
+        env:
+          STATIC_AND_CONTRACT_GATES_RESULT: ${{ needs.static-and-contract-gates.result }}
+          PACKAGE_BUILD_DRY_RUN_RESULT: ${{ needs.package-build-dry-run.result }}
+          KIND_INTEGRATION_RESULT: ${{ needs.kind-integration.result }}
+          FULL_E2E_RESULT: ${{ needs.full-e2e.result }}
+          AWS_LIVE_RESULT: ${{ needs.aws-live.result }}
+          CLEANUP_VERIFY_RESULT: ${{ needs.cleanup-verify.result }}
+          RELEASE_EVIDENCE_RESULT: ${{ needs.release-evidence.result }}
 
       - name: Create or update issue
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -531,20 +531,11 @@ jobs:
           path: release-metadata/release-metadata.json
           if-no-files-found: error
 
-      - name: Create annotated tag
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ inputs.version }}" \
-            -m "Release ${{ inputs.version }}" \
-            "${{ needs.resolve-candidate.outputs.release_sha }}"
-          git push origin "${{ inputs.version }}"
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2
         with:
           tag_name: ${{ inputs.version }}
+          target_commitish: ${{ needs.resolve-candidate.outputs.release_sha }}
           name: Release ${{ inputs.version }}
           generate_release_notes: true
           draft: false
@@ -564,6 +555,7 @@ jobs:
       - aws-live
       - cleanup-verify
       - release-evidence
+      - create-release
     permissions:
       contents: read
       issues: write
@@ -588,13 +580,15 @@ jobs:
           failed_gate="unknown"
           failed_result="failure"
           for gate in \
+            resolve-candidate="${RESOLVE_CANDIDATE_RESULT}" \
             static-and-contract-gates="${STATIC_AND_CONTRACT_GATES_RESULT}" \
             package-build-dry-run="${PACKAGE_BUILD_DRY_RUN_RESULT}" \
             kind-integration="${KIND_INTEGRATION_RESULT}" \
             full-e2e="${FULL_E2E_RESULT}" \
             aws-live="${AWS_LIVE_RESULT}" \
             cleanup-verify="${CLEANUP_VERIFY_RESULT}" \
-            release-evidence="${RELEASE_EVIDENCE_RESULT}"; do
+            release-evidence="${RELEASE_EVIDENCE_RESULT}" \
+            create-release="${CREATE_RELEASE_RESULT}"; do
             name="${gate%%=*}"
             result="${gate#*=}"
             if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
@@ -614,6 +608,9 @@ jobs:
             cleanup-verify)
               classification="cleanup"
               ;;
+            resolve-candidate|create-release)
+              classification="release-tooling"
+              ;;
             static-and-contract-gates|package-build-dry-run|release-evidence)
               classification="product"
               ;;
@@ -632,6 +629,7 @@ jobs:
             --skipped-output pypi \
             --output issue.json
         env:
+          RESOLVE_CANDIDATE_RESULT: ${{ needs.resolve-candidate.result }}
           STATIC_AND_CONTRACT_GATES_RESULT: ${{ needs.static-and-contract-gates.result }}
           PACKAGE_BUILD_DRY_RUN_RESULT: ${{ needs.package-build-dry-run.result }}
           KIND_INTEGRATION_RESULT: ${{ needs.kind-integration.result }}
@@ -639,6 +637,7 @@ jobs:
           AWS_LIVE_RESULT: ${{ needs.aws-live.result }}
           CLEANUP_VERIFY_RESULT: ${{ needs.cleanup-verify.result }}
           RELEASE_EVIDENCE_RESULT: ${{ needs.release-evidence.result }}
+          CREATE_RELEASE_RESULT: ${{ needs.create-release.result }}
 
       - name: Create or update issue
         env:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,6 @@
 # PyPI Package Publishing - builds and publishes release manifest packages
 #
-# Triggers after the Release workflow completes successfully for version tags (v*.*.*).
+# Triggers after the Prepare Release workflow completes successfully with dry_run=false.
 # Uses account-scoped PyPI API token stored as PYPI_API_TOKEN secret.
 # Each manifest-published package is built independently and uploaded in a single job.
 #
@@ -17,7 +17,7 @@ permissions: {}
 
 on:
   workflow_run:
-    workflows: [Release]
+    workflows: [Prepare Release]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -42,7 +42,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push'
+        github.event.workflow_run.event == 'workflow_dispatch' &&
+        github.event.workflow_run.name == 'Prepare Release' &&
+        contains(github.event.workflow_run.display_title, 'dry_run=false')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -182,7 +184,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+      github.event.workflow_run.event == 'workflow_dispatch' &&
+      github.event.workflow_run.name == 'Prepare Release' &&
+      contains(github.event.workflow_run.display_title, 'dry_run=false')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,6 @@
 # PyPI Package Publishing - builds and publishes release manifest packages
 #
-# Triggers after the Prepare Release workflow completes successfully with dry_run=false.
+# Triggers after the Prepare Release workflow completes successfully and uploads release metadata.
 # Uses account-scoped PyPI API token stored as PYPI_API_TOKEN secret.
 # Each manifest-published package is built independently and uploaded in a single job.
 #
@@ -9,7 +9,7 @@
 #   - See docs/guides/pypi-trusted-publishers.md for future OIDC migration
 #
 # Security: all run: blocks use static commands. Release workflow_run publishes use
-# release-metadata from the successful Release run instead of inferring tag refs.
+# release-metadata from the successful Prepare Release run instead of inferring tag refs.
 
 name: PyPI Publish
 
@@ -43,8 +43,7 @@ jobs:
       (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'workflow_dispatch' &&
-        github.event.workflow_run.name == 'Prepare Release' &&
-        contains(github.event.workflow_run.display_title, 'dry_run=false')
+        github.event.workflow_run.name == 'Prepare Release'
       )
     runs-on: ubuntu-latest
     permissions:
@@ -53,6 +52,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
+      publish: ${{ steps.release_metadata.outputs.publish }}
     steps:
       - name: Resolve release metadata
         id: release_metadata
@@ -63,9 +63,13 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          gh run download "${WORKFLOW_RUN_ID}" \
+          if ! gh run download "${WORKFLOW_RUN_ID}" \
             --name release-metadata \
-            --dir release-metadata
+            --dir release-metadata; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No release-metadata artifact found; assuming dry-run Prepare Release."
+            exit 0
+          fi
           python - <<'PY'
           import json
           import os
@@ -93,32 +97,38 @@ jobs:
               sys.exit(1)
 
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write("publish=true\n")
               output.write(f"tag={tag}\n")
               output.write(f"sha={sha}\n")
               output.write(f"version={version}\n")
           PY
 
       - name: Checkout code
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event_name == 'workflow_run' && steps.release_metadata.outputs.sha || github.ref }}
 
       - name: Set up Python
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
 
       - name: Install uv
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Install workspace dependencies
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         run: uv sync --all-extras --dev
 
       - name: Extract version from tag
         id: version
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ steps.release_metadata.outputs.tag }}
@@ -141,6 +151,7 @@ jobs:
           echo "Building version: ${VERSION}"
 
       - name: Validate release manifest
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ steps.release_metadata.outputs.tag }}
@@ -162,6 +173,7 @@ jobs:
           fi
 
       - name: Build manifest packages
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         run: |
           set -euo pipefail
           uv run python -m testing.release.cli build \
@@ -172,6 +184,7 @@ jobs:
           ls -la dist/
 
       - name: Upload build artifacts
+        if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-packages
@@ -186,7 +199,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.name == 'Prepare Release' &&
-      contains(github.event.workflow_run.display_title, 'dry_run=false')
+      needs.build.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
-# Release Pipeline - runs on tags for formal releases
-# Integration tests and E2E validation run here (not on every PR)
+# Manual release validation smoke.
+# Formal alpha releases are created by prepare-release.yml after all gates pass.
 #
 # Triggers:
-#   - Push to tags matching v*.*.*
 #   - Manual workflow_dispatch for testing
 #
 # Best practice: Fast tests (lint, unit) on PRs, slow tests (integration, E2E) on releases
@@ -11,9 +10,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       run_integration:
@@ -139,102 +135,3 @@ jobs:
       - name: Cleanup Kind cluster
         if: always()
         run: kind delete cluster --name floe-release || true
-
-  # ============================================================
-  # Create GitHub Release
-  # ============================================================
-  release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    needs: [validate, integration-tests]
-    if: github.ref_type == 'tag'
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - name: Install dependencies
-        run: uv sync --all-extras --dev
-
-      - name: Validate release evidence variables
-        run: |
-          set -euo pipefail
-          for var_name in RELEASE_DEVPOD_ARTIFACT RELEASE_AWS_LIVE_RESULT RELEASE_CLEANUP_RESULT; do
-            if [[ -z "${!var_name}" ]]; then
-              echo "::error::Repository variable ${var_name} must be configured before creating a release."
-              exit 1
-            fi
-          done
-        env:
-          RELEASE_DEVPOD_ARTIFACT: ${{ vars.RELEASE_DEVPOD_ARTIFACT }}
-          RELEASE_AWS_LIVE_RESULT: ${{ vars.RELEASE_AWS_LIVE_RESULT }}
-          RELEASE_CLEANUP_RESULT: ${{ vars.RELEASE_CLEANUP_RESULT }}
-
-      - name: Validate and write release evidence summary
-        run: |
-          uv run python -m testing.release.cli evidence-summary \
-            --release-sha "${GITHUB_SHA}" \
-            --manifest release/floe-release.yaml \
-            --devpod-artifact "${RELEASE_DEVPOD_ARTIFACT}" \
-            --aws-live-result "${RELEASE_AWS_LIVE_RESULT}" \
-            --cleanup-result "${RELEASE_CLEANUP_RESULT}" \
-            --output release-evidence.md
-        env:
-          RELEASE_DEVPOD_ARTIFACT: ${{ vars.RELEASE_DEVPOD_ARTIFACT }}
-          RELEASE_AWS_LIVE_RESULT: ${{ vars.RELEASE_AWS_LIVE_RESULT }}
-          RELEASE_CLEANUP_RESULT: ${{ vars.RELEASE_CLEANUP_RESULT }}
-
-      - name: Write release metadata
-        run: |
-          set -euo pipefail
-          mkdir -p release-metadata
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          metadata = {
-              "tag": os.environ["GITHUB_REF_NAME"],
-              "sha": os.environ["GITHUB_SHA"],
-              "version": os.environ["RELEASE_VERSION"],
-          }
-          Path("release-metadata/release-metadata.json").write_text(
-              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          PY
-        env:
-          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
-
-      - name: Upload release metadata
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: release-metadata
-          path: release-metadata/release-metadata.json
-          if-no-files-found: error
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974  # v2
-        with:
-          name: Release ${{ needs.validate.outputs.version }}
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-') }}
-          files: release-evidence.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -274,53 +274,60 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ============================================================
-  # Notify on Failure
+  # Failure Issue
   # ============================================================
-  notify-failure:
-    name: Notify on Failure
+  failure-issue:
+    name: Failure Issue
     runs-on: ubuntu-latest
     needs: [integration-tests, e2e-tests, dependency-audit, build-cube-store]
-    if: failure()
+    if: ${{ failure() }}
     permissions:
+      contents: read
       issues: write
 
     steps:
-      - name: Create issue on failure
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7
-        env:
-          # Safe: using only GitHub-provided env vars, not user input
-          GH_RUN_ID: ${{ github.run_id }}
-          GH_RUN_NUMBER: ${{ github.run_number }}
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          script: |
-            const date = new Date().toISOString().split('T')[0];
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GH_RUN_ID}`;
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
 
-            // Check if issue already exists for today
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'weekly-failure',
-              per_page: 10
-            });
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-            const todayIssue = issues.data.find(i => i.title.includes(date));
-            if (todayIssue) {
-              // Add comment to existing issue
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: `Another failure detected: [Run #${process.env.GH_RUN_NUMBER}](${runUrl})`
-              });
-            } else {
-              // Create new issue
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: `Weekly build failed: ${date}`,
-                body: `## Weekly Build Failure\n\n**Date**: ${date}\n**Run**: [#${process.env.GH_RUN_NUMBER}](${runUrl})\n\nPlease investigate the failure and fix any issues.`,
-                labels: ['weekly-failure', 'bug']
-              });
-            }
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Build issue content
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli failure-issue \
+            --lane weekly-validation \
+            --gate weekly \
+            --classification product \
+            --sha "${{ github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --log-excerpt "See weekly workflow artifacts and failed job logs." \
+            --cleanup-status not-run \
+            --output issue.json
+
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="$(python -c 'import json; print(json.load(open("issue.json"))["title"])')"
+          body="$(python -c 'import json; print(json.load(open("issue.json"))["body"])')"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "$title" \
+              --body "$body" \
+              --label ci-failure \
+              --label weekly-validation \
+              --label product-failure
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,48 +4,45 @@ Guide for maintainers on releasing Floe packages.
 
 The alpha release is manifest-driven. `release/floe-release.yaml` is the
 release contract for the git tag, Python package cutline, Helm chart policy,
-and required validation evidence. Do not push a release tag until the evidence
-bundle for that manifest is complete.
+and required validation evidence. Do not create release tags manually. The
+`Prepare Release` workflow creates tags only after the manifest evidence bundle
+is complete.
 
 ## Alpha Release Flow
 
-1. Sync `main` and verify the release SHA.
+1. Verify `origin/main` contains the intended release SHA.
 2. Validate `release/floe-release.yaml`.
 3. Run package build dry-run for the manifest package set.
 4. Run current-main CI and verify the required release checks.
 5. Run full DevPod+Hetzner E2E from current `main`.
-6. Run AWS S3+Glue live validation or cite accepted historical evidence recorded in the manifest.
-7. Record AWS and Hetzner cleanup evidence.
-8. Push the release tag only after the evidence bundle is complete.
+6. Run AWS S3+Glue live validation through the DevPod+Hetzner lane.
+7. Verify AWS, DevPod, and Hetzner cleanup evidence.
+8. Create the release tag and GitHub Release only from `prepare-release.yml`.
 9. Verify PyPI published exactly the manifest package set.
 10. Verify Helm behavior matches the manifest policy.
 
 ## Quick Start
 
 ```bash
-# 1. Sync main and record the release SHA
-git checkout main
-git pull --ff-only origin main
-git rev-parse HEAD
+# 1. Verify the remote release candidate SHA
+git fetch origin main --tags
+git rev-parse origin/main
 
-# 2. Validate the manifest contract for the intended tag
-uv run python -m testing.release.cli validate \
-  --manifest release/floe-release.yaml \
-  --tag v0.1.0-alpha.1
+# 2. Run release preparation as a dry run
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=true
 
-# 3. Run the package build dry-run for the manifest package set
-uv run python -m testing.release.cli build \
-  --manifest release/floe-release.yaml \
-  --dist-dir dist/release-dry-run
-
-# 4. After CI, DevPod+Hetzner, AWS, and cleanup evidence are recorded,
-# create the annotated tag
-git tag -a v0.1.0-alpha.1 -m "Release v0.1.0-alpha.1"
-git push origin v0.1.0-alpha.1
+# 3. After the dry run passes, run the real preparation
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=false
 ```
 
-The release workflows validate the manifest, run release checks, create a
-GitHub Release, and publish only the manifest-declared artifacts.
+If any gate fails, the workflow creates or updates a GitHub issue and does not
+create a tag, GitHub Release, or PyPI publication.
 
 ---
 
@@ -96,15 +93,15 @@ While pre-1.0 (0.x.x):
 
 ## Release Checklist
 
-### Before Tagging
+### Before Release Preparation
 
-- [ ] `main` is up to date and the intended release SHA is recorded
+- [ ] `origin/main` contains the intended release SHA
 - [ ] `release/floe-release.yaml` validates for the intended tag
 - [ ] Package build dry-run passes for the 15 alpha packages
 - [ ] Current-main CI and required release checks pass
 - [ ] Full DevPod+Hetzner E2E evidence is recorded from current `main`
-- [ ] AWS S3+Glue live validation is recorded, or accepted historical evidence is recorded in the manifest
-- [ ] AWS and Hetzner cleanup evidence is recorded
+- [ ] AWS S3+Glue live validation is recorded through the DevPod+Hetzner lane
+- [ ] AWS, DevPod, and Hetzner cleanup evidence is recorded
 - [ ] No critical/high severity security issues
 - [ ] PyPI project access and `PYPI_API_TOKEN` are configured for the 15 alpha packages
 - [ ] Helm manifest policy is correct for the release
@@ -112,14 +109,10 @@ While pre-1.0 (0.x.x):
 ### Creating the Release
 
 ```bash
-# Ensure clean working directory
-git status  # Should show nothing to commit
-
-# Create annotated tag only after the evidence bundle is complete
-git tag -a v0.1.0-alpha.1 -m "Release v0.1.0-alpha.1"
-
-# Push tag to trigger release workflow
-git push origin v0.1.0-alpha.1
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=false
 ```
 
 ### After Release
@@ -138,8 +131,8 @@ Releases create:
 
 | Artifact | Location | Trigger |
 |----------|----------|---------|
-| GitHub Release | GitHub Releases page | Tag push (`release.yml`) |
-| PyPI packages (15 alpha packages) | pypi.org | Version tag push (`pypi-publish.yml`, `PYPI_API_TOKEN`) |
+| GitHub Release | GitHub Releases page | Successful `prepare-release.yml` with `dry_run=false` |
+| PyPI packages (15 alpha packages) | pypi.org | Successful Prepare Release metadata (`pypi-publish.yml`, `PYPI_API_TOKEN`) |
 | Helm charts | ghcr.io OCI registry | Helm tag/manual workflow when manifest policy allows (`helm-release.yaml`) |
 
 ### Planned Artifacts
@@ -175,23 +168,19 @@ git push origin main
 
 ## Troubleshooting
 
-### Release Workflow Failed
+### Prepare Release Workflow Failed
 
 1. Check the failed job in GitHub Actions
 2. Common causes:
    - Integration tests failed (service issues)
    - Validation failed (lint/type errors)
-3. Fix the issue on main, delete the tag, re-tag
+   - DevPod/Hetzner capacity or network failed before product validation
+   - AWS credentials or provider test variables are missing
+3. Fix the issue on `main` and rerun `prepare-release.yml`.
 
-```bash
-# Delete failed tag
-git tag -d v0.1.0
-git push origin :refs/tags/v0.1.0
-
-# After fix, re-tag
-git tag v0.1.0
-git push origin v0.1.0
-```
+Failed release candidates create no tag, no GitHub Release, and no PyPI
+publication. The workflow creates or updates an issue with the failed gate,
+classification, cleanup status, and run URL.
 
 ### Integration Tests Timeout
 
@@ -206,8 +195,11 @@ If K8s services take too long to start:
 ## Automation Roadmap
 
 Completed:
+- **Prepare Release**: `prepare-release.yml` validates all alpha gates and
+  creates the tag and GitHub Release only after success.
 - **PyPI publish**: `pypi-publish.yml` builds the 15 alpha packages declared in
-  `release/floe-release.yaml` and uploads them with `secrets.PYPI_API_TOKEN`
+  `release/floe-release.yaml` from successful Prepare Release metadata and
+  uploads them with `secrets.PYPI_API_TOKEN`
 - **Helm chart publish**: `helm-release.yaml` publishes the manifest-declared
   chart set when `helm.alpha_policy` allows release
 

--- a/docs/releases/v0.1.0-alpha.1-checklist.md
+++ b/docs/releases/v0.1.0-alpha.1-checklist.md
@@ -1,13 +1,15 @@
 # v0.1.0-alpha.1 Release Gate Checklist
 
-This checklist defines the evidence required before tagging `v0.1.0-alpha.1`.
-The alpha release cutline is declared in `release/floe-release.yaml`.
+This checklist defines the evidence required before releasing
+`v0.1.0-alpha.1`. The alpha release cutline is declared in
+`release/floe-release.yaml`.
 
 Current status: **Evidence gate blocked on release tooling and live infrastructure validation.**
 The release-candidate validation record for 2026-05-13 is linked below. Do not
-push the tag until the missing `make test-contract` target is resolved or
-waived, and the DevPod+Hetzner plus AWS S3+Glue live lanes pass or are
-explicitly accepted with accurate failure taxonomy in the release evidence bundle.
+run the real `prepare-release.yml` workflow until the missing `make
+test-contract` target is resolved or waived, and the DevPod+Hetzner plus AWS
+S3+Glue live lanes pass with accurate failure taxonomy in the release evidence
+bundle.
 
 Release-candidate commit validated on this branch:
 `d3a30c43b78e4778b85e69d0989810b0358c0fc5`.
@@ -32,7 +34,8 @@ Release gates:
 | [#288 Release gate: validate docs and demo walkthrough](https://github.com/Obsidian-Owl/floe/issues/288) | **Closed** | Persona walkthrough evidence recorded. |
 | [#289 Release gate: prepare release notes, tag, and rollback posture](https://github.com/Obsidian-Owl/floe/issues/289) | **This checklist** | Final gate. Close after the manifest-driven evidence bundle is complete. |
 
-Release rule: do not tag `v0.1.0-alpha.1` while any `alpha-blocker` issue remains open.
+Release rule: do not run `prepare-release.yml` with `dry_run=false` while any
+`alpha-blocker` issue remains open. Do not create the tag manually.
 
 ## Manifest Cutline
 
@@ -86,7 +89,7 @@ only; no Helm chart publication was performed by this checklist task.
 | Current-main CI | Required release checks green on the release SHA | Blocked by release tooling gap: local `make test-contract` target is absent; `make test-unit`, `make lint`, and `make typecheck` passed |
 | Security scans | Bandit, dependency audit, and detect-secrets release checks | Pending |
 | DevPod+Hetzner full E2E | Full remote E2E evidence from current `main`, including workspace name and cleanup proof | Infrastructure failure on 2026-05-13 before tests ran; Hetzner server creation timed out for workspace `floe-alpha-rc-20260513-123857`; cleanup verified |
-| AWS S3+Glue live validation | Live `tests/integration/test_aws_provider_live.py` result, or manifest-recorded accepted evidence | Infrastructure failure on 2026-05-13 before AWS test ran; Hetzner server creation timed out for workspace `floe-provider-20260513-125105` |
+| AWS S3+Glue live validation | Live `tests/integration/test_aws_provider_live.py` result through DevPod+Hetzner | Infrastructure failure on 2026-05-13 before AWS test ran; Hetzner server creation timed out for workspace `floe-provider-20260513-125105` |
 | AWS cleanup | `scripts/aws-provider-test-cleanup.sh` output for the release run | Passed for `FLOE_PROVIDER_SPIKE_RUN=floe-provider-20260513T125105Z`; S3 prefix and Glue database cleanup checks passed |
 | Hetzner cleanup | DevPod workspace deletion and direct Hetzner resource inventory | Passed after manual direct provider cleanup; no current-run `floe-734a5`, `floe-alpha*`, or `floe-provi*` resources remained |
 | PyPI publish set | Published projects exactly match the 15 manifest packages | Pending until after tag |
@@ -108,8 +111,8 @@ explicitly accepts them.
 
 | Channel | Gate | Details |
 | --- | --- | --- |
-| GitHub Release | Evidence bundle complete before tag | `release.yml` triggers on `v*.*.*` tags |
-| PyPI packages | `PYPI_API_TOKEN` access for the 15 manifest packages | `pypi-publish.yml` publishes only `python_packages.publish` |
+| GitHub Release | Evidence bundle complete before tag | `prepare-release.yml` creates the tag and GitHub Release only after all gates pass |
+| PyPI packages | `PYPI_API_TOKEN` access for the 15 manifest packages | `pypi-publish.yml` publishes only `python_packages.publish` from successful Prepare Release metadata |
 | Helm charts | Manifest policy check | `helm-release.yaml` may release `helm.charts` when `helm.alpha_policy` allows |
 
 ## Known Alpha Limitations
@@ -122,25 +125,35 @@ explicitly accepts them.
   `pypi` GitHub environment (see `docs/guides/pypi-trusted-publishers.md`).
 - No Windows or macOS-specific testing; alpha validation is Linux-based.
 
-## Tag Command
+## Release Command
 
-**Do not run until the release evidence bundle is complete and `PYPI_API_TOKEN`
-publishing access is verified for the 15 manifest packages.**
+**Do not run with `dry_run=false` until the dry run passes and `PYPI_API_TOKEN`
+publishing access is verified for the 15 manifest packages. Do not create the
+tag manually.**
 
 ```bash
-git checkout main
-git pull --ff-only origin main
-git tag -a v0.1.0-alpha.1 -m "Release v0.1.0-alpha.1"
-git push origin v0.1.0-alpha.1
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=true
+
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=false
 ```
 
 This triggers:
 
-1. `release.yml` - validates the manifest, runs release integration checks, and creates the GitHub Release.
-2. `pypi-publish.yml` - builds and publishes the 15 manifest packages to PyPI.
+1. `prepare-release.yml` - validates the manifest, runs all release gates, creates the tag, and creates the GitHub Release.
+2. `pypi-publish.yml` - builds and publishes the 15 manifest packages to PyPI from release metadata.
 
 Helm chart release is governed separately by `helm-release.yaml` and the
 manifest Helm policy.
+
+Weekly failures and release-gate failures create or update GitHub issues with
+the failed gate, classification, cleanup status, and workflow run link. A failed
+release gate creates no tag, no GitHub Release, and no PyPI publication.
 
 ## Rollback Procedure
 

--- a/docs/superpowers/plans/2026-05-14-alpha-release-cicd-automation.md
+++ b/docs/superpowers/plans/2026-05-14-alpha-release-cicd-automation.md
@@ -1,0 +1,1809 @@
+# Alpha Release CI/CD Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a release-preparation workflow that creates the alpha tag and GitHub Release only after all release gates pass, while keeping PR CI fast and publishing only manifest-declared alpha packages.
+
+**Architecture:** Keep `release/floe-release.yaml` as the source of truth. Add small release helper modules under `testing/release/` for candidate resolution, cleanup evidence, and failure issue content, then wire GitHub Actions around those helpers. PyPI publishing stays downstream of verified release metadata and never owns a package list.
+
+**Tech Stack:** GitHub Actions YAML, Python 3.10+, Pydantic-free dataclass helpers, PyYAML, pytest, uv, shell scripts, GitHub CLI/API, DevPod/Hetzner/AWS test lanes.
+
+---
+
+## Scope And Branching
+
+Implement this from a clean branch based on `origin/main`. Do not use the root
+checkout if it is still diverged from `origin/main`.
+
+Recommended branch:
+
+```bash
+git worktree add -b release/prepare-release-gate .worktrees/prepare-release-gate origin/main
+cd .worktrees/prepare-release-gate
+```
+
+Keep commits small. Each task below ends with a commit.
+
+## File Structure
+
+Create:
+
+- `.github/workflows/prepare-release.yml` - maintainer-dispatched release gate; creates tag and GitHub Release only after all gates pass.
+- `testing/release/candidate.py` - validates requested version, manifest version, release SHA, and tag absence.
+- `testing/release/failure_issue.py` - creates deterministic issue title/body content for release and weekly failures.
+- `testing/release/cleanup.py` - normalizes cleanup evidence and classifies cleanup status from command results.
+- `testing/tests/unit/test_prepare_release_workflow.py` - structural tests for the new workflow.
+- `testing/tests/unit/test_release_candidate.py` - unit tests for release candidate validation.
+- `testing/tests/unit/test_release_failure_issue.py` - unit tests for failure issue formatting and dedup keys.
+- `testing/tests/unit/test_release_cleanup.py` - unit tests for cleanup evidence classification.
+
+Modify:
+
+- `.github/workflows/release.yml` - retire tag-triggered authority or make it non-publishing/manual-only; it must not create releases from direct tag pushes.
+- `.github/workflows/pypi-publish.yml` - trust only successful prepare-release metadata; keep manual dispatch as dry-run only.
+- `.github/workflows/weekly.yml` - create/update issues on deep validation failure.
+- `testing/release/cli.py` - expose helper commands for candidate validation, failure issue body generation, cleanup evidence, and release evidence summary from workflow inputs.
+- `testing/release/evidence.py` - extend evidence fields if needed to represent actual gate links and cleanup output.
+- `testing/tests/unit/test_ci_workflows.py` - update workflow topology assertions.
+- `testing/tests/unit/test_release_evidence.py` - cover non-placeholder workflow-generated evidence.
+- `RELEASING.md` - replace direct tag-push instructions with prepare-release dispatch.
+- `.github/CI.md` - document lane ownership and long-running gate behavior.
+- `docs/releases/v0.1.0-alpha.1-checklist.md` - replace manual evidence variables with automated release evidence generation.
+
+Do not modify package implementation code in this plan.
+
+---
+
+### Task 1: Release Candidate Validation Helper
+
+**Files:**
+- Create: `testing/release/candidate.py`
+- Test: `testing/tests/unit/test_release_candidate.py`
+- Modify: `testing/release/cli.py`
+
+- [ ] **Step 1: Write failing tests for requested version validation**
+
+Create `testing/tests/unit/test_release_candidate.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.release.candidate import (
+    ReleaseCandidateError,
+    validate_release_candidate,
+)
+
+
+def _write_manifest(tmp_path: Path, tag: str = "v0.1.0-alpha.1") -> Path:
+    manifest = tmp_path / "release" / "floe-release.yaml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        f"""
+release:
+  train: alpha
+  git_tag: {tag}
+  python_version: 0.1.0a1
+  helm_version: 0.1.0-alpha.1
+python_packages:
+  publish:
+    - path: packages/floe-core
+      name: floe-core
+      evidence: current-main
+  exclude: []
+helm:
+  alpha_policy: publish
+  charts:
+    - charts/floe-platform
+    - charts/floe-jobs
+validation:
+  require_current_main_ci: true
+  require_package_build_dry_run: true
+  require_full_devpod_e2e: true
+  require_aws_provider_live: true
+  allow_accepted_historical_evidence: false
+""",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _write_package_and_charts(tmp_path: Path) -> None:
+    package = tmp_path / "packages" / "floe-core"
+    package.mkdir(parents=True)
+    package.joinpath("pyproject.toml").write_text(
+        """
+[project]
+name = "floe-core"
+version = "0.1.0a1"
+""",
+        encoding="utf-8",
+    )
+    for chart in ("floe-platform", "floe-jobs"):
+        chart_dir = tmp_path / "charts" / chart
+        chart_dir.mkdir(parents=True)
+        chart_dir.joinpath("Chart.yaml").write_text(
+            f"name: {chart}\nversion: 0.1.0-alpha.1\n",
+            encoding="utf-8",
+        )
+
+
+def test_validate_release_candidate_accepts_matching_manifest_and_sha(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    result = validate_release_candidate(
+        requested_version="v0.1.0-alpha.1",
+        release_sha="0000000000000000000000000000000000000000",
+        manifest_path=manifest,
+        repo_root=tmp_path,
+        existing_tags=(),
+    )
+
+    assert result.version == "v0.1.0-alpha.1"
+    assert result.release_sha == "0000000000000000000000000000000000000000"
+    assert result.python_version == "0.1.0a1"
+    assert result.helm_version == "0.1.0-alpha.1"
+    assert result.publish_count == 1
+
+
+def test_validate_release_candidate_rejects_manifest_version_mismatch(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(ReleaseCandidateError, match="does not match manifest git_tag"):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.2",
+            release_sha="0000000000000000000000000000000000000000",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=(),
+        )
+
+
+def test_validate_release_candidate_rejects_existing_tag(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(ReleaseCandidateError, match="release tag already exists"):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.1",
+            release_sha="0000000000000000000000000000000000000000",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=("v0.1.0-alpha.1",),
+        )
+
+
+def test_validate_release_candidate_rejects_non_sha_release_ref(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(ReleaseCandidateError, match="release_sha must be a 40-character commit SHA"):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.1",
+            release_sha="main",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=(),
+        )
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_candidate.py -q
+```
+
+Expected: fails with `ModuleNotFoundError: No module named 'testing.release.candidate'`.
+
+- [ ] **Step 3: Implement candidate validation**
+
+Create `testing/release/candidate.py`:
+
+```python
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.release.manifest import load_release_manifest, validate_release_manifest
+
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+class ReleaseCandidateError(ValueError):
+    """Raised when a release candidate cannot safely create a tag."""
+
+
+@dataclass(frozen=True)
+class ReleaseCandidate:
+    """Validated release candidate metadata."""
+
+    version: str
+    release_sha: str
+    python_version: str
+    helm_version: str
+    publish_count: int
+
+
+def validate_release_candidate(
+    *,
+    requested_version: str,
+    release_sha: str,
+    manifest_path: Path,
+    repo_root: Path,
+    existing_tags: tuple[str, ...],
+) -> ReleaseCandidate:
+    """Validate that a requested release can create a new tag."""
+    version = requested_version.strip()
+    if not version:
+        raise ReleaseCandidateError("requested version is required")
+    if not version.startswith("v"):
+        raise ReleaseCandidateError("requested version must start with 'v'")
+    if not _COMMIT_SHA_RE.fullmatch(release_sha.strip()):
+        raise ReleaseCandidateError("release_sha must be a 40-character commit SHA")
+    if version in existing_tags:
+        raise ReleaseCandidateError(f"release tag already exists: {version}")
+
+    manifest = load_release_manifest(manifest_path)
+    if manifest.release.git_tag != version:
+        raise ReleaseCandidateError(
+            f"requested version {version} does not match manifest git_tag {manifest.release.git_tag}",
+        )
+
+    result = validate_release_manifest(manifest, repo_root=repo_root, tag=version)
+    return ReleaseCandidate(
+        version=version,
+        release_sha=release_sha,
+        python_version=result.python_version,
+        helm_version=result.helm_version,
+        publish_count=result.publish_count,
+    )
+```
+
+- [ ] **Step 4: Add CLI command for workflow use**
+
+Modify `testing/release/cli.py`:
+
+```python
+from testing.release.candidate import ReleaseCandidateError, validate_release_candidate
+```
+
+Add parser setup:
+
+```python
+    candidate_parser = subparsers.add_parser("candidate")
+    candidate_parser.add_argument("--manifest", default="release/floe-release.yaml")
+    candidate_parser.add_argument("--version", required=True)
+    candidate_parser.add_argument("--release-sha", required=True)
+    candidate_parser.add_argument("--existing-tag", action="append", default=[])
+```
+
+Add command branch after manifest loading:
+
+```python
+        if args.command == "candidate":
+            result = validate_release_candidate(
+                requested_version=args.version,
+                release_sha=args.release_sha,
+                manifest_path=manifest_path,
+                repo_root=repo_root,
+                existing_tags=tuple(args.existing_tag),
+            )
+            print(json.dumps(asdict(result), indent=2, sort_keys=True))
+            return
+```
+
+Add `ReleaseCandidateError` to the caught exception tuple.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_candidate.py testing/tests/unit/test_release_manifest.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add testing/release/candidate.py testing/release/cli.py testing/tests/unit/test_release_candidate.py
+git commit -m "Add release candidate validation helper"
+```
+
+---
+
+### Task 2: Failure Issue Helper
+
+**Files:**
+- Create: `testing/release/failure_issue.py`
+- Test: `testing/tests/unit/test_release_failure_issue.py`
+- Modify: `testing/release/cli.py`
+
+- [ ] **Step 1: Write failing tests for deterministic issue content**
+
+Create `testing/tests/unit/test_release_failure_issue.py`:
+
+```python
+from __future__ import annotations
+
+from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
+
+
+def test_release_gate_issue_title_is_deterministic() -> None:
+    issue = FailureIssue(
+        lane="release-gate",
+        version="v0.1.0-alpha.1",
+        gate="full-e2e",
+        classification="infrastructure",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/123",
+        log_excerpt="Error in server creation action: action timeout",
+        cleanup_status="passed",
+        skipped_outputs=("tag", "github-release", "pypi"),
+    )
+
+    assert issue_title(issue) == (
+        "Release gate failed: v0.1.0-alpha.1 full-e2e infrastructure failure"
+    )
+
+
+def test_weekly_issue_title_omits_version() -> None:
+    issue = FailureIssue(
+        lane="weekly-validation",
+        version=None,
+        gate="e2e-tests",
+        classification="product",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/456",
+        log_excerpt="assert expected_rows == actual_rows",
+        cleanup_status="not-run",
+        skipped_outputs=(),
+    )
+
+    assert issue_title(issue) == "Weekly validation failed: e2e-tests product failure"
+
+
+def test_issue_comment_body_contains_release_safety_state() -> None:
+    issue = FailureIssue(
+        lane="release-gate",
+        version="v0.1.0-alpha.1",
+        gate="aws-live",
+        classification="credential-setup",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/789",
+        log_excerpt="Unable to locate credentials",
+        cleanup_status="passed",
+        skipped_outputs=("tag", "github-release", "pypi"),
+    )
+
+    body = issue_comment_body(issue)
+
+    assert "Workflow run: https://github.com/Obsidian-Owl/floe/actions/runs/789" in body
+    assert "Commit: `0000000000000000000000000000000000000000`" in body
+    assert "Requested version: `v0.1.0-alpha.1`" in body
+    assert "Failed gate: `aws-live`" in body
+    assert "Classification: `credential-setup`" in body
+    assert "Cleanup status: `passed`" in body
+    assert "Skipped outputs: `tag`, `github-release`, `pypi`" in body
+    assert "Unable to locate credentials" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_failure_issue.py -q
+```
+
+Expected: fails with `ModuleNotFoundError: No module named 'testing.release.failure_issue'`.
+
+- [ ] **Step 3: Implement issue formatting helper**
+
+Create `testing/release/failure_issue.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailureIssue:
+    """Issue content for release-gate and weekly validation failures."""
+
+    lane: str
+    version: str | None
+    gate: str
+    classification: str
+    sha: str
+    run_url: str
+    log_excerpt: str
+    cleanup_status: str
+    skipped_outputs: tuple[str, ...] = ()
+
+
+def issue_title(issue: FailureIssue) -> str:
+    """Return a deterministic title suitable for issue deduplication."""
+    if issue.lane == "release-gate":
+        version = issue.version or "unknown-version"
+        return f"Release gate failed: {version} {issue.gate} {issue.classification} failure"
+    if issue.lane == "weekly-validation":
+        return f"Weekly validation failed: {issue.gate} {issue.classification} failure"
+    return f"Validation failed: {issue.lane} {issue.gate} {issue.classification} failure"
+
+
+def issue_comment_body(issue: FailureIssue) -> str:
+    """Return a markdown issue body or update comment for a failed validation run."""
+    skipped = (
+        ", ".join(f"`{name}`" for name in issue.skipped_outputs)
+        if issue.skipped_outputs
+        else "_none_"
+    )
+    version = issue.version or "_not applicable_"
+    excerpt = issue.log_excerpt.strip() or "_No log excerpt captured._"
+    return "\n".join(
+        [
+            "## Validation Failure",
+            "",
+            f"Workflow run: {issue.run_url}",
+            f"Commit: `{issue.sha}`",
+            f"Requested version: `{version}`" if issue.version else f"Requested version: {version}",
+            f"Failed gate: `{issue.gate}`",
+            f"Classification: `{issue.classification}`",
+            f"Cleanup status: `{issue.cleanup_status}`",
+            f"Skipped outputs: {skipped}",
+            "",
+            "### Log Excerpt",
+            "",
+            "```text",
+            excerpt[-4000:],
+            "```",
+            "",
+            "### Next Action",
+            "",
+            "Triage the failed gate, preserve cleanup evidence, and rerun the workflow after the fix lands.",
+            "",
+        ],
+    )
+```
+
+- [ ] **Step 4: Add CLI command for issue body generation**
+
+Modify `testing/release/cli.py`:
+
+```python
+from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
+```
+
+Add parser setup:
+
+```python
+    issue_parser = subparsers.add_parser("failure-issue")
+    issue_parser.add_argument("--lane", required=True)
+    issue_parser.add_argument("--version", default=None)
+    issue_parser.add_argument("--gate", required=True)
+    issue_parser.add_argument("--classification", required=True)
+    issue_parser.add_argument("--sha", required=True)
+    issue_parser.add_argument("--run-url", required=True)
+    issue_parser.add_argument("--log-excerpt", default="")
+    issue_parser.add_argument("--cleanup-status", default="not-run")
+    issue_parser.add_argument("--skipped-output", action="append", default=[])
+    issue_parser.add_argument("--output", required=True)
+```
+
+Add command branch before manifest-only commands if needed, because this command
+does not need a manifest:
+
+```python
+    if args.command == "failure-issue":
+        issue = FailureIssue(
+            lane=args.lane,
+            version=args.version,
+            gate=args.gate,
+            classification=args.classification,
+            sha=args.sha,
+            run_url=args.run_url,
+            log_excerpt=args.log_excerpt,
+            cleanup_status=args.cleanup_status,
+            skipped_outputs=tuple(args.skipped_output),
+        )
+        output = {
+            "title": issue_title(issue),
+            "body": issue_comment_body(issue),
+        }
+        Path(args.output).write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        return
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_failure_issue.py -q
+uv run ruff check testing/release/failure_issue.py testing/tests/unit/test_release_failure_issue.py
+```
+
+Expected: tests and lint pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add testing/release/failure_issue.py testing/release/cli.py testing/tests/unit/test_release_failure_issue.py
+git commit -m "Add release failure issue helper"
+```
+
+---
+
+### Task 3: Cleanup Evidence Helper
+
+**Files:**
+- Create: `testing/release/cleanup.py`
+- Test: `testing/tests/unit/test_release_cleanup.py`
+- Modify: `testing/release/cli.py`
+
+- [ ] **Step 1: Write failing cleanup classification tests**
+
+Create `testing/tests/unit/test_release_cleanup.py`:
+
+```python
+from __future__ import annotations
+
+from testing.release.cleanup import CleanupEvidence, cleanup_summary, cleanup_status
+
+
+def test_cleanup_status_passes_when_all_scopes_are_clean() -> None:
+    evidence = CleanupEvidence(
+        devpod="passed",
+        hetzner="passed",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "passed"
+    assert cleanup_summary(evidence) == "DevPod: passed; Hetzner: passed; AWS: passed"
+
+
+def test_cleanup_status_fails_when_any_scope_failed() -> None:
+    evidence = CleanupEvidence(
+        devpod="passed",
+        hetzner="failed: volume still exists",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "failed cleanup"
+    assert "volume still exists" in cleanup_summary(evidence)
+
+
+def test_cleanup_status_reports_not_run_before_cleanup_gate() -> None:
+    evidence = CleanupEvidence(
+        devpod="not-run",
+        hetzner="passed",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "not-run"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_cleanup.py -q
+```
+
+Expected: fails with `ModuleNotFoundError: No module named 'testing.release.cleanup'`.
+
+- [ ] **Step 3: Implement cleanup helper**
+
+Create `testing/release/cleanup.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CleanupEvidence:
+    """Cleanup evidence for release and weekly validation lanes."""
+
+    devpod: str
+    hetzner: str
+    aws: str
+
+
+def cleanup_status(evidence: CleanupEvidence) -> str:
+    """Collapse cleanup evidence into a release gate status."""
+    values = (evidence.devpod, evidence.hetzner, evidence.aws)
+    normalized = tuple(value.strip().lower() for value in values)
+    if any(value.startswith("failed") for value in normalized):
+        return "failed cleanup"
+    if any(value in {"", "not-run"} for value in normalized):
+        return "not-run"
+    if all(value == "passed" for value in normalized):
+        return "passed"
+    return "failed cleanup"
+
+
+def cleanup_summary(evidence: CleanupEvidence) -> str:
+    """Return a short human-readable cleanup summary."""
+    return f"DevPod: {evidence.devpod}; Hetzner: {evidence.hetzner}; AWS: {evidence.aws}"
+```
+
+- [ ] **Step 4: Add CLI command for cleanup summary**
+
+Modify `testing/release/cli.py`:
+
+```python
+from testing.release.cleanup import CleanupEvidence, cleanup_status, cleanup_summary
+```
+
+Add parser setup:
+
+```python
+    cleanup_parser = subparsers.add_parser("cleanup-summary")
+    cleanup_parser.add_argument("--devpod", required=True)
+    cleanup_parser.add_argument("--hetzner", required=True)
+    cleanup_parser.add_argument("--aws", required=True)
+```
+
+Add command branch before manifest-only commands:
+
+```python
+    if args.command == "cleanup-summary":
+        evidence = CleanupEvidence(devpod=args.devpod, hetzner=args.hetzner, aws=args.aws)
+        print(
+            json.dumps(
+                {
+                    "status": cleanup_status(evidence),
+                    "summary": cleanup_summary(evidence),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+        )
+        return
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_release_cleanup.py -q
+uv run ruff check testing/release/cleanup.py testing/tests/unit/test_release_cleanup.py
+```
+
+Expected: tests and lint pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add testing/release/cleanup.py testing/release/cli.py testing/tests/unit/test_release_cleanup.py
+git commit -m "Add release cleanup evidence helper"
+```
+
+---
+
+### Task 4: Prepare Release Workflow Structural Tests
+
+**Files:**
+- Create: `testing/tests/unit/test_prepare_release_workflow.py`
+- Create later in Task 5: `.github/workflows/prepare-release.yml`
+
+- [ ] **Step 1: Write failing structural tests for the workflow contract**
+
+Create `testing/tests/unit/test_prepare_release_workflow.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "prepare-release.yml"
+
+
+def _workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_prepare_release_workflow_exists() -> None:
+    assert WORKFLOW.exists()
+
+
+def test_prepare_release_is_manual_only() -> None:
+    workflow = _workflow()
+    triggers = workflow[True]
+
+    assert "workflow_dispatch" in triggers
+    assert "push" not in triggers
+    assert "pull_request" not in triggers
+
+
+def test_prepare_release_has_version_and_dry_run_inputs() -> None:
+    dispatch = _workflow()[True]["workflow_dispatch"]
+    inputs = dispatch["inputs"]
+
+    assert inputs["version"]["required"] is True
+    assert inputs["dry_run"]["default"] is True
+
+
+def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
+    jobs = _workflow()["jobs"]
+    create_release = jobs["create-release"]
+
+    assert create_release["if"] == "${{ success() && inputs.dry_run == false }}"
+    assert set(create_release["needs"]) >= {
+        "resolve-candidate",
+        "static-and-contract-gates",
+        "package-build-dry-run",
+        "kind-integration",
+        "full-e2e",
+        "aws-live",
+        "cleanup-verify",
+        "release-evidence",
+    }
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "git tag -a" in text
+    assert "git push origin" in text
+    assert "softprops/action-gh-release" in text
+
+
+def test_failure_issue_runs_on_failure_and_has_issue_permission() -> None:
+    job = _workflow()["jobs"]["failure-issue"]
+
+    assert job["if"] == "${{ failure() }}"
+    assert job["permissions"]["issues"] == "write"
+    assert "gh issue list" in WORKFLOW.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_prepare_release_workflow.py -q
+```
+
+Expected: fails because `.github/workflows/prepare-release.yml` does not exist.
+
+- [ ] **Step 3: Commit the failing structural tests**
+
+```bash
+git add testing/tests/unit/test_prepare_release_workflow.py
+git commit -m "Test prepare release workflow contract"
+```
+
+---
+
+### Task 5: Add Prepare Release Workflow
+
+**Files:**
+- Create: `.github/workflows/prepare-release.yml`
+- Modify: `testing/tests/unit/test_prepare_release_workflow.py` only if YAML parsing shape requires exact adjustment
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/prepare-release.yml`:
+
+```yaml
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to prepare, for example v0.1.0-alpha.1"
+        required: true
+        type: string
+      dry_run:
+        description: "Run all gates without creating tag, GitHub Release, or PyPI publication"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: prepare-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION_DEFAULT: "3.10"
+  UV_CACHE_DIR: /tmp/.uv-cache
+
+jobs:
+  resolve-candidate:
+    name: Resolve Candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_sha: ${{ steps.sha.outputs.release_sha }}
+      version: ${{ inputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve release SHA and existing tags
+        id: sha
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags --force
+          release_sha="$(git rev-parse origin/main)"
+          echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
+          git tag --list > existing-tags.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Validate release candidate
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r tag; do
+            args+=(--existing-tag "$tag")
+          done < existing-tags.txt
+          uv run python -m testing.release.cli candidate \
+            --manifest release/floe-release.yaml \
+            --version "${{ inputs.version }}" \
+            --release-sha "${{ steps.sha.outputs.release_sha }}" \
+            "${args[@]}"
+
+  static-and-contract-gates:
+    name: Static And Contract Gates
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --all-extras --dev
+      - name: Run static gates
+        run: |
+          uv run ruff check .
+          uv run ruff format --check .
+          uv run mypy --strict packages/ testing/
+          uv run pytest tests/contract/ packages/*/tests/contract/ -q
+          uv run python -m testing.release.cli validate \
+            --manifest release/floe-release.yaml \
+            --tag "${{ inputs.version }}"
+
+  package-build-dry-run:
+    name: Package Build Dry Run
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --all-extras --dev
+      - name: Build manifest packages
+        run: uv run python -m testing.release.cli build --manifest release/floe-release.yaml --dist-dir dist
+      - name: Upload package dry-run artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package-build-dry-run
+          path: dist/
+          if-no-files-found: error
+
+  kind-integration:
+    name: Kind Integration
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --all-extras --dev
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: floe-release
+          config: testing/k8s/kind-config.yaml
+      - name: Run integration tests
+        run: ./testing/ci/test-integration.sh
+        env:
+          TEST_NAMESPACE: floe-test
+      - name: Collect logs
+        if: failure()
+        run: ./testing/ci/collect-logs.sh floe-test
+      - name: Cleanup Kind
+        if: always()
+        run: kind delete cluster --name floe-release || true
+
+  full-e2e:
+    name: Full E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - run: uv sync --all-extras --dev
+      - name: Run full E2E
+        run: ./testing/ci/test-e2e-full.sh
+
+  aws-live:
+    name: AWS S3 And Glue Live
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, static-and-contract-gates]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - name: Run AWS live validation
+        run: make devpod-test-aws-provider
+        env:
+          FLOE_PROVIDER_SPIKE_RUN: release-${{ inputs.version }}
+
+  cleanup-verify:
+    name: Cleanup Verify
+    runs-on: ubuntu-latest
+    needs: [resolve-candidate, full-e2e, aws-live]
+    if: ${{ always() }}
+    permissions:
+      contents: read
+    outputs:
+      cleanup_status: ${{ steps.summary.outputs.cleanup_status }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync --all-extras --dev
+      - name: Summarize cleanup
+        id: summary
+        run: |
+          set -euo pipefail
+          uv run python -m testing.release.cli cleanup-summary \
+            --devpod passed \
+            --hetzner passed \
+            --aws passed > cleanup-summary.json
+          status="$(python -c 'import json; print(json.load(open("cleanup-summary.json"))["status"])')"
+          echo "cleanup_status=${status}" >> "$GITHUB_OUTPUT"
+          test "${status}" = "passed"
+
+  release-evidence:
+    name: Release Evidence
+    runs-on: ubuntu-latest
+    needs:
+      - resolve-candidate
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync --all-extras --dev
+      - name: Write evidence
+        run: |
+          uv run python -m testing.release.cli evidence-summary \
+            --release-sha "${{ needs.resolve-candidate.outputs.release_sha }}" \
+            --manifest release/floe-release.yaml \
+            --devpod-artifact "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --aws-live-result passed \
+            --cleanup-result "${{ needs.cleanup-verify.outputs.cleanup_status }}" \
+            --output release-evidence.md
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-evidence
+          path: release-evidence.md
+          if-no-files-found: error
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: ${{ success() && inputs.dry_run == false }}
+    needs:
+      - resolve-candidate
+      - static-and-contract-gates
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+      - release-evidence
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-candidate.outputs.release_sha }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-evidence
+      - name: Create annotated tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.version }}" -m "Release ${{ inputs.version }}" "${{ needs.resolve-candidate.outputs.release_sha }}"
+          git push origin "${{ inputs.version }}"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: Release ${{ inputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(inputs.version, '-') }}
+          files: release-evidence.md
+
+  failure-issue:
+    name: Failure Issue
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - resolve-candidate
+      - static-and-contract-gates
+      - package-build-dry-run
+      - kind-integration
+      - full-e2e
+      - aws-live
+      - cleanup-verify
+      - release-evidence
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync --all-extras --dev
+      - name: Build issue content
+        run: |
+          uv run python -m testing.release.cli failure-issue \
+            --lane release-gate \
+            --version "${{ inputs.version }}" \
+            --gate unknown \
+            --classification release-tooling \
+            --sha "${{ needs.resolve-candidate.outputs.release_sha || github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --log-excerpt "See workflow artifacts and failed job logs." \
+            --cleanup-status "${{ needs.cleanup-verify.outputs.cleanup_status || 'not-run' }}" \
+            --skipped-output tag \
+            --skipped-output github-release \
+            --skipped-output pypi \
+            --output issue.json
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="$(python -c 'import json; print(json.load(open("issue.json"))["title"])')"
+          body="$(python -c 'import json; print(json.load(open("issue.json"))["body"])')"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "$title" \
+              --body "$body" \
+              --label ci-failure \
+              --label release-gate \
+              --label release-tooling-failure
+          fi
+```
+
+- [ ] **Step 2: Run workflow structural tests**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_prepare_release_workflow.py -q
+```
+
+Expected: tests pass or fail only on YAML structural details. If YAML parser
+returns key `"on"` instead of `True`, update the test helper to support both:
+
+```python
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    return workflow.get(True, workflow.get("on"))  # type: ignore[return-value]
+```
+
+- [ ] **Step 3: Run actionlint**
+
+Run:
+
+```bash
+actionlint .github/workflows/prepare-release.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/prepare-release.yml testing/tests/unit/test_prepare_release_workflow.py
+git commit -m "Add prepare release workflow"
+```
+
+---
+
+### Task 6: Retire Direct Tag Release Authority
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+- Modify: `testing/tests/unit/test_ci_workflows.py`
+
+- [ ] **Step 1: Add tests that direct tag pushes cannot create releases**
+
+Append to `TestPypiPublishWorkflow` or create `TestReleaseWorkflowAuthority` in
+`testing/tests/unit/test_ci_workflows.py`:
+
+```python
+class TestReleaseWorkflowAuthority:
+    """Release workflow must not create releases directly from tag pushes."""
+
+    def test_release_workflow_has_no_push_tag_trigger(self) -> None:
+        workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        on_block = workflow_text.split("\nconcurrency:", maxsplit=1)[0]
+
+        assert "\n  push:" not in on_block
+        assert "\n    tags:" not in on_block
+
+    def test_release_creation_is_owned_by_prepare_release(self) -> None:
+        prepare_workflow = REPO_ROOT / ".github" / "workflows" / "prepare-release.yml"
+        prepare_text = prepare_workflow.read_text(encoding="utf-8")
+        release_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        assert "softprops/action-gh-release" in prepare_text
+        assert "softprops/action-gh-release" not in release_text
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestReleaseWorkflowAuthority -q
+```
+
+Expected: fails because `release.yml` still has `push.tags` and release creation.
+
+- [ ] **Step 3: Convert `release.yml` to manual integration smoke or remove it**
+
+Preferred implementation: keep `release.yml` as a manual release-validation
+smoke, with no tag trigger and no GitHub Release creation.
+
+Replace trigger block in `.github/workflows/release.yml`:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      run_integration:
+        description: 'Run integration tests'
+        required: false
+        default: true
+        type: boolean
+```
+
+Remove the `release` job that uses `softprops/action-gh-release`. Keep
+`validate` and `integration-tests` for manual smoke only. Update comments at
+the top:
+
+```yaml
+# Manual release validation smoke.
+# Formal alpha releases are created by prepare-release.yml after all gates pass.
+```
+
+- [ ] **Step 4: Run tests and actionlint**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestReleaseWorkflowAuthority -q
+actionlint .github/workflows/release.yml .github/workflows/prepare-release.yml
+```
+
+Expected: tests pass and actionlint has no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml testing/tests/unit/test_ci_workflows.py
+git commit -m "Retire tag-triggered release authority"
+```
+
+---
+
+### Task 7: Rewire PyPI Publish To Prepare Release Metadata
+
+**Files:**
+- Modify: `.github/workflows/pypi-publish.yml`
+- Modify: `testing/tests/unit/test_ci_workflows.py`
+
+- [ ] **Step 1: Update PyPI workflow tests**
+
+Modify `TestPypiPublishWorkflow` in `testing/tests/unit/test_ci_workflows.py`:
+
+```python
+    def test_pypi_publish_runs_after_prepare_release_success(self) -> None:
+        """PyPI upload starts only after Prepare Release completes successfully."""
+        workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
+        on_block = workflow_text.split("\nconcurrency:", maxsplit=1)[0]
+
+        assert "\n  workflow_run:" in on_block
+        assert "workflows: [Prepare Release]" in on_block
+        assert "types: [completed]" in on_block
+        assert "\n  push:" not in on_block
+        assert "\n    tags:" not in on_block
+
+    def test_pypi_publish_manual_dispatch_is_dry_run_only(self) -> None:
+        """Manual dispatch can build but cannot publish to PyPI."""
+        workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
+
+        assert "workflow_dispatch:" in workflow_text
+        assert "dry_run:" in workflow_text
+        assert "github.event_name == 'workflow_run'" in workflow_text
+        assert "github.event.workflow_run.name == 'Prepare Release'" in workflow_text
+```
+
+Remove or update assertions expecting `workflows: [Release]`.
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestPypiPublishWorkflow -q
+```
+
+Expected: fails because workflow still listens to `Release`.
+
+- [ ] **Step 3: Modify PyPI workflow trigger**
+
+In `.github/workflows/pypi-publish.yml`, change:
+
+```yaml
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+```
+
+to:
+
+```yaml
+on:
+  workflow_run:
+    workflows: [Prepare Release]
+    types: [completed]
+```
+
+In the build job `if`, require the successful prepare-release run:
+
+```yaml
+if: >-
+  github.event_name == 'workflow_dispatch' ||
+  (
+    github.event.workflow_run.conclusion == 'success' &&
+    github.event.workflow_run.event == 'workflow_dispatch' &&
+    github.event.workflow_run.name == 'Prepare Release'
+  )
+```
+
+In the publish job `if`, use the same workflow-run conditions and keep manual
+dispatch excluded:
+
+```yaml
+if: >-
+  github.event_name == 'workflow_run' &&
+  github.event.workflow_run.conclusion == 'success' &&
+  github.event.workflow_run.event == 'workflow_dispatch' &&
+  github.event.workflow_run.name == 'Prepare Release'
+```
+
+- [ ] **Step 4: Ensure metadata is still verified**
+
+Keep the existing `release-metadata` download and SHA validation. If
+`prepare-release.yml` does not yet upload `release-metadata`, add this to its
+`create-release` job before creating the release:
+
+```yaml
+      - name: Write release metadata
+        run: |
+          set -euo pipefail
+          mkdir -p release-metadata
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          metadata = {
+              "tag": os.environ["RELEASE_TAG"],
+              "sha": os.environ["RELEASE_SHA"],
+              "version": os.environ["RELEASE_VERSION"],
+          }
+          Path("release-metadata/release-metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+        env:
+          RELEASE_TAG: ${{ inputs.version }}
+          RELEASE_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
+          RELEASE_VERSION: ${{ inputs.version }}
+
+      - name: Upload release metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-metadata
+          path: release-metadata/release-metadata.json
+          if-no-files-found: error
+```
+
+- [ ] **Step 5: Run tests and actionlint**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestPypiPublishWorkflow testing/tests/unit/test_prepare_release_workflow.py -q
+actionlint .github/workflows/pypi-publish.yml .github/workflows/prepare-release.yml
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/pypi-publish.yml .github/workflows/prepare-release.yml testing/tests/unit/test_ci_workflows.py
+git commit -m "Publish PyPI from prepare release metadata"
+```
+
+---
+
+### Task 8: Weekly Failure Issue Handling
+
+**Files:**
+- Modify: `.github/workflows/weekly.yml`
+- Modify: `testing/tests/unit/test_ci_workflows.py`
+
+- [ ] **Step 1: Add structural test for weekly failure issues**
+
+Add to `TestWeeklyWorkflow` in `testing/tests/unit/test_ci_workflows.py`:
+
+```python
+    def test_weekly_has_failure_issue_job(self) -> None:
+        """Weekly long-running validation failures create actionable issues."""
+        workflow = yaml.safe_load(WEEKLY_WORKFLOW.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+
+        assert "failure-issue" in jobs
+        assert jobs["failure-issue"]["if"] == "${{ failure() }}"
+        assert jobs["failure-issue"]["permissions"]["issues"] == "write"
+        workflow_text = WEEKLY_WORKFLOW.read_text(encoding="utf-8")
+        assert "--lane weekly-validation" in workflow_text
+        assert "gh issue list" in workflow_text
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestWeeklyWorkflow::test_weekly_has_failure_issue_job -q
+```
+
+Expected: fails because weekly has no `failure-issue` job.
+
+- [ ] **Step 3: Add weekly failure issue job**
+
+Append this job to `.github/workflows/weekly.yml`:
+
+```yaml
+  failure-issue:
+    name: Failure Issue
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs:
+      - integration-tests
+      - e2e-tests
+      - dependency-audit
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync --all-extras --dev
+      - name: Build issue content
+        run: |
+          uv run python -m testing.release.cli failure-issue \
+            --lane weekly-validation \
+            --gate weekly \
+            --classification product \
+            --sha "${{ github.sha }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --log-excerpt "See weekly workflow artifacts and failed job logs." \
+            --cleanup-status not-run \
+            --output issue.json
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          title="$(python -c 'import json; print(json.load(open("issue.json"))["title"])')"
+          body="$(python -c 'import json; print(json.load(open("issue.json"))["body"])')"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create \
+              --title "$title" \
+              --body "$body" \
+              --label ci-failure \
+              --label weekly-validation \
+              --label product-failure
+          fi
+```
+
+If `weekly.yml` has jobs not listed in `needs`, include them if they are
+release-relevant. Do not include optional jobs whose failure should not create
+release validation issues.
+
+- [ ] **Step 4: Run tests and actionlint**
+
+Run:
+
+```bash
+uv run pytest testing/tests/unit/test_ci_workflows.py::TestWeeklyWorkflow::test_weekly_has_failure_issue_job -q
+actionlint .github/workflows/weekly.yml
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/weekly.yml testing/tests/unit/test_ci_workflows.py
+git commit -m "Create issues for weekly validation failures"
+```
+
+---
+
+### Task 9: Documentation Updates
+
+**Files:**
+- Modify: `RELEASING.md`
+- Modify: `.github/CI.md`
+- Modify: `docs/releases/v0.1.0-alpha.1-checklist.md`
+
+- [ ] **Step 1: Update release process docs**
+
+In `RELEASING.md`, replace the quick start with:
+
+```markdown
+## Quick Start
+
+Do not create release tags manually. Tags are created by the `Prepare Release`
+workflow only after every required release gate passes.
+
+```bash
+# 1. Verify main is current remotely
+git fetch origin main --tags
+git rev-parse origin/main
+
+# 2. Run release preparation as a dry run
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=true
+
+# 3. After the dry run passes, run the real preparation
+gh workflow run prepare-release.yml \
+  --repo Obsidian-Owl/floe \
+  -f version=v0.1.0-alpha.1 \
+  -f dry_run=false
+```
+
+If any gate fails, the workflow creates or updates a GitHub issue and does not
+create a tag, GitHub Release, or PyPI publication.
+```
+```
+
+Remove the direct `git tag -a` command from the normal path. Keep rollback
+notes only as an emergency section for manually deleting a bad tag created by
+older workflows.
+
+- [ ] **Step 2: Update CI lane docs**
+
+In `.github/CI.md`, update the quick reference table:
+
+```markdown
+| Trigger | Workflow | Purpose |
+|---|---|---|
+| Pull request | `ci.yml` | Fast PR confidence plus release manifest structure |
+| `merge_group` / pull request label `run-e2e` / infra path / manual | `e2e.yml` | Opt-in full E2E validation |
+| Manual | `prepare-release.yml` | Runs all release gates, creates tag and GitHub Release only on success |
+| Successful Prepare Release | `pypi-publish.yml` | Builds and publishes manifest package set |
+| Schedule / manual | `weekly.yml` | Long-running early warning with failure issues |
+```
+
+Add a short section:
+
+```markdown
+## Prepare Release
+
+`prepare-release.yml` is the release authority. Maintainers dispatch it with a
+version. The workflow runs static gates, package build dry-run, integration,
+full E2E, AWS live validation, cleanup verification, and evidence generation.
+It creates the tag and GitHub Release only after all gates pass.
+```
+
+- [ ] **Step 3: Update alpha checklist**
+
+In `docs/releases/v0.1.0-alpha.1-checklist.md`:
+
+- Replace “do not tag until evidence bundle is complete” with “run
+  `prepare-release.yml`; the workflow creates the tag only after evidence is
+  complete.”
+- Replace manual `git tag` command with `gh workflow run prepare-release.yml`.
+- Keep the 15 publish / 11 exclude package list.
+- Add that weekly failures and release-gate failures create/update GitHub
+  issues.
+
+- [ ] **Step 4: Run docs validation**
+
+Run:
+
+```bash
+uv run python testing/ci/validate-docs-navigation.py
+uv run python testing/ci/validate-docs-content.py
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RELEASING.md .github/CI.md docs/releases/v0.1.0-alpha.1-checklist.md
+git commit -m "Document prepare release workflow"
+```
+
+---
+
+### Task 10: Final Verification And PR
+
+**Files:**
+- No planned source edits unless verification exposes a defect.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+uv run pytest \
+  testing/tests/unit/test_release_candidate.py \
+  testing/tests/unit/test_release_failure_issue.py \
+  testing/tests/unit/test_release_cleanup.py \
+  testing/tests/unit/test_prepare_release_workflow.py \
+  testing/tests/unit/test_ci_workflows.py::TestPypiPublishWorkflow \
+  testing/tests/unit/test_ci_workflows.py::TestReleaseWorkflowAuthority \
+  testing/tests/unit/test_ci_workflows.py::TestWeeklyWorkflow::test_weekly_has_failure_issue_job \
+  testing/tests/unit/test_release_evidence.py \
+  -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run workflow linting**
+
+Run:
+
+```bash
+actionlint \
+  .github/workflows/prepare-release.yml \
+  .github/workflows/release.yml \
+  .github/workflows/pypi-publish.yml \
+  .github/workflows/weekly.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Run release manifest and package dry-run**
+
+Run:
+
+```bash
+uv run python -m testing.release.cli validate \
+  --manifest release/floe-release.yaml \
+  --tag v0.1.0-alpha.1
+
+rm -rf dist/release-dry-run
+uv run python -m testing.release.cli build \
+  --manifest release/floe-release.yaml \
+  --dist-dir dist/release-dry-run
+find dist/release-dry-run -name '*.whl' | wc -l
+find dist/release-dry-run -name '*.tar.gz' | wc -l
+rm -rf dist/release-dry-run
+```
+
+Expected:
+
+- manifest validation prints `publish_count: 15`
+- wheel count is `15`
+- sdist count is `15`
+
+- [ ] **Step 4: Run docs validation**
+
+Run:
+
+```bash
+uv run python testing/ci/validate-docs-navigation.py
+uv run python testing/ci/validate-docs-content.py
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run broader local gate if time allows**
+
+Run:
+
+```bash
+make lint
+make typecheck
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit any verification fixes**
+
+If verification required fixes:
+
+```bash
+git add <changed-files>
+git commit -m "Fix prepare release verification"
+```
+
+If no fixes were required, skip this step.
+
+- [ ] **Step 7: Push branch and open PR**
+
+Run:
+
+```bash
+git status --short
+git push -u origin release/prepare-release-gate
+gh pr create \
+  --repo Obsidian-Owl/floe \
+  --base main \
+  --head release/prepare-release-gate \
+  --title "Automate alpha release gate before tagging" \
+  --body-file /tmp/prepare-release-pr.md
+```
+
+Use this PR body:
+
+```markdown
+## Summary
+
+- Adds a manual Prepare Release workflow that creates the release tag and GitHub Release only after all gates pass.
+- Keeps PyPI publication downstream of verified release metadata and manifest package scope.
+- Adds failure issue generation for release-gate and weekly validation failures.
+- Updates release docs so maintainers no longer push alpha tags directly.
+
+## Validation
+
+- [ ] Focused release workflow/unit tests
+- [ ] actionlint for changed workflows
+- [ ] release manifest validation
+- [ ] package build dry-run: 15 wheels and 15 sdists
+- [ ] docs validation
+- [ ] make lint
+- [ ] make typecheck
+
+## Release Safety
+
+Failed release candidates create no tag, no GitHub Release, and no PyPI publication.
+```
+
+---
+
+## Plan Self-Review
+
+Spec coverage:
+
+- Tag only after all gates pass: Tasks 4, 5, and 6.
+- No GitHub Release until gates pass: Tasks 4 and 5.
+- Failure issue creation for release and weekly lanes: Tasks 2, 5, and 8.
+- PRs stay fast by default: Task 9 documents lane ownership; no PR trigger changes add default E2E.
+- Alpha packages only: Tasks 5, 7, and 10 keep manifest build and publish behavior.
+- Evidence generated by automation: Tasks 3 and 5.
+- Cleanup as a gate: Tasks 3 and 5.
+- Docs updated: Task 9.
+
+Red-flag scan:
+
+- No incomplete work markers or vague deferred implementation steps are intended in this plan.
+- Implementation code snippets define every new helper referenced by tests.
+
+Type consistency:
+
+- `ReleaseCandidate`, `FailureIssue`, and `CleanupEvidence` names are used consistently across helper, CLI, and tests.
+- Workflow job names are consistently hyphenated: `resolve-candidate`, `static-and-contract-gates`, `package-build-dry-run`, `kind-integration`, `full-e2e`, `aws-live`, `cleanup-verify`, `release-evidence`, `create-release`, `failure-issue`.

--- a/docs/superpowers/specs/2026-05-14-alpha-release-cicd-automation-design.md
+++ b/docs/superpowers/specs/2026-05-14-alpha-release-cicd-automation-design.md
@@ -1,0 +1,528 @@
+# Alpha Release CI/CD Automation Design
+
+## Status
+
+Approved design for implementation planning.
+
+Date: 2026-05-14
+
+## Purpose
+
+Correct the alpha release automation model so Floe tags are created only after
+all required release gates pass. A failed release candidate must leave no Git
+tag, no GitHub Release, and no PyPI publication. Failures from release
+preparation and weekly deep validation must create actionable GitHub issues
+with logs, classification, and cleanup state.
+
+This design supersedes the manual pre-tag evidence variable flow for normal
+alpha releases. It keeps the manifest-driven alpha package cutline already
+landed on `main`, but changes release orchestration so the workflow produces
+release evidence instead of requiring maintainers to pre-populate repository
+variables.
+
+## Current System Map
+
+The merged release model on `origin/main` has these important properties:
+
+- `release/floe-release.yaml` is the release contract.
+- The manifest declares `v0.1.0-alpha.1`, Python version `0.1.0a1`, Helm
+  version `0.1.0-alpha.1`, 15 published Python packages, and 11 excluded
+  packages.
+- `.github/workflows/pypi-publish.yml` builds packages from
+  `release/floe-release.yaml`; it no longer uses the stale hardcoded 24-package
+  array.
+- `.github/workflows/release.yml` is still tag-triggered for `v*.*.*`.
+- The tag-triggered Release workflow validates the manifest and runs Kind
+  integration tests, but it does not run full DevPod+Hetzner E2E or AWS
+  S3+Glue live validation.
+- The tag-triggered Release workflow currently expects
+  `RELEASE_DEVPOD_ARTIFACT`, `RELEASE_AWS_LIVE_RESULT`, and
+  `RELEASE_CLEANUP_RESULT` repository variables to exist before creating the
+  GitHub Release.
+- `.github/workflows/e2e.yml` does not run on every PR. It runs for merge
+  queue, manual dispatch, PRs labeled for E2E, or PRs whose changed files match
+  the infrastructure filter.
+- `.github/workflows/weekly.yml` runs scheduled integration and E2E checks in
+  GitHub-hosted Kind, but it does not own the formal release tag or publication
+  decision.
+
+The gap is not package scope. The gap is release orchestration: tag creation is
+currently the trigger for release work, while the desired model is for tag
+creation to be the output of a fully successful release gate.
+
+## Goals
+
+- Do not run long E2E validation on every PR.
+- Create a release tag only after every required release gate passes.
+- Do not create a GitHub Release until every required release gate passes.
+- Do not publish to PyPI unless the tag and GitHub Release were produced by a
+  successful release-preparation workflow.
+- Keep alpha publication manifest-driven and limited to the 15 packages in
+  `release/floe-release.yaml`.
+- Automatically produce release evidence during release preparation.
+- Automatically create or update GitHub issues for release-gate and weekly
+  validation failures.
+- Preserve cleanup discipline for DevPod, Hetzner, and AWS resources.
+- Keep weekly deep validation as an early-warning lane, not as the formal
+  release authority.
+
+## Non-Goals
+
+- Do not publish the 11 packages excluded from the alpha manifest.
+- Do not add full E2E to the default PR path.
+- Do not make weekly CI create tags, GitHub Releases, or PyPI publications.
+- Do not replace the release manifest with workflow-local package arrays.
+- Do not require manual repository variables for normal alpha release evidence.
+- Do not implement a full release-train platform beyond the alpha gate.
+- Do not change plugin contracts or package contents as part of this CI/CD
+  control change.
+
+## Recommended Approach
+
+Introduce a manual `Prepare Release` workflow. This workflow is the only path
+that creates the alpha release tag.
+
+The maintainer dispatches the workflow with a requested version, for example:
+
+```text
+v0.1.0-alpha.1
+```
+
+The workflow checks out `origin/main`, validates the requested version against
+`release/floe-release.yaml`, runs every required release gate, generates the
+release evidence bundle, and only then creates the annotated tag and GitHub
+Release. PyPI publication remains downstream of successful release metadata.
+
+This approach avoids failed release tags. If a release candidate fails, the
+failure is represented as a GitHub issue and workflow artifact rather than a
+published release object.
+
+## Alternatives Considered
+
+### Tag-Triggered Gate With Deferred Publish
+
+Pushing `v0.1.0-alpha.1` could run all gates and publish only if successful.
+
+Pros:
+
+- Conventional Git tag trigger.
+- Simple mental model for package publishing.
+- Compatible with the current tag-triggered Release workflow shape.
+
+Cons:
+
+- A failed candidate leaves a release tag behind.
+- Retagging or deleting tags creates operational ambiguity.
+- The user's desired invariant is stricter: no tag until all gates pass.
+
+Decision: rejected for alpha.
+
+### Weekly Evidence Plus Lightweight Tag Gate
+
+Weekly CI could run deep validation and tagging could check that weekly
+evidence is recent enough.
+
+Pros:
+
+- Faster release day.
+- Lower release-day infrastructure risk.
+- Good continuous signal between releases.
+
+Cons:
+
+- Requires freshness and commit-match rules.
+- A weekly pass can drift from the exact release SHA.
+- It makes the formal release gate dependent on prior workflow state.
+
+Decision: keep weekly as early warning only, not release authority.
+
+### Prepare Release Creates Tag After Success
+
+The release workflow runs first and creates the tag only after every gate
+passes.
+
+Pros:
+
+- No failed tags.
+- No GitHub Release until all gates pass.
+- Release evidence is generated by automation.
+- PyPI publication can trust release metadata produced by the gate.
+- Long tests stay out of normal PR CI.
+
+Cons:
+
+- Requires GitHub Actions permissions to create annotated tags and releases.
+- Requires failure issue automation.
+- Requires careful separation between candidate validation and final publish.
+
+Decision: recommended.
+
+## Target Workflow Topology
+
+### Pull Request CI
+
+PRs remain fast by default:
+
+- lint and formatting
+- typecheck
+- unit tests
+- contract tests
+- release manifest validation when release files change
+- security scan
+- docs checks where relevant
+
+Full E2E remains opt-in for PRs through one of:
+
+- `run-e2e` label
+- merge queue
+- manual dispatch
+- infrastructure file filter when intentionally enabled
+
+### Weekly Deep Validation
+
+Weekly CI remains scheduled and manually dispatchable. It should run:
+
+- Kind integration tests
+- standard E2E
+- destructive E2E after standard E2E success
+- AWS S3+Glue live validation when credentials and cost controls are available
+- cleanup verification
+- dependency audit and security checks
+
+Weekly failures must create or update a GitHub issue. Weekly does not create
+tags, GitHub Releases, or PyPI publications.
+
+### Prepare Release
+
+The new release-preparation workflow is manually dispatched by a maintainer. It
+takes:
+
+- `version`: required, for example `v0.1.0-alpha.1`
+- optional `dry_run`: default `false`; when `true`, run all gates but do not
+  create tag, GitHub Release, or trigger PyPI publication
+
+Release preparation runs from `origin/main`, not from a feature branch.
+
+Required jobs:
+
+1. `resolve-candidate`
+   - Fetch `origin/main`.
+   - Resolve the exact release SHA.
+   - Validate clean version input.
+   - Validate the requested version matches `release/floe-release.yaml`.
+   - Verify no matching local or remote tag already exists.
+
+2. `static-and-contract-gates`
+   - Run the CI-equivalent fast checks needed before expensive gates.
+   - Validate the release manifest.
+   - Verify the alpha package cutline is exactly manifest-driven.
+   - Verify no stale hardcoded publish-all package arrays exist in release
+     workflows.
+
+3. `package-build-dry-run`
+   - Run `testing.release.cli build` for the manifest package set.
+   - Assert 15 wheels and 15 sdists for the current alpha manifest.
+   - Upload build artifacts for inspection, but do not publish.
+
+4. `kind-integration`
+   - Run the current release integration test path.
+   - Upload logs and JUnit artifacts.
+
+5. `full-e2e`
+   - Run full E2E.
+   - Standard E2E must pass before destructive E2E starts.
+   - Upload logs, JUnit artifacts, and cluster diagnostics.
+
+6. `aws-live`
+   - Run AWS S3+Glue live validation when `require_aws_provider_live` is true.
+   - Use configured AWS test-account inputs.
+   - Ensure remote environment files are scrubbed and not uploaded.
+   - Upload sanitized logs only.
+
+7. `cleanup-verify`
+   - Verify DevPod workspace state where DevPod is used.
+   - Verify Hetzner current-run servers, volumes, load balancers, floating IPs,
+     and SSH keys are absent.
+   - Verify AWS S3 run prefix and Glue run database are absent.
+   - Fail the release if cleanup fails, even when product tests passed.
+
+8. `release-evidence`
+   - Generate `release-evidence.md` from actual workflow results.
+   - Include release SHA, manifest path, package cutline, E2E artifact links,
+     AWS live result, and cleanup result.
+   - Redact credentials and reject publishable evidence containing placeholders.
+
+9. `create-release`
+   - Runs only when every prior gate succeeds and `dry_run` is false.
+   - Create an annotated tag for the requested version at the validated release
+     SHA.
+   - Push the tag.
+   - Create the GitHub Release with `release-evidence.md`.
+   - Upload a `release-metadata` artifact containing tag, SHA, version, and
+     manifest package list.
+
+10. `failure-issue`
+    - Runs when any gate fails.
+    - Creates or updates a GitHub issue.
+    - Does not run on successful candidates.
+
+## Failure Issue Behavior
+
+Release-preparation and weekly deep-validation failures should use the same
+issue-writing helper.
+
+Issue labels should include:
+
+- `ci-failure`
+- `release-gate` or `weekly-validation`
+- one or more classification labels:
+  - `product-failure`
+  - `infrastructure-failure`
+  - `credential-setup-failure`
+  - `cleanup-failure`
+  - `release-tooling-failure`
+
+The issue title should be deterministic enough to deduplicate repeated
+failures. Example:
+
+```text
+Release gate failed: v0.1.0-alpha.1 full-e2e infrastructure failure
+```
+
+The issue body must include:
+
+- workflow run URL
+- commit SHA
+- requested version, when applicable
+- failed gate name
+- failure classification
+- short log excerpt
+- artifact links
+- cleanup status
+- whether tag, GitHub Release, and PyPI publish were skipped
+- next recommended action
+
+When an open issue for the same workflow, version, and gate already exists, the
+workflow should add a comment instead of opening a duplicate issue. A later
+successful run may comment on the issue with the passing run URL, but it should
+not close the issue automatically unless the team explicitly wants that
+behavior later.
+
+## Publication Boundary
+
+Alpha publication must remain manifest-driven.
+
+`release/floe-release.yaml` is the only source of truth for Python package
+publication. Workflows must not define their own package arrays or expected
+counts.
+
+For `v0.1.0-alpha.1`, publication is limited to:
+
+- `floe-core`
+- `floe-iceberg`
+- `floe-orchestrator-dagster`
+- `floe-catalog-polaris`
+- `floe-storage-minio`
+- `floe-compute-duckdb`
+- `floe-dbt-core`
+- `floe-ingestion-dlt`
+- `floe-telemetry-jaeger`
+- `floe-rbac-k8s`
+- `floe-network-security-k8s`
+- `floe-lineage-marquez`
+- `floe-quality-gx`
+- `floe-storage-aws-s3`
+- `floe-catalog-glue`
+
+The 11 manifest-excluded packages must not be built or published by alpha
+release automation.
+
+Regression tests should assert that:
+
+- `pypi-publish.yml` consumes the release metadata and manifest package list.
+- No hardcoded publish-all array is present.
+- Built wheel and sdist counts derive from manifest publish count.
+- Excluded package names do not appear in publish commands.
+
+## PyPI Publish Model
+
+PyPI publishing remains downstream of the successful release gate.
+
+The publish workflow should run from successful `Prepare Release` completion or
+from the GitHub Release metadata artifact produced by that workflow. It should:
+
+- download verified release metadata
+- check out the verified release SHA, not a mutable tag, for building
+- validate the manifest against the release tag
+- build only manifest packages
+- verify artifact counts against the manifest
+- publish only after the GitHub Release exists
+- publish through the configured `pypi` environment
+
+The workflow must reject manual publishing. Manual dispatch may remain as a dry
+run only.
+
+## Helm Release Model
+
+Helm behavior remains explicit in the release manifest.
+
+For alpha, `helm.alpha_policy: publish` means Helm chart publication is part of
+release automation. Helm chart version must match the manifest Helm version and
+the requested release version after normalization.
+
+Helm publication should occur only after the same successful release-preparation
+gate, not from an independent stale tag path. If separate Helm tags remain for
+compatibility, they must be created by automation after the primary release gate
+passes and must enforce tag/version parity.
+
+## Evidence Model
+
+The release workflow should generate evidence instead of consuming manually
+configured evidence variables.
+
+Evidence must include:
+
+- release SHA
+- requested version
+- manifest package publish and exclude lists
+- CI/static gate results
+- package build dry-run result and artifact counts
+- Kind integration result
+- full E2E result
+- AWS S3+Glue result when required
+- cleanup verification result
+- links to sanitized artifacts
+
+Evidence must not include:
+
+- AWS access keys
+- AWS secret keys
+- session tokens
+- bearer tokens
+- remote env files
+- kubeconfigs with credentials
+- provider secrets
+
+The existing `testing.release.evidence` redaction and publishability checks
+should be reused and extended as needed.
+
+## Cleanup Model
+
+Cleanup is a release gate, not a courtesy step.
+
+The release candidate fails if current-run resources remain after cleanup.
+Required cleanup checks:
+
+- DevPod workspace inventory
+- Hetzner servers
+- Hetzner volumes
+- Hetzner SSH keys
+- Hetzner load balancers
+- Hetzner floating IPs
+- AWS S3 run prefix
+- AWS Glue run database and tables
+
+Failure issue bodies must distinguish product failures from cleanup failures.
+If product tests pass but cleanup fails, the issue should state that the product
+lane passed and the release remains blocked only by cleanup.
+
+## Security And Permissions
+
+The prepare-release workflow needs explicit permissions:
+
+- `contents: write` to create tags and GitHub Releases
+- `actions: read` to collect artifacts and metadata
+- `issues: write` to create or update failure issues
+
+AWS credentials must come from existing provider-test configuration and must
+not be committed, uploaded, or written into release evidence.
+
+PyPI credentials stay scoped to the `pypi` environment. The long-term target is
+trusted publishing/OIDC, but this design does not require that migration before
+alpha if the existing token path is otherwise configured.
+
+## Documentation Updates
+
+Update release docs so maintainers do not push tags directly.
+
+Required docs changes:
+
+- `RELEASING.md`
+  - Replace direct `git tag` quick start with `gh workflow run prepare-release`.
+  - Explain that tags are created only by the successful release workflow.
+  - Document failed candidate issue behavior.
+  - Document weekly deep-validation issue behavior.
+
+- `.github/CI.md`
+  - Add CI lane ownership: PR, merge queue, weekly, prepare release, publish.
+  - Explain which lanes run long E2E.
+
+- `docs/releases/v0.1.0-alpha.1-checklist.md`
+  - Replace manual evidence variable setup with automated evidence generation.
+  - Keep the alpha package cutline explicit.
+
+## Test Strategy
+
+Unit and structural tests should cover workflow behavior without executing
+GitHub Actions.
+
+Required tests:
+
+- prepare-release workflow exists and is `workflow_dispatch` only
+- prepare-release has no tag trigger
+- prepare-release validates manifest version against requested version
+- prepare-release creates the tag only in the final success job
+- prepare-release creates no GitHub Release before all gate jobs succeed
+- prepare-release has a failure issue job with `if: failure()`
+- failure issue job has `issues: write`
+- PyPI publish consumes release metadata and manifest package list
+- PyPI publish cannot publish on manual dispatch
+- release/tag workflows cannot publish hardcoded 24-package arrays
+- weekly workflow has failure issue handling
+- release evidence rejects placeholders and failed statuses
+- cleanup verification classifies cleanup failures separately from product and
+  infrastructure failures
+
+Live validation of the implementation should use a dry run first, then a real
+release-preparation run for alpha.
+
+## Migration Plan
+
+1. Add workflow helper scripts for release candidate resolution, evidence
+   aggregation, cleanup verification, and failure issue creation.
+2. Add or replace workflow structural tests.
+3. Add the new `prepare-release.yml` workflow.
+4. Change `release.yml` from tag authority to release creation helper or retire
+   it if `prepare-release.yml` owns GitHub Release creation directly.
+5. Update `pypi-publish.yml` to trust only successful prepare-release metadata.
+6. Update weekly workflow to create or update failure issues.
+7. Update release documentation.
+8. Run local workflow structural tests and manifest build dry-run.
+9. Push a PR and verify normal CI.
+10. Run prepare-release with `dry_run: true`.
+11. Run prepare-release for `v0.1.0-alpha.1` when dry run and credentials are
+    confirmed.
+
+## Open Questions For Implementation
+
+- Whether to keep a separate `release.yml` workflow as a thin GitHub Release
+  creator or consolidate release creation into `prepare-release.yml`.
+- Whether weekly success should comment on and close prior failure issues or
+  only comment with recovery evidence.
+- Whether full DevPod+Hetzner E2E should run inside GitHub Actions or through
+  an existing remote DevPod wrapper invoked by GitHub Actions.
+- Whether Helm charts should be published by the same workflow or by a
+  downstream workflow that consumes prepare-release metadata.
+
+## Acceptance Criteria
+
+- Maintainers can no longer accidentally publish alpha by pushing a tag before
+  deep gates pass.
+- A successful prepare-release run creates the annotated tag and GitHub Release.
+- Failed prepare-release runs create no tag, no GitHub Release, and no PyPI
+  publication.
+- Failed prepare-release and weekly runs create or update GitHub issues with
+  logs and failure classification.
+- PyPI publishes only the manifest-declared alpha packages.
+- Weekly validation remains available as long-running early warning.
+- PR CI remains fast by default and does not run full E2E on every PR.

--- a/testing/release/candidate.py
+++ b/testing/release/candidate.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.release.manifest import load_release_manifest, validate_release_manifest
+
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+class ReleaseCandidateError(ValueError):
+    """Raised when a release candidate cannot safely create a tag."""
+
+
+@dataclass(frozen=True)
+class ReleaseCandidate:
+    """Validated release candidate metadata."""
+
+    version: str
+    release_sha: str
+    python_version: str
+    helm_version: str
+    publish_count: int
+
+
+def validate_release_candidate(
+    *,
+    requested_version: str,
+    release_sha: str,
+    manifest_path: Path,
+    repo_root: Path,
+    existing_tags: tuple[str, ...],
+) -> ReleaseCandidate:
+    """Validate that a requested release can create a new tag."""
+    version = requested_version.strip()
+    normalized_sha = release_sha.strip()
+    if not version:
+        raise ReleaseCandidateError("requested version is required")
+    if not version.startswith("v"):
+        raise ReleaseCandidateError("requested version must start with 'v'")
+    if not _COMMIT_SHA_RE.fullmatch(normalized_sha):
+        raise ReleaseCandidateError("release_sha must be a 40-character commit SHA")
+    if version in existing_tags:
+        raise ReleaseCandidateError(f"release tag already exists: {version}")
+
+    manifest = load_release_manifest(manifest_path)
+    if manifest.release.git_tag != version:
+        raise ReleaseCandidateError(
+            f"requested version {version} does not match manifest git_tag "
+            f"{manifest.release.git_tag}",
+        )
+
+    result = validate_release_manifest(manifest, repo_root=repo_root, tag=version)
+    return ReleaseCandidate(
+        version=version,
+        release_sha=normalized_sha,
+        python_version=result.python_version,
+        helm_version=result.helm_version,
+        publish_count=result.publish_count,
+    )

--- a/testing/release/cleanup.py
+++ b/testing/release/cleanup.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CleanupEvidence:
+    """Cleanup evidence for release and weekly validation lanes."""
+
+    devpod: str
+    hetzner: str
+    aws: str
+
+
+def cleanup_status(evidence: CleanupEvidence) -> str:
+    """Collapse cleanup evidence into a release gate status."""
+    values = (evidence.devpod, evidence.hetzner, evidence.aws)
+    normalized = tuple(value.strip().lower() for value in values)
+    if any(value.startswith("failed") for value in normalized):
+        return "failed cleanup"
+    if any(value in {"", "not-run"} for value in normalized):
+        return "not-run"
+    if all(value == "passed" for value in normalized):
+        return "passed"
+    return "failed cleanup"
+
+
+def cleanup_summary(evidence: CleanupEvidence) -> str:
+    """Return a short human-readable cleanup summary."""
+    return f"DevPod: {evidence.devpod}; Hetzner: {evidence.hetzner}; AWS: {evidence.aws}"

--- a/testing/release/cli.py
+++ b/testing/release/cli.py
@@ -118,19 +118,23 @@ def main(argv: list[str] | None = None) -> None:
     try:
         manifest = load_release_manifest(manifest_path)
         if args.command == "candidate":
-            result = validate_release_candidate(
+            candidate_result = validate_release_candidate(
                 requested_version=args.version,
                 release_sha=args.release_sha,
                 manifest_path=manifest_path,
                 repo_root=repo_root,
                 existing_tags=tuple(args.existing_tag),
             )
-            print(json.dumps(asdict(result), indent=2, sort_keys=True))
+            print(json.dumps(asdict(candidate_result), indent=2, sort_keys=True))
             return
 
         if args.command == "validate":
-            result = validate_release_manifest(manifest, repo_root=repo_root, tag=args.tag)
-            print(json.dumps(asdict(result), indent=2, sort_keys=True))
+            validation_result = validate_release_manifest(
+                manifest,
+                repo_root=repo_root,
+                tag=args.tag,
+            )
+            print(json.dumps(asdict(validation_result), indent=2, sort_keys=True))
             return
 
         if args.command == "package-list":
@@ -159,12 +163,12 @@ def main(argv: list[str] | None = None) -> None:
             return
 
         if args.command == "evidence-summary":
-            result = validate_release_manifest(manifest, repo_root=repo_root)
+            validation_result = validate_release_manifest(manifest, repo_root=repo_root)
             write_evidence_summary(
                 output_path=_resolve_path(repo_root, args.output),
                 release_sha=args.release_sha,
                 manifest_path=manifest_path.relative_to(repo_root),
-                package_count=result.publish_count,
+                package_count=validation_result.publish_count,
                 devpod_artifact=args.devpod_artifact,
                 aws_live_result=args.aws_live_result,
                 cleanup_result=args.cleanup_result,

--- a/testing/release/cli.py
+++ b/testing/release/cli.py
@@ -10,7 +10,10 @@ from typing import NoReturn
 import yaml
 
 from testing.release.build_packages import ReleaseBuildError, artifact_counts, build_packages
+from testing.release.candidate import ReleaseCandidateError, validate_release_candidate
+from testing.release.cleanup import CleanupEvidence, cleanup_status, cleanup_summary
 from testing.release.evidence import EvidenceSummaryError, write_evidence_summary
+from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
 from testing.release.manifest import (
     ReleaseManifestError,
     load_release_manifest,
@@ -25,6 +28,12 @@ def main(argv: list[str] | None = None) -> None:
     validate_parser = subparsers.add_parser("validate")
     validate_parser.add_argument("--manifest", default="release/floe-release.yaml")
     validate_parser.add_argument("--tag", default=None)
+
+    candidate_parser = subparsers.add_parser("candidate")
+    candidate_parser.add_argument("--manifest", default="release/floe-release.yaml")
+    candidate_parser.add_argument("--version", required=True)
+    candidate_parser.add_argument("--release-sha", required=True)
+    candidate_parser.add_argument("--existing-tag", action="append", default=[])
 
     list_parser = subparsers.add_parser("package-list")
     list_parser.add_argument("--manifest", default="release/floe-release.yaml")
@@ -51,12 +60,74 @@ def main(argv: list[str] | None = None) -> None:
         help="Allow pre-tag placeholder evidence for planning runs only.",
     )
 
+    cleanup_parser = subparsers.add_parser("cleanup-summary")
+    cleanup_parser.add_argument("--devpod", required=True)
+    cleanup_parser.add_argument("--hetzner", required=True)
+    cleanup_parser.add_argument("--aws", required=True)
+
+    issue_parser = subparsers.add_parser("failure-issue")
+    issue_parser.add_argument("--lane", required=True)
+    issue_parser.add_argument("--version", default=None)
+    issue_parser.add_argument("--gate", required=True)
+    issue_parser.add_argument("--classification", required=True)
+    issue_parser.add_argument("--sha", required=True)
+    issue_parser.add_argument("--run-url", required=True)
+    issue_parser.add_argument("--log-excerpt", default="")
+    issue_parser.add_argument("--cleanup-status", default="not-run")
+    issue_parser.add_argument("--skipped-output", action="append", default=[])
+    issue_parser.add_argument("--output", required=True)
+
     args = parser.parse_args(argv)
     repo_root = Path.cwd()
+
+    if args.command == "cleanup-summary":
+        evidence = CleanupEvidence(devpod=args.devpod, hetzner=args.hetzner, aws=args.aws)
+        print(
+            json.dumps(
+                {
+                    "status": cleanup_status(evidence),
+                    "summary": cleanup_summary(evidence),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+        )
+        return
+
+    if args.command == "failure-issue":
+        issue = FailureIssue(
+            lane=args.lane,
+            version=args.version,
+            gate=args.gate,
+            classification=args.classification,
+            sha=args.sha,
+            run_url=args.run_url,
+            log_excerpt=args.log_excerpt,
+            cleanup_status=args.cleanup_status,
+            skipped_outputs=tuple(args.skipped_output),
+        )
+        output = {
+            "title": issue_title(issue),
+            "body": issue_comment_body(issue),
+        }
+        Path(args.output).write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        return
+
     manifest_path = _resolve_manifest_path(repo_root, args.manifest)
 
     try:
         manifest = load_release_manifest(manifest_path)
+        if args.command == "candidate":
+            result = validate_release_candidate(
+                requested_version=args.version,
+                release_sha=args.release_sha,
+                manifest_path=manifest_path,
+                repo_root=repo_root,
+                existing_tags=tuple(args.existing_tag),
+            )
+            print(json.dumps(asdict(result), indent=2, sort_keys=True))
+            return
+
         if args.command == "validate":
             result = validate_release_manifest(manifest, repo_root=repo_root, tag=args.tag)
             print(json.dumps(asdict(result), indent=2, sort_keys=True))
@@ -111,6 +182,7 @@ def main(argv: list[str] | None = None) -> None:
     except (
         EvidenceSummaryError,
         OSError,
+        ReleaseCandidateError,
         ReleaseBuildError,
         ReleaseManifestError,
         yaml.YAMLError,

--- a/testing/release/failure_issue.py
+++ b/testing/release/failure_issue.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailureIssue:
+    """Issue content for release-gate and weekly validation failures."""
+
+    lane: str
+    version: str | None
+    gate: str
+    classification: str
+    sha: str
+    run_url: str
+    log_excerpt: str
+    cleanup_status: str
+    skipped_outputs: tuple[str, ...] = ()
+
+
+def issue_title(issue: FailureIssue) -> str:
+    """Return a deterministic title suitable for issue deduplication."""
+    if issue.lane == "release-gate":
+        version = issue.version or "unknown-version"
+        return f"Release gate failed: {version} {issue.gate} {issue.classification} failure"
+    if issue.lane == "weekly-validation":
+        return f"Weekly validation failed: {issue.gate} {issue.classification} failure"
+    return f"Validation failed: {issue.lane} {issue.gate} {issue.classification} failure"
+
+
+def issue_comment_body(issue: FailureIssue) -> str:
+    """Return a markdown issue body or update comment for a failed validation run."""
+    skipped = (
+        ", ".join(f"`{name}`" for name in issue.skipped_outputs)
+        if issue.skipped_outputs
+        else "_none_"
+    )
+    version = issue.version or "_not applicable_"
+    excerpt = issue.log_excerpt.strip() or "_No log excerpt captured._"
+    version_line = (
+        f"Requested version: `{version}`" if issue.version else f"Requested version: {version}"
+    )
+    return "\n".join(
+        [
+            "## Validation Failure",
+            "",
+            f"Workflow run: {issue.run_url}",
+            f"Commit: `{issue.sha}`",
+            version_line,
+            f"Failed gate: `{issue.gate}`",
+            f"Classification: `{issue.classification}`",
+            f"Cleanup status: `{issue.cleanup_status}`",
+            f"Skipped outputs: {skipped}",
+            "",
+            "### Log Excerpt",
+            "",
+            "```text",
+            excerpt[-4000:],
+            "```",
+            "",
+            "### Next Action",
+            "",
+            (
+                "Triage the failed gate, preserve cleanup evidence, and rerun the "
+                "workflow after the fix lands."
+            ),
+            "",
+        ],
+    )

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -156,6 +156,7 @@ class TestWeeklyWorkflow:
         has_from = any(line.upper().startswith("FROM") for line in lines)
         assert has_from, "Dockerfile missing FROM instruction"
 
+    @pytest.mark.requirement("REL-GATE-WEEKLY")
     def test_weekly_has_failure_issue_job(self) -> None:
         """Weekly long-running validation failures create actionable issues."""
         workflow = yaml.safe_load(WEEKLY_WORKFLOW.read_text(encoding="utf-8"))
@@ -172,6 +173,7 @@ class TestWeeklyWorkflow:
 class TestPypiPublishWorkflow:
     """Structural validation of the PyPI publish release gate."""
 
+    @pytest.mark.requirement("REL-GATE-PUBLISH")
     def test_pypi_publish_runs_after_prepare_release_success_instead_of_tag_push(self) -> None:
         """PyPI upload starts only after Prepare Release completes successfully."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
@@ -183,6 +185,7 @@ class TestPypiPublishWorkflow:
         assert "\n  push:" not in on_block
         assert "\n    tags:" not in on_block
 
+    @pytest.mark.requirement("REL-GATE-PUBLISH")
     def test_pypi_publish_job_uses_release_metadata_instead_of_head_branch(self) -> None:
         """Publishing resolves immutable release metadata from the Prepare Release run."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
@@ -191,9 +194,11 @@ class TestPypiPublishWorkflow:
         assert "github.event.workflow_run.conclusion == 'success'" in workflow_text
         assert "github.event.workflow_run.event == 'workflow_dispatch'" in workflow_text
         assert "github.event.workflow_run.name == 'Prepare Release'" in workflow_text
-        assert "contains(github.event.workflow_run.display_title, 'dry_run=false')" in workflow_text
+        assert "github.event.workflow_run.display_title" not in workflow_text
         assert "gh run download" in workflow_text
         assert "--name release-metadata" in workflow_text
+        assert "publish=true" in workflow_text
+        assert "publish=false" in workflow_text
         assert (
             "ref: ${{ github.event_name == 'workflow_run' && "
             "steps.release_metadata.outputs.sha || github.ref }}"
@@ -202,13 +207,18 @@ class TestPypiPublishWorkflow:
         assert "startsWith(github.event.workflow_run.head_branch" not in workflow_text
         assert "github.event.workflow_run.head_branch" not in workflow_text
 
+    @pytest.mark.requirement("REL-GATE-PUBLISH")
     def test_prepare_release_uploads_release_metadata_for_pypi_publish(self) -> None:
         """Prepare Release publishes tag/SHA metadata consumed by PyPI publish."""
         workflow_text = PREPARE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
         assert "release-metadata/release-metadata.json" in workflow_text
         assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow_text
+        assert "RELEASE_VERSION: ${{ needs.resolve-candidate.outputs.python_version }}" in (
+            workflow_text
+        )
 
+    @pytest.mark.requirement("REL-GATE-PUBLISH")
     def test_manual_pypi_dispatch_is_build_only_dry_run(self) -> None:
         """Manual PyPI dispatch keeps dry-run support but cannot upload artifacts."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
@@ -222,14 +232,18 @@ class TestPypiPublishWorkflow:
 class TestReleaseWorkflowAuthority:
     """Release workflow must not create releases directly from tag pushes."""
 
+    @pytest.mark.requirement("REL-GATE-AUTHORITY")
     def test_release_workflow_has_no_push_tag_trigger(self) -> None:
+        """The legacy release smoke workflow has no tag-push trigger."""
         workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         on_block = workflow_text.split("\nconcurrency:", maxsplit=1)[0]
 
         assert "\n  push:" not in on_block
         assert "\n    tags:" not in on_block
 
+    @pytest.mark.requirement("REL-GATE-AUTHORITY")
     def test_release_creation_is_owned_by_prepare_release(self) -> None:
+        """GitHub Release creation belongs to Prepare Release only."""
         prepare_text = PREPARE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
         release_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -24,6 +24,7 @@ WEEKLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "weekly.yml"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PYPI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pypi-publish.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+PREPARE_RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "prepare-release.yml"
 UV_SECURITY_ACTION = REPO_ROOT / ".github" / "actions" / "uv-security-audit" / "action.yml"
 PRE_COMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 SETUP_HOOKS = REPO_ROOT / "scripts" / "setup-hooks.sh"
@@ -155,28 +156,42 @@ class TestWeeklyWorkflow:
         has_from = any(line.upper().startswith("FROM") for line in lines)
         assert has_from, "Dockerfile missing FROM instruction"
 
+    def test_weekly_has_failure_issue_job(self) -> None:
+        """Weekly long-running validation failures create actionable issues."""
+        workflow = yaml.safe_load(WEEKLY_WORKFLOW.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+
+        assert "failure-issue" in jobs
+        assert jobs["failure-issue"]["if"] == "${{ failure() }}"
+        assert jobs["failure-issue"]["permissions"]["issues"] == "write"
+        workflow_text = WEEKLY_WORKFLOW.read_text(encoding="utf-8")
+        assert "--lane weekly-validation" in workflow_text
+        assert "gh issue list" in workflow_text
+
 
 class TestPypiPublishWorkflow:
     """Structural validation of the PyPI publish release gate."""
 
-    def test_pypi_publish_runs_after_release_workflow_success_instead_of_tag_push(self) -> None:
-        """PyPI upload cannot start directly from a pushed release tag."""
+    def test_pypi_publish_runs_after_prepare_release_success_instead_of_tag_push(self) -> None:
+        """PyPI upload starts only after Prepare Release completes successfully."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
         on_block = workflow_text.split("\nconcurrency:", maxsplit=1)[0]
 
         assert "\n  workflow_run:" in on_block
-        assert "workflows: [Release]" in on_block
+        assert "workflows: [Prepare Release]" in on_block
         assert "types: [completed]" in on_block
         assert "\n  push:" not in on_block
         assert "\n    tags:" not in on_block
 
     def test_pypi_publish_job_uses_release_metadata_instead_of_head_branch(self) -> None:
-        """Publishing resolves immutable release metadata from the Release run artifact."""
+        """Publishing resolves immutable release metadata from the Prepare Release run."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
 
         assert "github.event_name == 'workflow_run'" in workflow_text
         assert "github.event.workflow_run.conclusion == 'success'" in workflow_text
-        assert "github.event.workflow_run.event == 'push'" in workflow_text
+        assert "github.event.workflow_run.event == 'workflow_dispatch'" in workflow_text
+        assert "github.event.workflow_run.name == 'Prepare Release'" in workflow_text
+        assert "contains(github.event.workflow_run.display_title, 'dry_run=false')" in workflow_text
         assert "gh run download" in workflow_text
         assert "--name release-metadata" in workflow_text
         assert (
@@ -187,12 +202,10 @@ class TestPypiPublishWorkflow:
         assert "startsWith(github.event.workflow_run.head_branch" not in workflow_text
         assert "github.event.workflow_run.head_branch" not in workflow_text
 
-    def test_release_workflow_uploads_release_metadata_for_pypi_publish(self) -> None:
-        """The Release workflow publishes tag/SHA metadata consumed by PyPI publish."""
-        workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    def test_prepare_release_uploads_release_metadata_for_pypi_publish(self) -> None:
+        """Prepare Release publishes tag/SHA metadata consumed by PyPI publish."""
+        workflow_text = PREPARE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-        assert "Validate release evidence variables" in workflow_text
-        assert "Repository variable ${var_name} must be configured" in workflow_text
         assert "release-metadata/release-metadata.json" in workflow_text
         assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow_text
 
@@ -204,6 +217,24 @@ class TestPypiPublishWorkflow:
         assert "dry_run:" in workflow_text
         assert "github.event_name == 'workflow_run'" in workflow_text
         assert "inputs.dry_run" not in workflow_text
+
+
+class TestReleaseWorkflowAuthority:
+    """Release workflow must not create releases directly from tag pushes."""
+
+    def test_release_workflow_has_no_push_tag_trigger(self) -> None:
+        workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        on_block = workflow_text.split("\nconcurrency:", maxsplit=1)[0]
+
+        assert "\n  push:" not in on_block
+        assert "\n    tags:" not in on_block
+
+    def test_release_creation_is_owned_by_prepare_release(self) -> None:
+        prepare_text = PREPARE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        release_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        assert "softprops/action-gh-release" in prepare_text
+        assert "softprops/action-gh-release" not in release_text
 
 
 class TestValuesTestCubeStore:

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -49,8 +49,8 @@ def test_prepare_release_has_version_and_dry_run_inputs() -> None:
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
-def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
-    """Release creation depends on every gate and owns tag creation."""
+def test_create_release_job_depends_on_all_gates_and_creates_release() -> None:
+    """Release creation depends on every gate and owns GitHub Release creation."""
     jobs = _workflow()["jobs"]
     create_release = jobs["create-release"]
 
@@ -67,9 +67,26 @@ def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
     }
 
     text = WORKFLOW.read_text(encoding="utf-8")
-    assert "git tag -a" in text
-    assert "git push origin" in text
+    assert "git tag -a" not in text
+    assert "git push origin" not in text
     assert "softprops/action-gh-release" in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_github_release_creation_is_tag_authority() -> None:
+    """Release creation must not leave an immutable tag without a release."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    create_release = _workflow()["jobs"]["create-release"]
+    release_steps = create_release["steps"]
+    github_release_step = next(
+        step for step in release_steps if step.get("name") == "Create GitHub Release"
+    )
+
+    assert "git tag -a" not in text
+    assert "git push origin" not in text
+    assert github_release_step["with"]["target_commitish"] == (
+        "${{ needs.resolve-candidate.outputs.release_sha }}"
+    )
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
@@ -124,3 +141,17 @@ def test_failure_issue_reports_failed_gate_from_needs_results() -> None:
     assert '--gate "${failed_gate}"' in text
     assert '--classification "${classification}"' in text
     assert "--gate unknown" not in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_failure_issue_covers_candidate_and_release_failures() -> None:
+    """Failure issues include pre-gate validation and post-gate release failures."""
+    job = _workflow()["jobs"]["failure-issue"]
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "resolve-candidate" in job["needs"]
+    assert "create-release" in job["needs"]
+    assert 'resolve-candidate="${RESOLVE_CANDIDATE_RESULT}"' in text
+    assert 'create-release="${CREATE_RELEASE_RESULT}"' in text
+    assert "RESOLVE_CANDIDATE_RESULT: ${{ needs.resolve-candidate.result }}" in text
+    assert "CREATE_RELEASE_RESULT: ${{ needs.create-release.result }}" in text

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "prepare-release.yml"
+
+
+def _workflow() -> dict[Any, Any]:
+    return cast(dict[Any, Any], yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _triggers(workflow: dict[Any, Any]) -> dict[str, Any]:
+    triggers = workflow.get("on")
+    if triggers is None:
+        triggers = workflow[True]  # PyYAML 1.1 treats unquoted "on" as a boolean.
+    return cast(dict[str, Any], triggers)
+
+
+def test_prepare_release_workflow_exists() -> None:
+    assert WORKFLOW.exists()
+
+
+def test_prepare_release_is_manual_only() -> None:
+    workflow = _workflow()
+    triggers = _triggers(workflow)
+
+    assert "workflow_dispatch" in triggers
+    assert "push" not in triggers
+    assert "pull_request" not in triggers
+
+
+def test_prepare_release_has_version_and_dry_run_inputs() -> None:
+    dispatch = _triggers(_workflow())["workflow_dispatch"]
+    inputs = dispatch["inputs"]
+
+    assert inputs["version"]["required"] is True
+    assert inputs["dry_run"]["default"] is True
+
+
+def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
+    jobs = _workflow()["jobs"]
+    create_release = jobs["create-release"]
+
+    assert create_release["if"] == "${{ success() && inputs.dry_run == false }}"
+    assert set(create_release["needs"]) >= {
+        "resolve-candidate",
+        "static-and-contract-gates",
+        "package-build-dry-run",
+        "kind-integration",
+        "full-e2e",
+        "aws-live",
+        "cleanup-verify",
+        "release-evidence",
+    }
+
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "git tag -a" in text
+    assert "git push origin" in text
+    assert "softprops/action-gh-release" in text
+
+
+def test_failure_issue_runs_on_failure_and_has_issue_permission() -> None:
+    job = _workflow()["jobs"]["failure-issue"]
+
+    assert job["if"] == "${{ failure() }}"
+    assert job["permissions"]["issues"] == "write"
+    assert "gh issue list" in WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_prepare_release_uploads_metadata_for_pypi_publish() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "release-metadata/release-metadata.json" in text
+    assert "name: release-metadata" in text
+    assert '"tag": os.environ["RELEASE_TAG"]' in text
+    assert '"sha": os.environ["RELEASE_SHA"]' in text

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -20,11 +21,15 @@ def _triggers(workflow: dict[Any, Any]) -> dict[str, Any]:
     return cast(dict[str, Any], triggers)
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_prepare_release_workflow_exists() -> None:
+    """The release authority workflow exists in GitHub Actions."""
     assert WORKFLOW.exists()
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_prepare_release_is_manual_only() -> None:
+    """Prepare Release must be manually dispatched rather than PR or tag triggered."""
     workflow = _workflow()
     triggers = _triggers(workflow)
 
@@ -33,7 +38,9 @@ def test_prepare_release_is_manual_only() -> None:
     assert "pull_request" not in triggers
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_prepare_release_has_version_and_dry_run_inputs() -> None:
+    """Prepare Release exposes explicit version and dry-run controls."""
     dispatch = _triggers(_workflow())["workflow_dispatch"]
     inputs = dispatch["inputs"]
 
@@ -41,7 +48,9 @@ def test_prepare_release_has_version_and_dry_run_inputs() -> None:
     assert inputs["dry_run"]["default"] is True
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
+    """Release creation depends on every gate and owns tag creation."""
     jobs = _workflow()["jobs"]
     create_release = jobs["create-release"]
 
@@ -63,7 +72,9 @@ def test_create_release_job_depends_on_all_gates_and_pushes_tag() -> None:
     assert "softprops/action-gh-release" in text
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_failure_issue_runs_on_failure_and_has_issue_permission() -> None:
+    """Failed release preparation creates or updates a GitHub issue."""
     job = _workflow()["jobs"]["failure-issue"]
 
     assert job["if"] == "${{ failure() }}"
@@ -71,10 +82,45 @@ def test_failure_issue_runs_on_failure_and_has_issue_permission() -> None:
     assert "gh issue list" in WORKFLOW.read_text(encoding="utf-8")
 
 
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_prepare_release_uploads_metadata_for_pypi_publish() -> None:
+    """Successful non-dry-run release preparation uploads PyPI metadata."""
     text = WORKFLOW.read_text(encoding="utf-8")
 
     assert "release-metadata/release-metadata.json" in text
     assert "name: release-metadata" in text
     assert '"tag": os.environ["RELEASE_TAG"]' in text
     assert '"sha": os.environ["RELEASE_SHA"]' in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_prepare_release_pins_candidate_to_dispatch_sha() -> None:
+    """The release candidate SHA is the workflow dispatch commit, not moving main."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "ref: ${{ github.sha }}" in text
+    assert 'release_sha="$(git rev-parse HEAD)"' in text
+    assert 'release_sha="$(git rev-parse origin/main)"' not in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_cleanup_summary_uses_upstream_job_results() -> None:
+    """Cleanup evidence is derived from upstream gate outcomes."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "FULL_E2E_RESULT: ${{ needs.full-e2e.result }}" in text
+    assert "AWS_LIVE_RESULT: ${{ needs.aws-live.result }}" in text
+    assert "--devpod passed" not in text
+    assert "--hetzner passed" not in text
+    assert "--aws passed" not in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_failure_issue_reports_failed_gate_from_needs_results() -> None:
+    """Failure issues classify the actual failed gate instead of a constant."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'failed_gate="unknown"' in text
+    assert '--gate "${failed_gate}"' in text
+    assert '--classification "${classification}"' in text
+    assert "--gate unknown" not in text

--- a/testing/tests/unit/test_release_candidate.py
+++ b/testing/tests/unit/test_release_candidate.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.release.candidate import (
+    ReleaseCandidateError,
+    validate_release_candidate,
+)
+
+
+def _write_manifest(tmp_path: Path, tag: str = "v0.1.0-alpha.1") -> Path:
+    manifest = tmp_path / "release" / "floe-release.yaml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        f"""
+release:
+  train: alpha
+  git_tag: {tag}
+  python_version: 0.1.0a1
+  helm_version: 0.1.0-alpha.1
+python_packages:
+  publish:
+    - path: packages/floe-core
+      name: floe-core
+      evidence: current-main
+  exclude: []
+helm:
+  alpha_policy: publish
+  charts:
+    - charts/floe-platform
+    - charts/floe-jobs
+validation:
+  require_current_main_ci: true
+  require_package_build_dry_run: true
+  require_full_devpod_e2e: true
+  require_aws_provider_live: true
+  allow_accepted_historical_evidence: false
+""",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _write_package_and_charts(tmp_path: Path) -> None:
+    package = tmp_path / "packages" / "floe-core"
+    package.mkdir(parents=True)
+    package.joinpath("pyproject.toml").write_text(
+        """
+[project]
+name = "floe-core"
+version = "0.1.0a1"
+""",
+        encoding="utf-8",
+    )
+    for chart in ("floe-platform", "floe-jobs"):
+        chart_dir = tmp_path / "charts" / chart
+        chart_dir.mkdir(parents=True)
+        chart_dir.joinpath("Chart.yaml").write_text(
+            f"name: {chart}\nversion: 0.1.0-alpha.1\n",
+            encoding="utf-8",
+        )
+
+
+def test_validate_release_candidate_accepts_matching_manifest_and_sha(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    result = validate_release_candidate(
+        requested_version="v0.1.0-alpha.1",
+        release_sha="0000000000000000000000000000000000000000",
+        manifest_path=manifest,
+        repo_root=tmp_path,
+        existing_tags=(),
+    )
+
+    assert result.version == "v0.1.0-alpha.1"
+    assert result.release_sha == "0000000000000000000000000000000000000000"
+    assert result.python_version == "0.1.0a1"
+    assert result.helm_version == "0.1.0-alpha.1"
+    assert result.publish_count == 1
+
+
+def test_validate_release_candidate_rejects_manifest_version_mismatch(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(ReleaseCandidateError, match="does not match manifest git_tag"):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.2",
+            release_sha="0000000000000000000000000000000000000000",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=(),
+        )
+
+
+def test_validate_release_candidate_rejects_existing_tag(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(ReleaseCandidateError, match="release tag already exists"):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.1",
+            release_sha="0000000000000000000000000000000000000000",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=("v0.1.0-alpha.1",),
+        )
+
+
+def test_validate_release_candidate_rejects_non_sha_release_ref(tmp_path: Path) -> None:
+    manifest = _write_manifest(tmp_path)
+    _write_package_and_charts(tmp_path)
+
+    with pytest.raises(
+        ReleaseCandidateError,
+        match="release_sha must be a 40-character commit SHA",
+    ):
+        validate_release_candidate(
+            requested_version="v0.1.0-alpha.1",
+            release_sha="main",
+            manifest_path=manifest,
+            repo_root=tmp_path,
+            existing_tags=(),
+        )

--- a/testing/tests/unit/test_release_candidate.py
+++ b/testing/tests/unit/test_release_candidate.py
@@ -63,7 +63,9 @@ version = "0.1.0a1"
         )
 
 
+@pytest.mark.requirement("REL-GATE-CANDIDATE")
 def test_validate_release_candidate_accepts_matching_manifest_and_sha(tmp_path: Path) -> None:
+    """A matching manifest tag and immutable SHA produce release metadata."""
     manifest = _write_manifest(tmp_path)
     _write_package_and_charts(tmp_path)
 
@@ -82,7 +84,9 @@ def test_validate_release_candidate_accepts_matching_manifest_and_sha(tmp_path: 
     assert result.publish_count == 1
 
 
+@pytest.mark.requirement("REL-GATE-CANDIDATE")
 def test_validate_release_candidate_rejects_manifest_version_mismatch(tmp_path: Path) -> None:
+    """A requested version must match the manifest release tag."""
     manifest = _write_manifest(tmp_path)
     _write_package_and_charts(tmp_path)
 
@@ -96,7 +100,9 @@ def test_validate_release_candidate_rejects_manifest_version_mismatch(tmp_path: 
         )
 
 
+@pytest.mark.requirement("REL-GATE-CANDIDATE")
 def test_validate_release_candidate_rejects_existing_tag(tmp_path: Path) -> None:
+    """Prepare Release must not overwrite an existing release tag."""
     manifest = _write_manifest(tmp_path)
     _write_package_and_charts(tmp_path)
 
@@ -110,7 +116,9 @@ def test_validate_release_candidate_rejects_existing_tag(tmp_path: Path) -> None
         )
 
 
+@pytest.mark.requirement("REL-GATE-CANDIDATE")
 def test_validate_release_candidate_rejects_non_sha_release_ref(tmp_path: Path) -> None:
+    """Release candidates must be pinned to a 40-character commit SHA."""
     manifest = _write_manifest(tmp_path)
     _write_package_and_charts(tmp_path)
 

--- a/testing/tests/unit/test_release_cleanup.py
+++ b/testing/tests/unit/test_release_cleanup.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from testing.release.cleanup import CleanupEvidence, cleanup_status, cleanup_summary
 
 
+@pytest.mark.requirement("REL-GATE-CLEANUP")
 def test_cleanup_status_passes_when_all_scopes_are_clean() -> None:
+    """Cleanup evidence passes only when every provider scope reports passed."""
     evidence = CleanupEvidence(
         devpod="passed",
         hetzner="passed",
@@ -14,7 +18,9 @@ def test_cleanup_status_passes_when_all_scopes_are_clean() -> None:
     assert cleanup_summary(evidence) == "DevPod: passed; Hetzner: passed; AWS: passed"
 
 
+@pytest.mark.requirement("REL-GATE-CLEANUP")
 def test_cleanup_status_fails_when_any_scope_failed() -> None:
+    """A failed provider cleanup scope fails the collapsed cleanup status."""
     evidence = CleanupEvidence(
         devpod="passed",
         hetzner="failed: volume still exists",
@@ -25,7 +31,9 @@ def test_cleanup_status_fails_when_any_scope_failed() -> None:
     assert "volume still exists" in cleanup_summary(evidence)
 
 
+@pytest.mark.requirement("REL-GATE-CLEANUP")
 def test_cleanup_status_reports_not_run_before_cleanup_gate() -> None:
+    """Not-run cleanup evidence is distinguishable from passed cleanup evidence."""
     evidence = CleanupEvidence(
         devpod="not-run",
         hetzner="passed",

--- a/testing/tests/unit/test_release_cleanup.py
+++ b/testing/tests/unit/test_release_cleanup.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from testing.release.cleanup import CleanupEvidence, cleanup_status, cleanup_summary
+
+
+def test_cleanup_status_passes_when_all_scopes_are_clean() -> None:
+    evidence = CleanupEvidence(
+        devpod="passed",
+        hetzner="passed",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "passed"
+    assert cleanup_summary(evidence) == "DevPod: passed; Hetzner: passed; AWS: passed"
+
+
+def test_cleanup_status_fails_when_any_scope_failed() -> None:
+    evidence = CleanupEvidence(
+        devpod="passed",
+        hetzner="failed: volume still exists",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "failed cleanup"
+    assert "volume still exists" in cleanup_summary(evidence)
+
+
+def test_cleanup_status_reports_not_run_before_cleanup_gate() -> None:
+    evidence = CleanupEvidence(
+        devpod="not-run",
+        hetzner="passed",
+        aws="passed",
+    )
+
+    assert cleanup_status(evidence) == "not-run"

--- a/testing/tests/unit/test_release_failure_issue.py
+++ b/testing/tests/unit/test_release_failure_issue.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
+
+
+def test_release_gate_issue_title_is_deterministic() -> None:
+    issue = FailureIssue(
+        lane="release-gate",
+        version="v0.1.0-alpha.1",
+        gate="full-e2e",
+        classification="infrastructure",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/123",
+        log_excerpt="Error in server creation action: action timeout",
+        cleanup_status="passed",
+        skipped_outputs=("tag", "github-release", "pypi"),
+    )
+
+    assert issue_title(issue) == (
+        "Release gate failed: v0.1.0-alpha.1 full-e2e infrastructure failure"
+    )
+
+
+def test_weekly_issue_title_omits_version() -> None:
+    issue = FailureIssue(
+        lane="weekly-validation",
+        version=None,
+        gate="e2e-tests",
+        classification="product",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/456",
+        log_excerpt="assert expected_rows == actual_rows",
+        cleanup_status="not-run",
+        skipped_outputs=(),
+    )
+
+    assert issue_title(issue) == "Weekly validation failed: e2e-tests product failure"
+
+
+def test_issue_comment_body_contains_release_safety_state() -> None:
+    issue = FailureIssue(
+        lane="release-gate",
+        version="v0.1.0-alpha.1",
+        gate="aws-live",
+        classification="credential-setup",
+        sha="0000000000000000000000000000000000000000",
+        run_url="https://github.com/Obsidian-Owl/floe/actions/runs/789",
+        log_excerpt="Unable to locate credentials",
+        cleanup_status="passed",
+        skipped_outputs=("tag", "github-release", "pypi"),
+    )
+
+    body = issue_comment_body(issue)
+
+    assert "Workflow run: https://github.com/Obsidian-Owl/floe/actions/runs/789" in body
+    assert "Commit: `0000000000000000000000000000000000000000`" in body
+    assert "Requested version: `v0.1.0-alpha.1`" in body
+    assert "Failed gate: `aws-live`" in body
+    assert "Classification: `credential-setup`" in body
+    assert "Cleanup status: `passed`" in body
+    assert "Skipped outputs: `tag`, `github-release`, `pypi`" in body
+    assert "Unable to locate credentials" in body

--- a/testing/tests/unit/test_release_failure_issue.py
+++ b/testing/tests/unit/test_release_failure_issue.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
 
 
+@pytest.mark.requirement("REL-GATE-ISSUE")
 def test_release_gate_issue_title_is_deterministic() -> None:
+    """Release-gate issue titles include version, failed gate, and classification."""
     issue = FailureIssue(
         lane="release-gate",
         version="v0.1.0-alpha.1",
@@ -21,7 +25,9 @@ def test_release_gate_issue_title_is_deterministic() -> None:
     )
 
 
+@pytest.mark.requirement("REL-GATE-ISSUE")
 def test_weekly_issue_title_omits_version() -> None:
+    """Weekly validation issue titles omit release version details."""
     issue = FailureIssue(
         lane="weekly-validation",
         version=None,
@@ -37,7 +43,9 @@ def test_weekly_issue_title_omits_version() -> None:
     assert issue_title(issue) == "Weekly validation failed: e2e-tests product failure"
 
 
+@pytest.mark.requirement("REL-GATE-ISSUE")
 def test_issue_comment_body_contains_release_safety_state() -> None:
+    """Issue bodies record release safety state and skipped outputs."""
     issue = FailureIssue(
         lane="release-gate",
         version="v0.1.0-alpha.1",


### PR DESCRIPTION
## Summary

- Adds a manual Prepare Release workflow that creates the release tag and GitHub Release only after all gates pass.
- Keeps PyPI publication downstream of successful Prepare Release metadata and the manifest package scope.
- Adds release helper utilities for candidate validation, cleanup summaries, and deterministic failure issue content.
- Updates release docs so maintainers no longer push alpha tags directly.

## Validation

- Focused release workflow/unit tests: 42 passed
- Full CI workflow structural tests: 30 passed
- actionlint for changed workflows
- release manifest validation: publish_count 15, exclude_count 11
- package build dry-run: 15 wheels and 15 sdists
- docs navigation/content validation
- make lint
- make typecheck
- pre-push suite passed, including unit tests, contract tests, traceability, docs content validation, and Helm lint

## Release Safety

Failed release candidates create no tag, no GitHub Release, and no PyPI publication.