### PR TITLE
Fix alpha PyPI publish backfill

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -9,9 +9,9 @@ validates that manifest before release-specific workflows publish artifacts.
 | Trigger | Workflow | Purpose |
 |---|---|---|
 | Pull request | `ci.yml` | Fast PR confidence plus release manifest structure |
-| `merge_group` / pull request label `run-e2e` / infra path / manual | `e2e.yml` | Opt-in full E2E validation |
+| Manual | `e2e.yml` | Opt-in full E2E validation outside PR and release lanes |
 | Manual | `prepare-release.yml` | Runs all release gates, creates tag and GitHub Release only on success |
-| Successful Prepare Release | `pypi-publish.yml` | Builds and publishes the manifest package set |
+| Successful Prepare Release / manual `release_tag` backfill | `pypi-publish.yml` | Builds and publishes the manifest package set |
 | Manual | `release.yml` | Release-validation smoke only; does not create tags or GitHub Releases |
 | Tag `helm-v*` / `charts-v*` / manual | `helm-release.yaml` | Helm chart release when manifest policy allows |
 | Schedule / manual | `weekly.yml`, `security.yml`, `codspeed.yml` | Drift, security, performance maintenance |
@@ -37,14 +37,10 @@ PR CI stays fast and structural. It does not run live cloud/provider validation.
 
 ## E2E (`e2e.yml`)
 
-E2E runs only when explicitly requested or when paths that can affect the live
-platform change:
-
-- `merge_group`
-- `workflow_dispatch`
-- PR label `run-e2e`
-- Infra path filter, including charts, tests, packages/plugins, workflow files,
-  `release/floe-release.yaml`, and `testing/release/**`
+E2E runs only when explicitly requested with `workflow_dispatch`. Weekly
+validation owns scheduled long-running coverage, and `prepare-release.yml` owns
+release-blocking E2E/live validation. Pull requests and merge queues do not run
+the long E2E lane automatically.
 
 Failures should be classified as product, infrastructure, credential/setup, or
 cleanup failures before deciding whether to rerun or block the release.
@@ -60,6 +56,11 @@ only after all gates pass.
 Dry runs execute the same gates without creating a tag, GitHub Release, or PyPI
 publication. Real runs use `dry_run=false`; that successful workflow run uploads
 the release metadata consumed by `pypi-publish.yml`.
+
+If a GitHub Release already exists and PyPI publication needs to be retried
+after fixing the publish workflow, maintainers may dispatch `pypi-publish.yml`
+with an existing `release_tag` and `dry_run=false`. The workflow still validates
+the manifest and publishes only `python_packages.publish`.
 
 If a release gate fails, the workflow creates or updates a GitHub issue and
 records which outputs were skipped. Product, infrastructure, credential/setup,

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,14 +21,18 @@ on:
     types: [completed]
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: 'Existing release tag to build or publish, for example v0.1.0-alpha.1'
+        required: false
+        type: string
       dry_run:
-        description: 'Build packages without uploading (manual dispatch never publishes)'
+        description: 'Build packages without uploading; set false with release_tag to publish'
         required: false
         default: true
         type: boolean
 
 concurrency:
-  group: pypi-publish-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+  group: pypi-publish-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -43,7 +47,7 @@ jobs:
       (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'workflow_dispatch' &&
-        github.event.workflow_run.name == 'Prepare Release'
+        github.event.workflow_run.path == '.github/workflows/prepare-release.yml'
       )
     runs-on: ubuntu-latest
     permissions:
@@ -56,13 +60,47 @@ jobs:
     steps:
       - name: Resolve release metadata
         id: release_metadata
