### PR TITLE
Fix release DevPod gate sequencing

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -238,7 +238,7 @@ jobs:
           config: testing/k8s/kind-config.yaml
 
       - name: Install test infrastructure
-        run: make helm-install-test
+        run: make helm-install-test HELM_TEST_TIMEOUT=20m
         env:
           KIND_CLUSTER_NAME: floe-release
           FLOE_KIND_CLUSTER: floe-release
@@ -315,7 +315,8 @@ jobs:
       - name: Run full E2E on DevPod and Hetzner
         run: make devpod-test
         env:
-          DEVPOD_SOURCE: git:https://github.com/Obsidian-Owl/floe@${{ needs.resolve-candidate.outputs.release_sha }}
+          DEVPOD_GIT_REF: main
+          DEVPOD_REMOTE_GIT_CHECKOUT_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
           DEVPOD_WORKSPACE: floe-release-e2e-${{ github.run_id }}
           DEVPOD_REMOTE_E2E_MAKE_TARGET: test-e2e-full
           DEVPOD_REMOTE_E2E_TIMEOUT: "10800"
@@ -332,7 +333,7 @@ jobs:
     name: AWS S3 And Glue Live
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    needs: [resolve-candidate, static-and-contract-gates]
+    needs: [resolve-candidate, static-and-contract-gates, full-e2e]
     permissions:
       contents: read
     steps:
@@ -385,7 +386,8 @@ jobs:
       - name: Run AWS live provider tests on DevPod
         run: make devpod-test-aws-provider
         env:
-          DEVPOD_SOURCE: git:https://github.com/Obsidian-Owl/floe@${{ needs.resolve-candidate.outputs.release_sha }}
+          DEVPOD_GIT_REF: main
+          DEVPOD_REMOTE_GIT_CHECKOUT_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
           DEVPOD_WORKSPACE: floe-release-aws-${{ github.run_id }}
           FLOE_PROVIDER_SPIKE_RUN: release-${{ inputs.version }}-${{ github.run_id }}
           FLOE_AWS_REGION: ${{ vars.FLOE_AWS_REGION }}

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ docs-validate: ## Validate docs navigation and build
 # Helm Chart Targets
 # ============================================================
 
+HELM_TEST_TIMEOUT ?= 20m
+
 .PHONY: helm-deps
 helm-deps: ## Update Helm chart dependencies
 	@echo "Updating Helm chart dependencies..."
@@ -322,12 +324,13 @@ helm-integration-test: helm-deps ## Run Helm integration tests in Kind cluster
 helm-install-test: helm-deps ## Install floe-platform with test values (requires Kind cluster)
 	@echo "Installing floe-platform with test configuration..."
 	@uv run floe platform deploy --env test --chart charts/floe-platform \
+		--timeout $(HELM_TEST_TIMEOUT) \
 		$(DEMO_IMAGE_HELM_SET_ARGS)
 	@echo "Installing floe-jobs with test configuration..."
 	@helm upgrade --install floe-jobs-test charts/floe-jobs \
 		--namespace floe-test \
 		--values charts/floe-jobs/values-test.yaml \
-		--wait --timeout 5m
+		--wait --timeout $(HELM_TEST_TIMEOUT)
 	@echo "Test infrastructure installed!"
 
 .PHONY: helm-upgrade-test

--- a/scripts/devpod-test.sh
+++ b/scripts/devpod-test.sh
@@ -24,6 +24,11 @@
 #   DEVPOD_REMOTE_E2E_MAKE_TARGET Make target to run after Kind bootstrap
 #                        (default: test-e2e). Use test-e2e-full for release
 #                        validation with destructive tests.
+#   DEVPOD_REMOTE_GIT_CHECKOUT_SHA Optional 40-character commit SHA to check out
+#                        inside the DevPod after cloning the configured branch.
+#                        Release workflows use this to keep DevPod sources
+#                        branch-clone compatible while executing the exact
+#                        resolved release candidate.
 #   DEVPOD_REMOTE_E2E_TIMEOUT Remote E2E timeout in seconds (default: 7200).
 #   DEVPOD_REMOTE_POLL_INTERVAL Remote E2E polling interval in seconds
 #                        (default: 20).
@@ -79,6 +84,7 @@ PROVIDER="${DEVPOD_PROVIDER:-hetzner}"
 DEVPOD_E2E_EXECUTION="${DEVPOD_E2E_EXECUTION:-remote}"
 DEVPOD_REMOTE_WORKDIR="${DEVPOD_REMOTE_WORKDIR:-/workspace}"
 DEVPOD_REMOTE_E2E_MAKE_TARGET="${DEVPOD_REMOTE_E2E_MAKE_TARGET:-test-e2e}"
