### PR TITLE
Fix release Helm CLI version handling

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -73,7 +73,7 @@ jobs:
           if [ -n "${INPUT_VERSION}" ]; then
             VERSION="${INPUT_VERSION}"
           else
-            VERSION=$(uv run python -c 'from pathlib import Path; from testing.release.manifest import load_release_manifest; print(load_release_manifest(Path("release/floe-release.yaml")).release.helm_version)')
+            VERSION=$(uv run python -c 'from pathlib import Path; from testing.release.manifest import load_release_manifest; print(load_release_manifest(Path("release/floe-release.yaml")).release.helm_chart_version)')
           fi
 
           if [ "${GH_REF_TYPE}" = "tag" ]; then

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,7 +32,8 @@ jobs:
     outputs:
       release_sha: ${{ steps.sha.outputs.release_sha }}
       python_version: ${{ steps.candidate.outputs.python_version }}
-      helm_version: ${{ steps.candidate.outputs.helm_version }}
+      helm_chart_version: ${{ steps.candidate.outputs.helm_chart_version }}
+      helm_cli_version: ${{ steps.candidate.outputs.helm_cli_version }}
       version: ${{ inputs.version }}
     steps:
       - name: Checkout main
@@ -93,7 +94,8 @@ jobs:
           candidate = json.loads(Path("candidate.json").read_text(encoding="utf-8"))
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               output.write(f"python_version={candidate['python_version']}\n")
-              output.write(f"helm_version={candidate['helm_version']}\n")
+              output.write(f"helm_chart_version={candidate['helm_chart_version']}\n")
+              output.write(f"helm_cli_version={candidate['helm_cli_version']}\n")
               output.write(f"publish_count={candidate['publish_count']}\n")
           PY
 
@@ -126,7 +128,7 @@ jobs:
       - name: Set up Helm
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: ${{ needs.resolve-candidate.outputs.helm_version }}
+          version: ${{ needs.resolve-candidate.outputs.helm_cli_version }}
 
       - name: Add Helm repositories
         run: |
@@ -587,6 +589,7 @@ jobs:
       - release-evidence
       - create-release
     permissions:
+      actions: read
       contents: read
       issues: write
     steps:
@@ -627,32 +630,20 @@ jobs:
               break
             fi
           done
-          classification="release-tooling"
-          case "${failed_gate}" in
-            aws-live)
-              classification="credential-setup"
-              ;;
-            full-e2e|kind-integration)
-              classification="infrastructure"
-              ;;
-            cleanup-verify)
-              classification="cleanup"
-              ;;
-            resolve-candidate|create-release)
-              classification="release-tooling"
-              ;;
-            static-and-contract-gates|package-build-dry-run|release-evidence)
-              classification="product"
-              ;;
-          esac
+          log_excerpt="Gate ${failed_gate} completed with result ${failed_result}. See workflow artifacts and failed job logs."
+          if gh run view "${GITHUB_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --log-failed > failed-logs.txt 2>/dev/null; then
+            log_excerpt="$(tail -c 12000 failed-logs.txt)"
+          fi
           uv run python -m testing.release.cli failure-issue \
             --lane release-gate \
             --version "${{ inputs.version }}" \
             --gate "${failed_gate}" \
-            --classification "${classification}" \
+            --classification auto \
             --sha "${{ needs.resolve-candidate.outputs.release_sha || github.sha }}" \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --log-excerpt "Gate ${failed_gate} completed with result ${failed_result}. See workflow artifacts and failed job logs." \
+            --log-excerpt "${log_excerpt}" \
             --cleanup-status "${{ needs.cleanup-verify.outputs.cleanup_status || 'not-run' }}" \
             --skipped-output tag \
             --skipped-output github-release \
