### PR TITLE
fix: cover Glue UDF cleanup in AWS live IAM

### DIFF
--- a/infra/aws-provider-tests/iam.tf
+++ b/infra/aws-provider-tests/iam.tf
@@ -53,6 +53,7 @@ data "aws_iam_policy_document" "provider_test_permissions" {
       "arn:aws:glue:${var.aws_region}:${local.account_id}:catalog",
       "arn:aws:glue:${var.aws_region}:${local.account_id}:database/${var.glue_database_prefix}*",
       "arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*",
+      "arn:aws:glue:${var.aws_region}:${local.account_id}:userDefinedFunction/${var.glue_database_prefix}*/*",
     ]
   }
 

--- a/scripts/aws-provider-test-readiness.sh
+++ b/scripts/aws-provider-test-readiness.sh
@@ -172,6 +172,7 @@ jq -e \
   and any(stmts[]; (actions(.) | index("glue:CreateDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):database/\($glue_prefix)*")))
   and any(stmts[]; (actions(.) | index("glue:CreateTable")) and (resources(.) | index("arn:aws:glue:\($region):\($account):table/\($glue_prefix)*/*")))
   and any(stmts[]; (actions(.) | index("glue:DeleteDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):table/\($glue_prefix)*/*")))
+  and any(stmts[]; (actions(.) | index("glue:DeleteDatabase")) and (resources(.) | index("arn:aws:glue:\($region):\($account):userDefinedFunction/\($glue_prefix)*/*")))
 ' "${policy_payload}" >/dev/null || \
     error "provider test IAM policy does not contain the expected scoped S3 and Glue statements"
 

--- a/tests/unit/test_aws_provider_iam_policy.py
+++ b/tests/unit/test_aws_provider_iam_policy.py
@@ -23,8 +23,8 @@ def _read_readiness_script() -> str:
 
 
 @pytest.mark.requirement("LIVE-VALIDATION")
-def test_glue_database_delete_policy_covers_child_tables() -> None:
-    """PyIceberg Glue namespace deletion authorizes DeleteDatabase on table ARNs."""
+def test_glue_database_delete_policy_covers_child_resources() -> None:
+    """PyIceberg Glue namespace deletion authorizes DeleteDatabase on child ARNs."""
     iam_tf = _read_iam_tf()
 
     database_statement = re.search(
@@ -40,15 +40,24 @@ def test_glue_database_delete_policy_covers_child_tables() -> None:
         '"arn:aws:glue:${var.aws_region}:${local.account_id}:table/${var.glue_database_prefix}*/*"'
         in body
     )
+    assert (
+        '"arn:aws:glue:${var.aws_region}:${local.account_id}:userDefinedFunction/${var.glue_database_prefix}*/*"'
+        in body
+    )
 
 
 @pytest.mark.requirement("LIVE-VALIDATION")
-def test_readiness_policy_check_requires_delete_database_on_table_resources() -> None:
+def test_readiness_policy_check_requires_delete_database_on_child_resources() -> None:
     """Readiness must catch the IAM gap that only appears on non-empty Glue namespaces."""
     script = _read_readiness_script()
+    expected_udf_resource = (
+        'resources(.) | index("arn:aws:glue:\\($region):\\($account):'
+        'userDefinedFunction/\\($glue_prefix)*/*")'
+    )
 
     assert 'actions(.) | index("glue:DeleteDatabase")' in script
     assert (
         'resources(.) | index("arn:aws:glue:\\($region):\\($account):table/\\($glue_prefix)*/*")'
         in script
     )
+    assert expected_udf_resource in script


### PR DESCRIPTION
## Summary

- add Glue `userDefinedFunction/<database>/*` child ARNs to the AWS provider test IAM policy for `glue:DeleteDatabase`
- tighten readiness validation so missing table or UDF child-resource coverage is caught before long-running live tests
- extend structural IAM tests for the PyIceberg Glue namespace deletion behavior observed in release retry `25889434917`

## Validation

- `uv run pytest tests/unit/test_aws_provider_iam_policy.py -q`
- `uv run pytest tests/unit/test_aws_provider_iam_policy.py tests/unit/test_devpod_aws_provider_remote_validation.py -q`
- `bash -n scripts/aws-provider-test-readiness.sh scripts/aws-provider-test-cleanup.sh`
- `tofu -chdir=infra/aws-provider-tests fmt -check`
- `tofu -chdir=infra/aws-provider-tests validate`
- `AWS_PROFILE=floe-aws-bootstrap tofu -chdir=infra/aws-provider-tests plan -var='enable_access_key_user=true' -out=tfplan-release-iam-udf` -> `0 add, 1 change, 0 destroy`
- `AWS_PROFILE=floe-aws-bootstrap tofu -chdir=infra/aws-provider-tests apply -auto-approve tfplan-release-iam-udf` -> `0 added, 1 changed, 0 destroyed`
- live `scripts/aws-provider-test-readiness.sh` against account `278833447053` passed
- `scripts/aws-provider-test-cleanup.sh` cleaned failed run `floe-provider-20260514T231629Z`
- Hetzner inventory check found no remaining `floe-relea*` servers
- full local pre-push gate passed

## Release blocker

Follow-up for failed release workflow:
https://github.com/Obsidian-Owl/floe/actions/runs/25889434917

Tracked in issue #349:
https://github.com/Obsidian-Owl/floe/issues/349#issuecomment-4455593730
