### PR TITLE
Fix release live gate sequencing

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -237,6 +237,12 @@ jobs:
           cluster_name: floe-release
           config: testing/k8s/kind-config.yaml
 
+      - name: Build and load Dagster demo image
+        run: make build-demo-image
+        env:
+          KIND_CLUSTER_NAME: floe-release
+          FLOE_KIND_CLUSTER: floe-release
+
       - name: Install test infrastructure
         run: make helm-install-test HELM_TEST_TIMEOUT=20m
         env:
@@ -389,7 +395,6 @@ jobs:
           DEVPOD_GIT_REF: main
           DEVPOD_REMOTE_GIT_CHECKOUT_SHA: ${{ needs.resolve-candidate.outputs.release_sha }}
           DEVPOD_WORKSPACE: floe-release-aws-${{ github.run_id }}
-          FLOE_PROVIDER_SPIKE_RUN: release-${{ inputs.version }}-${{ github.run_id }}
           FLOE_AWS_REGION: ${{ vars.FLOE_AWS_REGION }}
           FLOE_AWS_TEST_BUCKET: ${{ vars.FLOE_AWS_TEST_BUCKET }}
           FLOE_AWS_TEST_PREFIX: ${{ vars.FLOE_AWS_TEST_PREFIX }}
@@ -662,9 +667,21 @@ jobs:
             fi
           done
           log_excerpt="Gate ${failed_gate} completed with result ${failed_result}. See workflow artifacts and failed job logs."
+          : > failed-logs.txt
           if gh run view "${GITHUB_RUN_ID}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --log-failed > failed-logs.txt 2>/dev/null; then
+            --json jobs \
+            --jq '.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped") | .databaseId' \
+            > failed-job-ids.txt 2>/dev/null; then
+            while IFS= read -r job_id; do
+              if [[ -n "${job_id}" ]]; then
+                gh run view "${GITHUB_RUN_ID}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --job "${job_id}" --log >> failed-logs.txt 2>/dev/null || true
+              fi
+            done < failed-job-ids.txt
+          fi
+          if [[ -s failed-logs.txt ]]; then
             log_excerpt="$(tail -c 12000 failed-logs.txt)"
           fi
           uv run python -m testing.release.cli failure-issue \

--- a/testing/tests/unit/test_prepare_release_workflow.py
+++ b/testing/tests/unit/test_prepare_release_workflow.py
@@ -214,6 +214,26 @@ def test_kind_gate_installs_test_stack_before_running_in_cluster_tests() -> None
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_kind_gate_builds_demo_image_before_installing_test_stack() -> None:
+    """The Kind release gate must load the local Dagster image before Helm waits."""
+    steps = _workflow()["jobs"]["kind-integration"]["steps"]
+    step_names = [step.get("name") for step in steps]
+
+    assert "Build and load Dagster demo image" in step_names
+    assert step_names.index("Create Kind cluster") < step_names.index(
+        "Build and load Dagster demo image"
+    )
+    assert step_names.index("Build and load Dagster demo image") < step_names.index(
+        "Install test infrastructure"
+    )
+
+    build_step = steps[step_names.index("Build and load Dagster demo image")]
+    assert build_step["run"] == "make build-demo-image"
+    assert build_step["env"]["KIND_CLUSTER_NAME"] == "floe-release"
+    assert build_step["env"]["FLOE_KIND_CLUSTER"] == "floe-release"
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_release_devpod_gates_clone_branch_then_pin_release_sha() -> None:
     """DevPod source must use a real ref and then detach to the release SHA."""
     for job_name, step_name in (
@@ -240,6 +260,21 @@ def test_release_devpod_gates_run_serially_to_fit_hetzner_quota() -> None:
         "static-and-contract-gates",
         "full-e2e",
     }
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_release_aws_live_uses_cleanup_safe_provider_run_id() -> None:
+    """Release AWS live runs must preserve the cleanup-safe provider id shape."""
+    steps = _workflow()["jobs"]["aws-live"]["steps"]
+    run_step = next(
+        step for step in steps if step.get("name") == "Run AWS live provider tests on DevPod"
+    )
+
+    assert "FLOE_PROVIDER_SPIKE_RUN" not in run_step["env"]
+    assert not any(
+        isinstance(value, str) and value.startswith("release-")
+        for value in run_step["env"].values()
+    )
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
@@ -282,6 +317,19 @@ def test_failure_issue_reports_failed_gate_from_needs_results() -> None:
 
 
 @pytest.mark.requirement("REL-GATE-WORKFLOW")
+def test_failure_issue_collects_completed_failed_job_logs() -> None:
+    """Failure issues must not rely on whole-run logs before the workflow completes."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--json jobs" in text
+    assert '.jobs[] | select(.status == "completed"' in text
+    assert '.conclusion != "success"' in text
+    assert '.conclusion != "skipped"' in text
+    assert '--job "${job_id}" --log' in text
+    assert "--log-failed" not in text
+
+
+@pytest.mark.requirement("REL-GATE-WORKFLOW")
 def test_failure_issue_collects_failed_logs_for_classification() -> None:
     """Failure issue classification must inspect failed job logs."""
     job = _workflow()["jobs"]["failure-issue"]
@@ -289,7 +337,9 @@ def test_failure_issue_collects_failed_logs_for_classification() -> None:
 
     assert job["permissions"]["actions"] == "read"
     assert 'gh run view "${GITHUB_RUN_ID}"' in text
-    assert "--log-failed" in text
+    assert "--json jobs" in text
+    assert ": > failed-logs.txt" in text
+    assert '--job "${job_id}" --log' in text
     assert '--log-excerpt "${log_excerpt}"' in text
 
 


### PR DESCRIPTION
## Summary

- Build and load the Dagster demo image before the release Kind install so `imagePullPolicy: Never` pods can start.
- Let `make devpod-test-aws-provider` generate the cleanup-safe `floe-provider-*` live AWS run id instead of passing an invalid release-shaped value.
- Collect logs from completed failed jobs for release failure issues, avoiding the generic whole-run fallback while the workflow is still in progress.

## Validation

- `uv run pytest testing/tests/unit/test_prepare_release_workflow.py testing/tests/unit/test_demo_packaging.py::TestMakefileDemoChain tests/unit/test_devpod_aws_provider_remote_validation.py -q`
- `uv run ruff check testing/tests/unit/test_prepare_release_workflow.py`
- `uv run ruff format --check testing/tests/unit/test_prepare_release_workflow.py`
- `actionlint .github/workflows/prepare-release.yml`
- normal pre-push hook passed

## Release Failure Evidence

- Latest failed release run: https://github.com/Obsidian-Owl/floe/actions/runs/25852888884
- Added detailed triage to #349: https://github.com/Obsidian-Owl/floe/issues/349#issuecomment-4449975259
