### PR TITLE
Harden release live gate setup

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -217,17 +217,38 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Set up Helm
+        uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: ${{ needs.resolve-candidate.outputs.helm_cli_version }}
+
+      - name: Add Helm repositories
+        run: |
+          set -euo pipefail
+          helm repo add dagster https://dagster-io.github.io/helm
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+          helm repo update
+
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: floe-release
           config: testing/k8s/kind-config.yaml
 
+      - name: Install test infrastructure
+        run: make helm-install-test
+        env:
+          KIND_CLUSTER_NAME: floe-release
+          FLOE_KIND_CLUSTER: floe-release
+
       - name: Run integration tests
         run: ./testing/ci/test-integration.sh
         env:
           TEST_NAMESPACE: floe-test
           KIND_CLUSTER_NAME: floe-release
+          FLOE_KIND_CLUSTER: floe-release
 
       - name: Collect logs on failure
         if: failure()
@@ -261,6 +282,10 @@ jobs:
       - name: Configure DevPod Hetzner provider
         run: |
           set -euo pipefail
+          if [[ -z "${DEVPOD_HETZNER_TOKEN}" ]]; then
+            echo "::error::DEVPOD_HETZNER_TOKEN GitHub secret is not configured."
+            exit 1
+          fi
           case "${DEVPOD_HETZNER_TOKEN}" in
             *$'\n'*|*$'\r'*)
               echo "::error::DEVPOD_HETZNER_TOKEN must be a single-line token."
@@ -327,6 +352,10 @@ jobs:
       - name: Configure DevPod Hetzner provider
         run: |
           set -euo pipefail
+          if [[ -z "${DEVPOD_HETZNER_TOKEN}" ]]; then
+            echo "::error::DEVPOD_HETZNER_TOKEN GitHub secret is not configured."
+            exit 1
+          fi
           case "${DEVPOD_HETZNER_TOKEN}" in
             *$'\n'*|*$'\r'*)
               echo "::error::DEVPOD_HETZNER_TOKEN must be a single-line token."

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ DOCKER_PLATFORM ?= linux/amd64
 # - Reads plugin selections from the manifest schema
 # - Maps selections through local workspace entry points
 # - Includes local workspace dependency closure because Docker installs with --no-deps
-DEMO_PLUGINS := $(shell .venv/bin/python scripts/resolve-demo-plugins.py --manifest $(DEMO_MANIFEST))
+DEMO_PLUGINS = $(shell uv run python scripts/resolve-demo-plugins.py --manifest $(DEMO_MANIFEST))
 
 build-demo-image: compile-demo ## Build Dagster demo Docker image and load to Kind
 	@echo "Building Dagster demo Docker image..."

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1363,6 +1363,17 @@ class TestMakefileBuildDemoImage:
             "so manifest-selected plugins include local workspace dependencies."
         )
 
+    @pytest.mark.requirement("WU11-AC6")
+    def test_demo_plugins_are_resolved_only_when_demo_image_builds(self) -> None:
+        """Non-demo make targets must not require a local .venv at parse time."""
+        content = _read_makefile_content()
+
+        assert "DEMO_PLUGINS = $(shell uv run python scripts/resolve-demo-plugins.py" in content
+        assert (
+            "DEMO_PLUGINS := $(shell .venv/bin/python scripts/resolve-demo-plugins.py"
+            not in content
+        )
+
 
 class TestDemoPluginResolver:
     """Validate manifest-driven demo image workspace package resolution."""

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -181,6 +181,53 @@ def test_static_gate_uses_tooling_helm_cli_version_not_chart_version() -> None:
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_kind_gate_installs_test_stack_before_running_in_cluster_tests() -> None:
+    """The release Kind gate must deploy chart-managed test infrastructure first."""
+    steps = _workflow()["jobs"]["kind-integration"]["steps"]
+    step_names = [step.get("name") for step in steps]
+
+    assert "Set up Helm" in step_names
+    assert "Add Helm repositories" in step_names
+    assert "Install test infrastructure" in step_names
+    assert step_names.index("Set up Helm") < step_names.index("Add Helm repositories")
+    assert step_names.index("Add Helm repositories") < step_names.index(
+        "Install test infrastructure"
+    )
+    assert step_names.index("Create Kind cluster") < step_names.index("Install test infrastructure")
+    assert step_names.index("Install test infrastructure") < step_names.index(
+        "Run integration tests"
+    )
+
+    helm_step = steps[step_names.index("Set up Helm")]
+    repo_step = steps[step_names.index("Add Helm repositories")]
+    install_step = steps[step_names.index("Install test infrastructure")]
+
+    assert helm_step["with"]["version"] == (
+        "${{ needs.resolve-candidate.outputs.helm_cli_version }}"
+    )
+    assert "helm repo add dagster https://dagster-io.github.io/helm" in repo_step["run"]
+    assert "helm repo add bitnami https://charts.bitnami.com/bitnami" in repo_step["run"]
+    assert "helm repo update" in repo_step["run"]
+    assert install_step["run"] == "make helm-install-test"
+    assert install_step["env"]["KIND_CLUSTER_NAME"] == "floe-release"
+    assert install_step["env"]["FLOE_KIND_CLUSTER"] == "floe-release"
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_devpod_release_jobs_fail_fast_when_hetzner_token_missing() -> None:
+    """DevPod release gates must report missing repository secret configuration directly."""
+    for job_name in ("full-e2e", "aws-live"):
+        steps = _workflow()["jobs"][job_name]["steps"]
+        configure_step = next(
+            step for step in steps if step.get("name") == "Configure DevPod Hetzner provider"
+        )
+
+        assert 'if [[ -z "${DEVPOD_HETZNER_TOKEN}" ]]; then' in configure_step["run"]
+        assert "DEVPOD_HETZNER_TOKEN GitHub secret is not configured" in configure_step["run"]
+        assert "make devpod-setup" in configure_step["run"]
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_cleanup_summary_does_not_fail_for_skipped_live_gates() -> None:
     """Skipped live gates are reported as not-run, not cleanup failures."""
     text = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- installs Helm, chart repositories, and chart-managed test infrastructure before the release Kind integration runner executes
- fails DevPod release gates explicitly when the Hetzner token secret is missing
- makes demo plugin resolution lazy so non-demo make targets do not require .venv during Makefile parsing

## Validation
- uv run pytest testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_makefile_kubeconfig.py testing/tests/unit/test_demo_packaging.py::TestMakefileBuildDemoImage -q
- uv run ruff check testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_packaging.py
- uv run ruff format --check testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_packaging.py
- actionlint .github/workflows/prepare-release.yml
- make -n devpod-setup
- uv run python -m testing.release.cli validate --manifest release/floe-release.yaml --tag v0.1.0-alpha.1
- git push pre-push hook: passed