+DEVPOD_REMOTE_GIT_CHECKOUT_SHA="${DEVPOD_REMOTE_GIT_CHECKOUT_SHA:-}"
 DEVPOD_REMOTE_RUN_ROOT="${DEVPOD_REMOTE_RUN_ROOT:-/tmp/floe-devpod-e2e}"
 DEVPOD_REMOTE_E2E_TIMEOUT="${DEVPOD_REMOTE_E2E_TIMEOUT:-7200}"
 DEVPOD_REMOTE_POLL_INTERVAL="${DEVPOD_REMOTE_POLL_INTERVAL:-20}"
@@ -237,6 +243,11 @@ if [[ -z "${DEVPOD_REMOTE_E2E_MAKE_TARGET}" ]]; then
     exit 1
 fi
 
+if [[ -n "${DEVPOD_REMOTE_GIT_CHECKOUT_SHA}" && ! "${DEVPOD_REMOTE_GIT_CHECKOUT_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    error "Invalid DEVPOD_REMOTE_GIT_CHECKOUT_SHA='${DEVPOD_REMOTE_GIT_CHECKOUT_SHA}'"
+    exit 1
+fi
+
 for env_name in ${DEVPOD_REMOTE_ENV_ALLOWLIST}; do
     if [[ ! "${env_name}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
         error "Invalid DEVPOD_REMOTE_ENV_ALLOWLIST entry '${env_name}'"
@@ -362,6 +373,7 @@ start_remote_e2e_run() {
     local run_dir_q
     local workdir_q
     local make_target_q
+    local git_checkout_sha_q
     local flux_settlement_timeout_q
     local flux_settlement_interval_q
     local flux_gitrepository_q
@@ -377,6 +389,7 @@ start_remote_e2e_run() {
     run_dir_q="$(shell_quote "${REMOTE_RUN_DIR}")"
     workdir_q="$(shell_quote "${DEVPOD_REMOTE_WORKDIR}")"
     make_target_q="$(shell_quote "${DEVPOD_REMOTE_E2E_MAKE_TARGET}")"
+    git_checkout_sha_q="$(shell_quote "${DEVPOD_REMOTE_GIT_CHECKOUT_SHA}")"
     flux_settlement_timeout_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_SETTLEMENT_TIMEOUT}")"
     flux_settlement_interval_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_SETTLEMENT_INTERVAL}")"
     flux_gitrepository_q="$(shell_quote "${DEVPOD_REMOTE_FLUX_GITREPOSITORY}")"
@@ -541,6 +554,12 @@ wait_for_flux_settlement() {
     echo "[remote-e2e] started at \$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     echo "[remote-e2e] workdir=\${FLOE_REMOTE_WORKDIR}"
     cd "\${FLOE_REMOTE_WORKDIR}"
+    if [[ -n "\${FLOE_REMOTE_GIT_CHECKOUT_SHA:-}" ]]; then
+        echo "[remote-e2e] checking out release SHA \${FLOE_REMOTE_GIT_CHECKOUT_SHA}"
+        git fetch origin "\${FLOE_REMOTE_GIT_CHECKOUT_SHA}" \
+            || git fetch --tags origin main
+        git checkout --detach "\${FLOE_REMOTE_GIT_CHECKOUT_SHA}"
+    fi
     if [[ -n "\${FLOE_REMOTE_ENV_FILE:-}" && -f "\${FLOE_REMOTE_ENV_FILE}" ]]; then
         echo "[remote-e2e] sourcing remote env allowlist"
         # shellcheck disable=SC1091
@@ -565,6 +584,7 @@ exit 0
 REMOTE_RUN
 chmod +x "\${run_dir}/run.sh"
 FLOE_REMOTE_WORKDIR="\${workdir}" FLOE_REMOTE_RUN_DIR="\${run_dir}" FLOE_REMOTE_E2E_MAKE_TARGET="\${make_target}" \
+    FLOE_REMOTE_GIT_CHECKOUT_SHA=${git_checkout_sha_q} \
     FLOE_REMOTE_ENV_FILE=${remote_env_file_q} \
     FLOE_REMOTE_FLUX_SETTLEMENT_TIMEOUT=${flux_settlement_timeout_q} \
     FLOE_REMOTE_FLUX_SETTLEMENT_INTERVAL=${flux_settlement_interval_q} \

--- a/testing/tests/unit/test_demo_makefile_kubeconfig.py
+++ b/testing/tests/unit/test_demo_makefile_kubeconfig.py
@@ -103,6 +103,18 @@ def test_devpod_script_exits_with_e2e_status() -> None:
 
 
 @pytest.mark.requirement("285")
+def test_devpod_remote_run_can_pin_commit_after_branch_clone() -> None:
+    """Release DevPods clone a branch but still execute the exact release SHA."""
+    test_script = Path("scripts/devpod-test.sh").read_text()
+
+    assert "DEVPOD_REMOTE_GIT_CHECKOUT_SHA" in test_script
+    assert "FLOE_REMOTE_GIT_CHECKOUT_SHA" in test_script
+    assert "git checkout --detach" in test_script
+    assert "git fetch origin" in test_script
+    assert "Invalid DEVPOD_REMOTE_GIT_CHECKOUT_SHA=" in test_script
+
+
+@pytest.mark.requirement("285")
 def test_devpod_successful_remote_run_requires_artifact_fetch() -> None:
     """Release validation success must include fetched remote evidence artifacts."""
     test_script = Path("scripts/devpod-test.sh").read_text()

--- a/testing/tests/unit/test_demo_packaging.py
+++ b/testing/tests/unit/test_demo_packaging.py
@@ -1582,6 +1582,15 @@ class TestMakefileDemoChain:
             )
 
     @pytest.mark.requirement("WU11-AC6")
+    def test_helm_install_test_uses_release_sized_timeout(self) -> None:
+        """The test install target must allow slow CI image pulls and rollouts."""
+        content = _read_makefile_content()
+        body = _extract_target_body(content, "helm-install-test")
+
+        assert "HELM_TEST_TIMEOUT ?= 20m" in content
+        assert "--timeout $(HELM_TEST_TIMEOUT)" in body
+
+    @pytest.mark.requirement("WU11-AC6")
     def test_remote_demo_build_passes_same_image_ref_as_deploy(self) -> None:
         """The DevPod demo build must use the same image ref Helm deploys.
 

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -208,9 +208,38 @@ def test_kind_gate_installs_test_stack_before_running_in_cluster_tests() -> None
     assert "helm repo add dagster https://dagster-io.github.io/helm" in repo_step["run"]
     assert "helm repo add bitnami https://charts.bitnami.com/bitnami" in repo_step["run"]
     assert "helm repo update" in repo_step["run"]
-    assert install_step["run"] == "make helm-install-test"
+    assert install_step["run"] == "make helm-install-test HELM_TEST_TIMEOUT=20m"
     assert install_step["env"]["KIND_CLUSTER_NAME"] == "floe-release"
     assert install_step["env"]["FLOE_KIND_CLUSTER"] == "floe-release"
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_release_devpod_gates_clone_branch_then_pin_release_sha() -> None:
+    """DevPod source must use a real ref and then detach to the release SHA."""
+    for job_name, step_name in (
+        ("full-e2e", "Run full E2E on DevPod and Hetzner"),
+        ("aws-live", "Run AWS live provider tests on DevPod"),
+    ):
+        steps = _workflow()["jobs"][job_name]["steps"]
+        run_step = next(step for step in steps if step.get("name") == step_name)
+
+        assert "DEVPOD_SOURCE" not in run_step["env"]
+        assert run_step["env"]["DEVPOD_GIT_REF"] == "main"
+        assert run_step["env"]["DEVPOD_REMOTE_GIT_CHECKOUT_SHA"] == (
+            "${{ needs.resolve-candidate.outputs.release_sha }}"
+        )
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_release_devpod_gates_run_serially_to_fit_hetzner_quota() -> None:
+    """The release workflow must not provision two Hetzner DevPods at once."""
+    aws_live = _workflow()["jobs"]["aws-live"]
+
+    assert set(aws_live["needs"]) >= {
+        "resolve-candidate",
+        "static-and-contract-gates",
+        "full-e2e",
+    }
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")


### PR DESCRIPTION
## Summary
- serializes the two Hetzner DevPod release lanes so the release workflow does not exceed the account's dedicated-core quota
- changes release DevPod sources to clone `main` and then check out the resolved release SHA inside the workspace
- gives the Kind release install a 20 minute test-infra timeout for slower CI image pulls and Dagster rollout

## Release failure addressed
- Prepare Release run: https://github.com/Obsidian-Owl/floe/actions/runs/25850573921
- Full DevPod E2E failed on Hetzner dedicated core quota due concurrent DevPod provisioning
- AWS live failed because DevPod treated the resolved commit SHA as a branch
- Kind install timed out at 10 minutes waiting for Dagster deployments

## Validation
- `uv run pytest testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_makefile_kubeconfig.py testing/tests/unit/test_demo_packaging.py::TestMakefileBuildDemoImage testing/tests/unit/test_demo_packaging.py::TestMakefileDemoChain -q`
- `uv run ruff check testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_makefile_kubeconfig.py testing/tests/unit/test_demo_packaging.py`
- `uv run ruff format --check testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_makefile_kubeconfig.py testing/tests/unit/test_demo_packaging.py`
- `bash -n scripts/devpod-test.sh`
- `actionlint .github/workflows/prepare-release.yml`
- `make -n helm-install-test HELM_TEST_TIMEOUT=20m`
- git push pre-push hook: passed