-        if: github.event_name == 'workflow_run'
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_DRY_RUN: ${{ inputs.dry_run }}
+          MANUAL_RELEASE_TAG: ${{ inputs.release_tag }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${MANUAL_DRY_RUN}" != "true" && -z "${MANUAL_RELEASE_TAG}" ]]; then
+              echo "::error::Manual PyPI publish requires release_tag when dry_run is false."
+              exit 1
+            fi
+            if [[ -z "${MANUAL_RELEASE_TAG}" ]]; then
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [[ "${MANUAL_RELEASE_TAG}" != v* ]]; then
+              echo "::error::Manual release_tag must start with 'v': ${MANUAL_RELEASE_TAG}"
+              exit 1
+            fi
+            REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+            TAG_REF="refs/tags/${MANUAL_RELEASE_TAG}"
+            SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}^{}" | awk '{print $1}')"
+            if [[ -z "${SHA}" ]]; then
+              SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}" | awk '{print $1}')"
+            fi
+            if [[ -z "${SHA}" ]]; then
+              echo "::error::Release tag does not exist on origin: ${MANUAL_RELEASE_TAG}"
+              exit 1
+            fi
+            {
+              echo "publish=true"
+              echo "tag=${MANUAL_RELEASE_TAG}"
+              echo "sha=${SHA}"
+              echo "version="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if ! gh run download "${WORKFLOW_RUN_ID}" \
             --name release-metadata \
             --dir release-metadata; then
@@ -107,7 +145,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event_name == 'workflow_run' && steps.release_metadata.outputs.sha || github.ref }}
+          ref: ${{ steps.release_metadata.outputs.sha || steps.release_metadata.outputs.tag || github.ref }}
 
       - name: Set up Python
         if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
@@ -139,6 +177,16 @@ jobs:
           if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
             VERSION="${RELEASE_VERSION}"
             TAG="${RELEASE_TAG}"
+          elif [[ -n "${RELEASE_TAG}" ]]; then
+            VERSION="$(uv run python - <<'PY'
+          import os
+
+          from testing.release.manifest import normalize_tag_to_python_version
+
+          print(normalize_tag_to_python_version(os.environ["RELEASE_TAG"]))
+          PY
+          )"
+            TAG="${RELEASE_TAG}"
           elif [[ "${GH_REF_TYPE}" == "tag" ]]; then
             VERSION="${GH_REF#refs/tags/v}"
             TAG="${GH_REF#refs/tags/}"
@@ -160,6 +208,10 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            uv run python -m testing.release.cli validate \
+              --manifest release/floe-release.yaml \
+              --tag "${RELEASE_TAG}"
+          elif [[ -n "${RELEASE_TAG}" ]]; then
             uv run python -m testing.release.cli validate \
               --manifest release/floe-release.yaml \
               --tag "${RELEASE_TAG}"
@@ -198,8 +250,15 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'workflow_dispatch' &&
-      github.event.workflow_run.name == 'Prepare Release' &&
       needs.build.outputs.publish == 'true'
+      && github.event.workflow_run.path == '.github/workflows/prepare-release.yml'
+      ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.dry_run == false &&
+        inputs.release_tag != '' &&
+        needs.build.outputs.publish == 'true'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -78,15 +78,16 @@ jobs:
               echo "publish=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            if [[ "${MANUAL_RELEASE_TAG}" != v* ]]; then
-              echo "::error::Manual release_tag must start with 'v': ${MANUAL_RELEASE_TAG}"
+            if [[ ! "${MANUAL_RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-alpha\.[0-9]+)?$ ]]; then
+              echo "::error::Manual release_tag must match the release manifest tag format: ${MANUAL_RELEASE_TAG}"
               exit 1
             fi
+            echo "::notice::Manual PyPI publish backfill requested for ${MANUAL_RELEASE_TAG} by ${GITHUB_ACTOR}; dry_run=${MANUAL_DRY_RUN}"
             REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
             TAG_REF="refs/tags/${MANUAL_RELEASE_TAG}"
-            SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}^{}" | awk '{print $1}')"
+            SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}^{}" | awk '{print $1}' | head -n 1)"
             if [[ -z "${SHA}" ]]; then
