### PR TITLE
Fix Prepare Release Helm repository setup

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -123,6 +123,20 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: ${{ needs.resolve-candidate.outputs.helm_version }}
+
+      - name: Add Helm repositories
+        run: |
+          set -euo pipefail
+          helm repo add dagster https://dagster-io.github.io/helm
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+          helm repo update
+
       - name: Run static and contract gates
         run: |
           set -euo pipefail

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -144,6 +144,24 @@ def test_static_gate_builds_helm_dependencies_before_contract_tests() -> None:
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_static_gate_adds_helm_repositories_before_dependency_build() -> None:
+    """Release Helm dependency builds must register every remote chart repo."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    dependency_index = text.index("helm dependency build charts/floe-platform")
+
+    for repo in (
+        "helm repo add dagster https://dagster-io.github.io/helm",
+        "helm repo add bitnami https://charts.bitnami.com/bitnami",
+        "helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts",
+        "helm repo add jaegertracing https://jaegertracing.github.io/helm-charts",
+        "helm repo update",
+    ):
+        assert repo in text
+        assert text.index(repo) < dependency_index
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_cleanup_summary_does_not_fail_for_skipped_live_gates() -> None:
     """Skipped live gates are reported as not-run, not cleanup failures."""
     text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add Helm setup and remote chart repository registration before Prepare Release static contract gates build chart dependencies
- cover the release workflow with a regression test that all remote Helm repos are added before dependency build

## Validation
- uv run pytest testing/tests/unit/test_prepare_release_workflow.py -q
- uv run pytest testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_ci_workflows.py -q
- actionlint .github/workflows/prepare-release.yml
- uv run ruff check . && uv run ruff format --check .
- uv run mypy --strict packages/ testing/
- helm repo add dagster/bitnami/open-telemetry/jaegertracing with temporary Helm config && helm dependency build charts/floe-platform
- uv run pytest tests/contract/ packages/*/tests/contract/ -q
- uv run python -m testing.release.cli validate --manifest release/floe-release.yaml --tag v0.1.0-alpha.1
- pre-push hooks

Closes #344