@@ -668,6 +659,7 @@ jobs:
           CLEANUP_VERIFY_RESULT: ${{ needs.cleanup-verify.result }}
           RELEASE_EVIDENCE_RESULT: ${{ needs.release-evidence.result }}
           CREATE_RELEASE_RESULT: ${{ needs.create-release.result }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create or update issue
         env:

--- a/release/floe-release.yaml
+++ b/release/floe-release.yaml
@@ -2,7 +2,10 @@ release:
   train: alpha
   git_tag: v0.1.0-alpha.1
   python_version: 0.1.0a1
-  helm_version: 0.1.0-alpha.1
+  helm_chart_version: 0.1.0-alpha.1
+
+tooling:
+  helm_cli_version: v4.1.3
 
 python_packages:
   publish:

--- a/testing/release/candidate.py
+++ b/testing/release/candidate.py
@@ -20,7 +20,8 @@ class ReleaseCandidate:
     version: str
     release_sha: str
     python_version: str
-    helm_version: str
+    helm_chart_version: str
+    helm_cli_version: str
     publish_count: int
 
 
@@ -56,6 +57,7 @@ def validate_release_candidate(
         version=version,
         release_sha=normalized_sha,
         python_version=result.python_version,
-        helm_version=result.helm_version,
+        helm_chart_version=result.helm_chart_version,
+        helm_cli_version=result.helm_cli_version,
         publish_count=result.publish_count,
     )

--- a/testing/release/cli.py
+++ b/testing/release/cli.py
@@ -13,7 +13,12 @@ from testing.release.build_packages import ReleaseBuildError, artifact_counts, b
 from testing.release.candidate import ReleaseCandidateError, validate_release_candidate
 from testing.release.cleanup import CleanupEvidence, cleanup_status, cleanup_summary
 from testing.release.evidence import EvidenceSummaryError, write_evidence_summary
-from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
+from testing.release.failure_issue import (
+    FailureIssue,
+    classify_failure,
+    issue_comment_body,
+    issue_title,
+)
 from testing.release.manifest import (
     ReleaseManifestError,
     load_release_manifest,
@@ -95,11 +100,16 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.command == "failure-issue":
+        classification = (
+            classify_failure(args.gate, args.log_excerpt)
+            if args.classification == "auto"
+            else args.classification
+        )
         issue = FailureIssue(
             lane=args.lane,
             version=args.version,
             gate=args.gate,
-            classification=args.classification,
+            classification=classification,
             sha=args.sha,
             run_url=args.run_url,
             log_excerpt=args.log_excerpt,

--- a/testing/release/failure_issue.py
+++ b/testing/release/failure_issue.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+TOOLING_FAILURE_MARKERS = (
+    "Failed to download Helm",
+    "Azure/setup-helm",
+    "actions/setup-python",
+    "astral-sh/setup-uv",
+    "helm-v",
+    "No such file or directory",
+)
+
 
 @dataclass(frozen=True)
 class FailureIssue:
@@ -16,6 +25,23 @@ class FailureIssue:
     log_excerpt: str
     cleanup_status: str
     skipped_outputs: tuple[str, ...] = ()
+
+
+def classify_failure(gate: str, log_excerpt: str) -> str:
+    """Classify a failed release gate using the failed gate and logs."""
+    if _contains_any(log_excerpt, TOOLING_FAILURE_MARKERS):
+        return "release-tooling"
+    if gate == "aws-live":
+        return "credential-setup"
+    if gate in {"full-e2e", "kind-integration"}:
+        return "infrastructure"
+    if gate == "cleanup-verify":
+        return "cleanup"
+    if gate in {"resolve-candidate", "create-release"}:
+        return "release-tooling"
+    if gate in {"static-and-contract-gates", "package-build-dry-run", "release-evidence"}:
+        return "product"
+    return "release-tooling"
 
 
 def issue_title(issue: FailureIssue) -> str:
@@ -67,3 +93,8 @@ def issue_comment_body(issue: FailureIssue) -> str:
             "",
         ],
     )
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(marker.lower() in lowered for marker in markers)

--- a/testing/release/manifest.py
+++ b/testing/release/manifest.py
@@ -40,7 +40,12 @@ class ReleaseInfo:
     train: str
     git_tag: str
     python_version: str
-    helm_version: str
+    helm_chart_version: str
+
+
+@dataclass(frozen=True)
+class ToolingInfo:
+    helm_cli_version: str
 
 
 @dataclass(frozen=True)
@@ -75,6 +80,7 @@ class ValidationPolicy:
 @dataclass(frozen=True)
 class ReleaseManifest:
     release: ReleaseInfo
+    tooling: ToolingInfo
     python_packages: PythonPackages
     helm: HelmInfo
     validation: ValidationPolicy
@@ -84,7 +90,8 @@ class ReleaseManifest:
 class ManifestValidationResult:
     git_tag: str
     python_version: str
-    helm_version: str
+    helm_chart_version: str
+    helm_cli_version: str
     publish_count: int
     exclude_count: int
     publish_names: tuple[str, ...]
@@ -99,7 +106,7 @@ def normalize_tag_to_python_version(tag: str) -> str:
     return version
 
 
-def normalize_tag_to_helm_version(tag: str) -> str:
+def normalize_tag_to_helm_chart_version(tag: str) -> str:
     match = RELEASE_TAG_RE.fullmatch(tag)
     if not match:
         raise ReleaseManifestError(f"unsupported release tag format: {tag}")
@@ -115,6 +122,7 @@ def load_release_manifest(path: Path) -> ReleaseManifest:
     data = _require_mapping(raw, "manifest")
 
     release = _require_mapping(data.get("release"), "release")
+    tooling = _require_mapping(data.get("tooling"), "tooling")
     python_packages = _require_mapping(data.get("python_packages"), "python_packages")
     helm = _require_mapping(data.get("helm"), "helm")
     validation = _require_mapping(data.get("validation"), "validation")
@@ -127,7 +135,16 @@ def load_release_manifest(path: Path) -> ReleaseManifest:
                 release.get("python_version"),
                 "release.python_version",
             ),
