### PR TITLE
Fix AWS Glue live-test cleanup IAM

### DIFF
--- a/infra/aws-provider-tests/iam.tf
+++ b/infra/aws-provider-tests/iam.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "provider_test_permissions" {
     resources = [
       "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
       "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*",
     ]
   }
 

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -171,6 +171,7 @@ jq -e \
   and any(stmts[]; (actions(.) | index("s3:PutObject")) and (actions(.) | index("s3:DeleteObject")) and (resources(.) | index($objects)))
   and any(stmts[]; (actions(.) | index("glue:CreateDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):database/\($glue_prefix)*")))
   and any(stmts[]; (actions(.) | index("glue:CreateTable")) and (resources(.) | index("arn:aws:glue:\($region):\($account):table/\($glue_prefix)*/*")))
+  and any(stmts[]; (actions(.) | index("glue:DeleteDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):table/\($glue_prefix)*/*")))
 ' "${policy_payload}" >/dev/null || \
     error "provider test IAM policy does not contain the expected scoped S3 and Glue statements"
 

--- a/tests/contract/test_storage_minio_rename.py
+++ b/tests/contract/test_storage_minio_rename.py
@@ -46,6 +46,7 @@ IGNORED_SCAN_PARTS = {
     "docs-site/node_modules",
     "docs-site/src/content/docs",
     "docs/superpowers",
+    ".claude/worktrees",
 }
 FORBIDDEN_REFERENCES = [
     OLD_PACKAGE_NAME,
@@ -230,6 +231,13 @@ def test_active_scan_files_ignore_historical_and_generated_docs() -> None:
     assert not any(path.startswith("docs-site/dist/") for path in scanned)
     assert not any(path.startswith("docs-site/node_modules/") for path in scanned)
     assert not any(path.startswith("docs-site/src/content/docs/") for path in scanned)
+
+
+def test_active_scan_files_ignore_agent_local_worktrees() -> None:
+    """Scans must skip local agent worktrees that are not active repo content."""
+    scanned = {path.relative_to(REPO_ROOT).as_posix() for path in _active_scan_files()}
+
+    assert not any(path.startswith(".claude/worktrees/") for path in scanned)
 
 
 def test_active_references_do_not_use_old_s3_plugin_names() -> None:

--- a/tests/unit/test_aws_provider_iam_policy.py
+++ b/tests/unit/test_aws_provider_iam_policy.py
@@ -1,0 +1,54 @@
+"""Structural tests for live AWS provider validation IAM contracts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_IAM_TF_PATH = _REPO_ROOT / "infra" / "aws-provider-tests" / "iam.tf"
+_READINESS_SCRIPT_PATH = _REPO_ROOT / "scripts" / "aws-provider-test-readiness.sh"
+
+
+def _read_iam_tf() -> str:
+    """Return the AWS provider test IAM OpenTofu module contents."""
+    return _IAM_TF_PATH.read_text()
+
+
+def _read_readiness_script() -> str:
+    """Return the AWS provider test readiness script contents."""
+    return _READINESS_SCRIPT_PATH.read_text()
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_glue_database_delete_policy_covers_child_tables() -> None:
+    """PyIceberg Glue namespace deletion authorizes DeleteDatabase on table ARNs."""
+    iam_tf = _read_iam_tf()
+
+    database_statement = re.search(
+        r'sid = "ManageProviderTestGlueDatabases"(?P<body>.*?)^\s*}\n',
+        iam_tf,
+        re.DOTALL | re.MULTILINE,
+    )
+
+    assert database_statement is not None
+    body = database_statement.group("body")
+    assert '"glue:DeleteDatabase"' in body
+    assert (
+        '"arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*"'
+        in body
+    )
+
+
+@pytest.mark.requirement("LIVE-VALIDATION")
+def test_readiness_policy_check_requires_delete_database_on_table_resources() -> None:
+    """Readiness must catch the IAM gap that only appears on non-empty Glue namespaces."""
+    script = _read_readiness_script()
+
+    assert 'actions(.) | index("glue:DeleteDatabase")' in script
+    assert (
+        'resources(.) | index("arn:aws:glue:\\($region):\\($account):table/\\($glue_prefix)*/*")'
+        in script
+    )


### PR DESCRIPTION
## Summary

- allow `glue:DeleteDatabase` on provider-test Glue table child resources so PyIceberg namespace deletion can clean non-empty Glue namespaces
- harden AWS provider readiness checks to require the same `DeleteDatabase` table-resource permission before long live validation runs
- exclude local `.claude/worktrees/` agent worktrees from the active MinIO rename contract scan, with regression coverage

## Release retry context

Release run `25884617477` passed static/contract gates, package dry-run, Kind integration, and full DevPod+Hetzner E2E, then failed in AWS S3+Glue live validation because `floe-provider-tests-user` could not call `glue:DeleteDatabase` on a table-scoped ARN.

I applied the corresponding OpenTofu policy update to the sandbox account before opening this PR:

- account: `278833447053`
- apply result: `0 added, 1 changed, 0 destroyed`
- readiness script: passed after apply
- failed run cleanup: `floe-provider-20260514T212804Z` S3 prefix and Glue database cleanup checks passed
- Hetzner cleanup: no `floe-relea*` servers remained

Issue evidence updated in #349: https://github.com/Obsidian-Owl/floe/issues/349#issuecomment-4455019049

## Validation

- `uv run pytest tests/unit/test_aws_provider_iam_policy.py tests/unit/test_devpod_aws_provider_remote_validation.py -q`
- `uv run pytest tests/contract/test_storage_minio_rename.py -q`
- `bash -n scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh`
- `tofu fmt -check infra/aws-provider-tests`
- `tofu -chdir=infra/aws-provider-tests validate`
- live `scripts/aws-provider-test-readiness.sh` against AWS account `278833447053`
- live `scripts/aws-provider-test-cleanup.sh` for failed run `floe-provider-20260514T212804Z`
- pre-push hooks: ruff, format, mypy, dbt requirements, bandit, uv-secure, unit coverage, contract tests, no-hardcoded-sleep, traceability, docs validation, helm lint