-              SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}" | awk '{print $1}')"
+              SHA="$(git ls-remote --tags "${REPO_URL}" "${TAG_REF}" | awk '{print $1}' | head -n 1)"
             fi
             if [[ -z "${SHA}" ]]; then
               echo "::error::Release tag does not exist on origin: ${MANUAL_RELEASE_TAG}"
@@ -207,11 +208,7 @@ jobs:
           GH_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
-            uv run python -m testing.release.cli validate \
-              --manifest release/floe-release.yaml \
-              --tag "${RELEASE_TAG}"
-          elif [[ -n "${RELEASE_TAG}" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_run" || -n "${RELEASE_TAG}" ]]; then
             uv run python -m testing.release.cli validate \
               --manifest release/floe-release.yaml \
               --tag "${RELEASE_TAG}"
@@ -247,11 +244,13 @@ jobs:
     name: Publish to PyPI
     needs: build
     if: >-
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'workflow_dispatch' &&
-      needs.build.outputs.publish == 'true'
-      && github.event.workflow_run.path == '.github/workflows/prepare-release.yml'
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'workflow_dispatch' &&
+        needs.build.outputs.publish == 'true' &&
+        github.event.workflow_run.path == '.github/workflows/prepare-release.yml'
+      )
       ||
       (
         github.event_name == 'workflow_dispatch' &&

--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@
 
 ---
 
+## Alpha Release Notice
+
+`v0.1.0-alpha.1` is an evaluation release for the documented Customer 360
+validation path and the manifest-declared alpha package cutline. APIs,
+configuration schemas, Helm values, generated artifacts, and plugin contracts
+may change before a stable release.
+
+Do not run Floe alpha releases with production data, production credentials,
+regulated workloads, customer-facing SLAs, or production-scale loads. Use
+isolated test accounts, synthetic or disposable data, scoped credentials,
+separate Kubernetes clusters/namespaces, and explicit cost limits when
+evaluating the platform.
+
+Floe is distributed under the Apache License 2.0 on an "AS IS" basis, without
+warranties or conditions. See [LICENSE](LICENSE) for the full license terms.
+
+**Alpha-supported today:**
+- Customer 360 demo compilation and validation.
+- The 15 Python packages declared in `release/floe-release.yaml`.
+- Local/dev Kubernetes evaluation paths documented in `docs/`.
+
+**Not alpha-supported today:**
+- Production data platform operation.
+- Production availability, backup, recovery, migration, or support guarantees.
+- Unbounded cloud-provider, Kubernetes, or data-processing workloads.
+
 ## What is floe?
 
 **floe** is an open platform for building internal data platforms.
@@ -41,7 +67,7 @@
 - ✅ Standards enforced automatically (compile-time validation)
 - ✅ Composition boundaries for the alpha path, with broader provider interchangeability tracked as follow-on work
 
-**Batteries included. Extensible by plugin. Alpha-ready for the documented Customer 360 validation path.**
+**Batteries included. Extensible by plugin. Alpha-ready for isolated evaluation of the documented Customer 360 validation path.**
 
 ---
 
@@ -369,7 +395,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Roadmap
 
-**Current alpha target (v0.1.0-alpha.1 release candidate)**:
+**Current alpha release (v0.1.0-alpha.1)**:
 - [x] Four-layer architecture
 - [x] Two-tier configuration
 - [x] Kubernetes-native deployment

--- a/docs/guides/pypi-trusted-publishers.md
+++ b/docs/guides/pypi-trusted-publishers.md
@@ -71,8 +71,21 @@ Publishing package: pypa/gh-action-pypi-publish
 
 1. Verify all 15 alpha packages are covered by the PyPI account token and
    project ownership.
-2. The `pypi-publish.yml` workflow, triggered by version tags, builds the
-   manifest package set and uploads artifacts with `PYPI_API_TOKEN`.
+2. A successful non-dry-run `prepare-release.yml` run uploads release metadata.
+3. The downstream `pypi-publish.yml` workflow builds only the manifest package
+   set and uploads artifacts with `PYPI_API_TOKEN`.
+
+If the GitHub Release already exists and the downstream publish workflow needs
+to be retried after a workflow fix, dispatch `pypi-publish.yml` manually with:
+
+```bash
+gh workflow run pypi-publish.yml \
+  -f release_tag=v0.1.0-alpha.1 \
+  -f dry_run=false
+```
+
+Manual publishing must always provide an existing `release_tag`; manual runs
+default to `dry_run=true`.
 
 ## Metadata
 

--- a/docs/releases/v0.1.0-alpha.1-release-notes.md
+++ b/docs/releases/v0.1.0-alpha.1-release-notes.md
@@ -91,9 +91,9 @@ The alpha evidence gate requires Customer 360 validation with Iceberg enabled:
 
 | Channel | Install |
 | --- | --- |
-| **PyPI** | `pip install floe-core floe-catalog-polaris floe-orchestrator-dagster` |
+| **PyPI** | `pip install "floe-core==0.1.0a1" "floe-iceberg==0.1.0a1" "floe-orchestrator-dagster==0.1.0a1"` after the PyPI publish workflow succeeds |
 | **Helm** | `helm install floe-platform oci://ghcr.io/obsidian-owl/charts/floe-platform` after Helm release policy allows publication |
-| **Source** | `git clone https://github.com/Obsidian-Owl/floe && uv sync` |
+| **Source** | `git clone https://github.com/Obsidian-Owl/floe && cd floe && git checkout v0.1.0-alpha.1 && uv sync --all-extras --dev` |
 
 ## Release Evidence Gate
 

--- a/packages/floe-core/README.md
+++ b/packages/floe-core/README.md
@@ -1,5 +1,7 @@
 # floe-core
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Core plugin registry and interfaces for the floe data platform.
 
 ## Installation

--- a/packages/floe-iceberg/README.md
+++ b/packages/floe-iceberg/README.md
@@ -1,5 +1,7 @@
 # floe-iceberg
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 IcebergTableManager utility for PyIceberg table operations in the floe data platform.
 
 ## Overview

--- a/plugins/floe-catalog-glue/README.md
+++ b/plugins/floe-catalog-glue/README.md
@@ -1,5 +1,7 @@
 # floe-catalog-glue
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Native AWS Glue catalog plugin for Floe.
 
 This package emits secret-free `CatalogDeploymentBinding` contracts for AWS

--- a/plugins/floe-catalog-polaris/README.md
+++ b/plugins/floe-catalog-polaris/README.md
@@ -1,5 +1,7 @@
 # floe-catalog-polaris
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Apache Polaris Catalog Plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-compute-duckdb/README.md
+++ b/plugins/floe-compute-duckdb/README.md
@@ -1,5 +1,7 @@
 # floe-compute-duckdb
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 DuckDB compute plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-dbt-core/README.md
+++ b/plugins/floe-dbt-core/README.md
@@ -1,5 +1,7 @@
 # floe-dbt-core
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 DBT plugin for floe using dbt-core Python API.
 
 ## Overview

--- a/plugins/floe-ingestion-dlt/README.md
+++ b/plugins/floe-ingestion-dlt/README.md
@@ -1,5 +1,7 @@
 # floe-ingestion-dlt
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 dlt (data load tool) ingestion plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-lineage-marquez/README.md
+++ b/plugins/floe-lineage-marquez/README.md
@@ -1,5 +1,7 @@
 # floe-lineage-marquez
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Marquez lineage backend plugin for floe - OpenLineage reference implementation for data lineage.
 
 ## Overview

--- a/plugins/floe-network-security-k8s/README.md
+++ b/plugins/floe-network-security-k8s/README.md
@@ -1,5 +1,7 @@
 # floe-network-security-k8s
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Kubernetes Network Security plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-orchestrator-dagster/README.md
+++ b/plugins/floe-orchestrator-dagster/README.md
@@ -1,5 +1,7 @@
 # floe-orchestrator-dagster
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Dagster orchestrator plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-quality-gx/README.md
+++ b/plugins/floe-quality-gx/README.md
@@ -1,5 +1,7 @@
 # floe-quality-gx
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Great Expectations data quality plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-rbac-k8s/README.md
+++ b/plugins/floe-rbac-k8s/README.md
@@ -1,5 +1,7 @@
 # floe-rbac-k8s
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Kubernetes RBAC plugin for the floe data platform.
 
 ## Overview

--- a/plugins/floe-storage-aws-s3/README.md
+++ b/plugins/floe-storage-aws-s3/README.md
@@ -1,5 +1,7 @@
 # floe-storage-aws-s3
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Native AWS S3 storage plugin for Floe.
 
 This package emits secret-free `StorageDeploymentBinding` contracts for an

--- a/plugins/floe-storage-minio/README.md
+++ b/plugins/floe-storage-minio/README.md
@@ -1,0 +1,5 @@
+# floe-storage-minio
+
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
+MinIO object storage plugin for Floe.

--- a/plugins/floe-telemetry-jaeger/README.md
+++ b/plugins/floe-telemetry-jaeger/README.md
@@ -1,5 +1,7 @@
 # floe-telemetry-jaeger
 
+> **Alpha release notice:** This `v0.1.0-alpha.1` package is for isolated evaluation only. Do not use Floe alpha packages with production data, production credentials, regulated workloads, customer-facing SLAs, or production-scale loads. Floe is distributed under Apache-2.0 on an "AS IS" basis; see the repository `LICENSE` for full terms.
+
 Jaeger telemetry backend plugin for floe - OTLP exporter for Jaeger distributed tracing.
 
 ## Overview

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -268,6 +268,7 @@ class TestPypiPublishWorkflow:
         assert "github.event.workflow_run.display_title" not in workflow_text
         assert "gh run download" in workflow_text
         assert "--name release-metadata" in workflow_text
+        assert "awk '{print $1}' | head -n 1" in workflow_text
         assert "publish=true" in workflow_text
         assert "publish=false" in workflow_text
         assert (
@@ -292,15 +293,24 @@ class TestPypiPublishWorkflow:
     def test_manual_pypi_dispatch_is_build_only_dry_run(self) -> None:
         """Manual PyPI dispatch defaults to dry-run and requires a tag to publish."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
+        publish_job = workflow_text.split("\n  publish:", maxsplit=1)[1].split(
+            "\n  verify:",
+            maxsplit=1,
+        )[0]
 
         assert "workflow_dispatch:" in workflow_text
         assert "release_tag:" in workflow_text
         assert "dry_run:" in workflow_text
         assert "inputs.dry_run == false" in workflow_text
         assert "inputs.release_tag != ''" in workflow_text
+        assert "(\n        github.event_name == 'workflow_run' &&" in publish_job
+        assert ")\n      ||\n      (" in publish_job
         assert "MANUAL_RELEASE_TAG" in workflow_text
         assert "github.com/${GITHUB_REPOSITORY}.git" in workflow_text
         assert "refs/tags/${MANUAL_RELEASE_TAG}" in workflow_text
+        assert "^v[0-9]+\\.[0-9]+\\.[0-9]+(-alpha\\.[0-9]+)?$" in workflow_text
+        assert "Manual PyPI publish backfill requested" in workflow_text
+        assert '[[ "${EVENT_NAME}" == "workflow_run" || -n "${RELEASE_TAG}" ]]' in workflow_text
 
 
 class TestReleaseWorkflowAuthority:

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -261,17 +261,19 @@ class TestPypiPublishWorkflow:
         assert "github.event_name == 'workflow_run'" in workflow_text
         assert "github.event.workflow_run.conclusion == 'success'" in workflow_text
         assert "github.event.workflow_run.event == 'workflow_dispatch'" in workflow_text
-        assert "github.event.workflow_run.name == 'Prepare Release'" in workflow_text
+        assert "github.event.workflow_run.path == '.github/workflows/prepare-release.yml'" in (
+            workflow_text
+        )
+        assert "github.event.workflow_run.name == 'Prepare Release'" not in workflow_text
         assert "github.event.workflow_run.display_title" not in workflow_text
         assert "gh run download" in workflow_text
         assert "--name release-metadata" in workflow_text
         assert "publish=true" in workflow_text
         assert "publish=false" in workflow_text
         assert (
-            "ref: ${{ github.event_name == 'workflow_run' && "
-            "steps.release_metadata.outputs.sha || github.ref }}"
+            "ref: ${{ steps.release_metadata.outputs.sha || "
+            "steps.release_metadata.outputs.tag || github.ref }}"
         ) in workflow_text
-        assert "steps.release_metadata.outputs.tag || github.ref" not in workflow_text
         assert "startsWith(github.event.workflow_run.head_branch" not in workflow_text
         assert "github.event.workflow_run.head_branch" not in workflow_text
 
@@ -288,13 +290,17 @@ class TestPypiPublishWorkflow:
 
     @pytest.mark.requirement("REL-GATE-PUBLISH")
     def test_manual_pypi_dispatch_is_build_only_dry_run(self) -> None:
-        """Manual PyPI dispatch keeps dry-run support but cannot upload artifacts."""
+        """Manual PyPI dispatch defaults to dry-run and requires a tag to publish."""
         workflow_text = PYPI_WORKFLOW.read_text(encoding="utf-8")
 
         assert "workflow_dispatch:" in workflow_text
+        assert "release_tag:" in workflow_text
         assert "dry_run:" in workflow_text
-        assert "github.event_name == 'workflow_run'" in workflow_text
-        assert "inputs.dry_run" not in workflow_text
+        assert "inputs.dry_run == false" in workflow_text
+        assert "inputs.release_tag != ''" in workflow_text
+        assert "MANUAL_RELEASE_TAG" in workflow_text
+        assert "github.com/${GITHUB_REPOSITORY}.git" in workflow_text
+        assert "refs/tags/${MANUAL_RELEASE_TAG}" in workflow_text
 
 
 class TestReleaseWorkflowAuthority:


### PR DESCRIPTION
## Summary
- fix PyPI publish workflow_run gating so custom Prepare Release run names do not skip all jobs
- add a guarded manual release_tag backfill path for an already-created GitHub Release
- document the release publish path and add alpha production-data warnings to the root README and alpha package READMEs

## Root cause
The downstream PyPI Publish workflow triggered from the successful Prepare Release run, but every job was skipped because the job-level guard compared `github.event.workflow_run.name` to `Prepare Release`. The Prepare Release workflow uses a custom `run-name`, so the workflow_run payload exposed `Prepare Release v0.1.0-alpha.1 dry_run=false` instead.

## Validation
- `uv run pytest testing/tests/unit/test_ci_workflows.py testing/ci/tests/test_github_actions_node24_pins.py -q`
- `actionlint .github/workflows/pypi-publish.yml .github/workflows/prepare-release.yml .github/workflows/e2e.yml`
- `uv run python -m testing.release.cli validate --manifest release/floe-release.yaml --tag v0.1.0-alpha.1`
- `uv run python -m testing.release.cli build --manifest release/floe-release.yaml --dist-dir .release-build/pypi-fix-dist`
- pre-push hook passed lint, format, mypy, security, unit, contract, traceability, docs, and helm lint gates

## Follow-up after merge
Dispatch `pypi-publish.yml` with `release_tag=v0.1.0-alpha.1` and `dry_run=false`, then monitor Publish and Verify Published Packages.

## Legal note
The alpha notices are engineering documentation, not legal advice. Counsel should review final project terms if Floe will be offered to third parties commercially.