-            helm_version=_require_str(release.get("helm_version"), "release.helm_version"),
+            helm_chart_version=_require_str(
+                release.get("helm_chart_version"),
+                "release.helm_chart_version",
+            ),
+        ),
+        tooling=ToolingInfo(
+            helm_cli_version=_require_str(
+                tooling.get("helm_cli_version"),
+                "tooling.helm_cli_version",
+            ),
         ),
         python_packages=PythonPackages(
             publish=_load_package_entries(
@@ -192,12 +209,13 @@ def validate_release_manifest(
             "manifest python_version does not match normalized git tag: "
             f"{manifest.release.python_version} != {expected_python_version}",
         )
-    expected_helm_version = normalize_tag_to_helm_version(tag or manifest.release.git_tag)
-    if manifest.release.helm_version != expected_helm_version:
+    expected_helm_version = normalize_tag_to_helm_chart_version(tag or manifest.release.git_tag)
+    if manifest.release.helm_chart_version != expected_helm_version:
         raise ReleaseManifestError(
-            "manifest helm_version does not match normalized git tag: "
-            f"{manifest.release.helm_version} != {expected_helm_version}",
+            "manifest helm_chart_version does not match normalized git tag: "
+            f"{manifest.release.helm_chart_version} != {expected_helm_version}",
         )
+    _validate_helm_cli_version(manifest.tooling.helm_cli_version)
     if manifest.helm.alpha_policy != "publish":
         raise ReleaseManifestError(
             f"unsupported helm.alpha_policy for alpha release: {manifest.helm.alpha_policy}",
@@ -247,11 +265,19 @@ def validate_release_manifest(
     return ManifestValidationResult(
         git_tag=manifest.release.git_tag,
         python_version=manifest.release.python_version,
-        helm_version=manifest.release.helm_version,
+        helm_chart_version=manifest.release.helm_chart_version,
+        helm_cli_version=manifest.tooling.helm_cli_version,
         publish_count=len(manifest.python_packages.publish),
         exclude_count=len(manifest.python_packages.exclude),
         publish_names=publish_names,
     )
+
+
+def _validate_helm_cli_version(version: str) -> None:
+    if not re.fullmatch(r"v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version):
+        raise ReleaseManifestError(
+            "tooling.helm_cli_version must be a pinned Helm CLI version like v4.1.3",
+        )
 
 
 def _validate_alpha_helm_publish_charts(chart_paths: tuple[str, ...]) -> None:

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -162,6 +162,25 @@ def test_static_gate_adds_helm_repositories_before_dependency_build() -> None:
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_static_gate_uses_tooling_helm_cli_version_not_chart_version() -> None:
+    """Helm CLI setup must not consume the Floe chart release version."""
+    workflow = _workflow()
+    resolve_outputs = workflow["jobs"]["resolve-candidate"]["outputs"]
+    setup_step = next(
+        step
+        for step in workflow["jobs"]["static-and-contract-gates"]["steps"]
+        if step.get("name") == "Set up Helm"
+    )
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "helm_cli_version" in resolve_outputs
+    assert "output.write(f\"helm_cli_version={candidate['helm_cli_version']}\\n\")" in text
+    assert setup_step["with"]["version"] == (
+        "${{ needs.resolve-candidate.outputs.helm_cli_version }}"
+    )
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_cleanup_summary_does_not_fail_for_skipped_live_gates() -> None:
     """Skipped live gates are reported as not-run, not cleanup failures."""
     text = WORKFLOW.read_text(encoding="utf-8")
@@ -182,8 +201,20 @@ def test_failure_issue_reports_failed_gate_from_needs_results() -> None:
 
     assert 'failed_gate="unknown"' in text
     assert '--gate "${failed_gate}"' in text
-    assert '--classification "${classification}"' in text
+    assert "--classification auto" in text
     assert "--gate unknown" not in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_failure_issue_collects_failed_logs_for_classification() -> None:
+    """Failure issue classification must inspect failed job logs."""
+    job = _workflow()["jobs"]["failure-issue"]
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert job["permissions"]["actions"] == "read"
+    assert 'gh run view "${GITHUB_RUN_ID}"' in text
+    assert "--log-failed" in text
+    assert '--log-excerpt "${log_excerpt}"' in text
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")

--- a/testing/tests/unit/test_release_build_packages.py
+++ b/testing/tests/unit/test_release_build_packages.py
@@ -310,7 +310,10 @@ def _write_manifest(repo_root: Path) -> Path:
                     "train": "alpha",
                     "git_tag": "v0.1.0-alpha.1",
                     "python_version": "0.1.0a1",
-                    "helm_version": "0.1.0-alpha.1",
+                    "helm_chart_version": "0.1.0-alpha.1",
+                },
+                "tooling": {
+                    "helm_cli_version": "v4.1.3",
                 },
                 "python_packages": {
                     "publish": [

--- a/testing/tests/unit/test_release_candidate.py
+++ b/testing/tests/unit/test_release_candidate.py
@@ -19,7 +19,9 @@ release:
   train: alpha
   git_tag: {tag}
   python_version: 0.1.0a1
-  helm_version: 0.1.0-alpha.1
+  helm_chart_version: 0.1.0-alpha.1
+tooling:
+  helm_cli_version: v4.1.3
 python_packages:
   publish:
     - path: packages/floe-core
@@ -80,7 +82,8 @@ def test_validate_release_candidate_accepts_matching_manifest_and_sha(tmp_path: 
     assert result.version == "v0.1.0-alpha.1"
     assert result.release_sha == "0000000000000000000000000000000000000000"
     assert result.python_version == "0.1.0a1"
-    assert result.helm_version == "0.1.0-alpha.1"
+    assert result.helm_chart_version == "0.1.0-alpha.1"
+    assert result.helm_cli_version == "v4.1.3"
     assert result.publish_count == 1
 
 

--- a/testing/tests/unit/test_release_failure_issue.py
+++ b/testing/tests/unit/test_release_failure_issue.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from testing.release.failure_issue import FailureIssue, issue_comment_body, issue_title
+from testing.release.failure_issue import (
+    FailureIssue,
+    classify_failure,
+    issue_comment_body,
+    issue_title,
+)
 
 
 @pytest.mark.requirement("REL-GATE-ISSUE")
@@ -68,3 +73,28 @@ def test_issue_comment_body_contains_release_safety_state() -> None:
     assert "Cleanup status: `passed`" in body
     assert "Skipped outputs: `tag`, `github-release`, `pypi`" in body
     assert "Unable to locate credentials" in body
+
+
+@pytest.mark.requirement("REL-GATE-ISSUE")
+def test_static_gate_setup_action_failures_are_release_tooling() -> None:
+    """Static gate setup/action failures are not product failures."""
+    assert (
+        classify_failure(
+            "static-and-contract-gates",
+            "Error: Failed to download Helm from location "
+            "https://get.helm.sh/helm-v0.1.0-alpha.1-linux-amd64.tar.gz",
+        )
+        == "release-tooling"
+    )
+
+
+@pytest.mark.requirement("REL-GATE-ISSUE")
+def test_static_gate_test_failures_remain_product_failures() -> None:
+    """Actual static or contract test failures stay product-classified."""
+    assert (
+        classify_failure(
+            "static-and-contract-gates",
+            "FAILED tests/contract/test_compilation.py::test_contract_roundtrip",
+        )
+        == "product"
+    )

--- a/testing/tests/unit/test_release_manifest.py
+++ b/testing/tests/unit/test_release_manifest.py
@@ -10,7 +10,7 @@ from testing.release import cli
 from testing.release.manifest import (
     ReleaseManifestError,
     load_release_manifest,
-    normalize_tag_to_helm_version,
+    normalize_tag_to_helm_chart_version,
     normalize_tag_to_python_version,
     validate_release_manifest,
 )
@@ -53,12 +53,12 @@ ALPHA_EXCLUDED = {
 
 def test_normalizes_alpha_git_tag_to_pep440() -> None:
     assert normalize_tag_to_python_version("v0.1.0-alpha.1") == "0.1.0a1"
-    assert normalize_tag_to_helm_version("v0.1.0-alpha.1") == "0.1.0-alpha.1"
+    assert normalize_tag_to_helm_chart_version("v0.1.0-alpha.1") == "0.1.0-alpha.1"
 
 
 def test_normalizes_non_alpha_git_tag_to_release_versions() -> None:
     assert normalize_tag_to_python_version("v0.1.1") == "0.1.1"
-    assert normalize_tag_to_helm_version("v0.1.1") == "0.1.1"
+    assert normalize_tag_to_helm_chart_version("v0.1.1") == "0.1.1"
 
 
 def test_release_manifest_exists_and_matches_cutline() -> None:
@@ -87,6 +87,22 @@ def test_release_manifest_validates_alpha_release_cutline() -> None:
     assert result.git_tag == "v0.1.0-alpha.1"
 
 
+def test_release_manifest_separates_helm_chart_and_cli_versions() -> None:
+    """Floe chart release versions must not feed Helm CLI installation."""
+    manifest = load_release_manifest(MANIFEST)
+
+    result = validate_release_manifest(
+        manifest,
+        repo_root=REPO_ROOT,
+        tag="v0.1.0-alpha.1",
+    )
+
+    assert manifest.release.helm_chart_version == "0.1.0-alpha.1"
+    assert manifest.tooling.helm_cli_version == "v4.1.3"
+    assert result.helm_chart_version == "0.1.0-alpha.1"
+    assert result.helm_cli_version == "v4.1.3"
+
+
 def test_release_manifest_validates_non_alpha_release_tag(tmp_path: Path) -> None:
     _write_chart(tmp_path / "charts" / "floe-platform")
     _write_chart(tmp_path / "charts" / "floe-jobs")
@@ -95,7 +111,7 @@ def test_release_manifest_validates_non_alpha_release_tag(tmp_path: Path) -> Non
         release={
             "git_tag": "v0.1.1",
             "python_version": "0.1.1",
-            "helm_version": "0.1.1",
+            "helm_chart_version": "0.1.1",
         },
     )
 
@@ -106,7 +122,7 @@ def test_release_manifest_validates_non_alpha_release_tag(tmp_path: Path) -> Non
     )
 
     assert result.python_version == "0.1.1"
-    assert result.helm_version == "0.1.1"
+    assert result.helm_chart_version == "0.1.1"
     assert result.git_tag == "v0.1.1"
 
 
@@ -115,7 +131,7 @@ def test_manifest_declares_helm_alpha_publish_policy() -> None:
 
     assert manifest.helm.alpha_policy == "publish"
     assert manifest.helm.charts == ("charts/floe-platform", "charts/floe-jobs")
-    assert manifest.release.helm_version == "0.1.0-alpha.1"
+    assert manifest.release.helm_chart_version == "0.1.0-alpha.1"
 
 
 def test_release_manifest_rejects_secret_like_values(tmp_path: Path) -> None:
@@ -126,7 +142,9 @@ release:
   train: alpha
   git_tag: v0.1.0-alpha.1
   python_version: 0.1.0a1
-  helm_version: 0.1.0-alpha.1
+  helm_chart_version: 0.1.0-alpha.1
+tooling:
+  helm_cli_version: v4.1.3
 python_packages:
   publish:
     - path: packages/floe-core
@@ -244,15 +262,15 @@ def test_release_manifest_rejects_duplicate_alpha_helm_chart_entries(
         validate_release_manifest(load_release_manifest(manifest_path), repo_root=tmp_path)
 
 
-def test_release_manifest_rejects_helm_version_mismatch(tmp_path: Path) -> None:
+def test_release_manifest_rejects_helm_chart_version_mismatch(tmp_path: Path) -> None:
     manifest_path = _write_manifest(
         tmp_path,
-        release={"helm_version": "0.1.0-alpha.2"},
+        release={"helm_chart_version": "0.1.0-alpha.2"},
     )
 
     with pytest.raises(
         ReleaseManifestError,
-        match="helm_version does not match normalized git tag",
+        match="helm_chart_version does not match normalized git tag",
     ):
         validate_release_manifest(
             load_release_manifest(manifest_path),
@@ -434,7 +452,7 @@ def _write_manifest(
         "train": "alpha",
         "git_tag": "v0.1.0-alpha.1",
         "python_version": "0.1.0a1",
-        "helm_version": "0.1.0-alpha.1",
+        "helm_chart_version": "0.1.0-alpha.1",
     }
     if release:
         release_data.update(release)
@@ -466,6 +484,9 @@ def _write_manifest(
         yaml.safe_dump(
             {
                 "release": release_data,
+                "tooling": {
+                    "helm_cli_version": "v4.1.3",
+                },
                 "python_packages": {
                     "publish": publish_entries,
                     "exclude": exclude_entries,


### PR DESCRIPTION
## Summary
- split Floe Helm chart version from the Helm CLI tooling version in the release manifest
- update Prepare Release to install Helm from the pinned tooling version instead of the release tag
- auto-classify release failure issues from failed job logs so setup/action failures are release-tooling, not product failures

## Validation
- uv run pytest testing/tests/unit/test_release_manifest.py testing/tests/unit/test_release_candidate.py testing/tests/unit/test_release_build_packages.py testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_release_failure_issue.py -q
- uv run ruff check .github testing/release testing/tests/unit/test_release_manifest.py testing/tests/unit/test_release_candidate.py testing/tests/unit/test_release_build_packages.py testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_release_failure_issue.py
- uv run ruff format --check .github testing/release testing/tests/unit/test_release_manifest.py testing/tests/unit/test_release_candidate.py testing/tests/unit/test_release_build_packages.py testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_release_failure_issue.py
- uv run mypy --strict testing/release
- uv run python -m testing.release.cli validate --manifest release/floe-release.yaml --tag v0.1.0-alpha.1
- uv run python -m testing.release.cli candidate --manifest release/floe-release.yaml --version v0.1.0-alpha.1 --release-sha dbd66bcae183872b53d41c3f6214a1cdaf778ab9
- pre-push hook: passed