### PR TITLE
Implement alpha operability validator evidence

### DIFF
--- a/docs/demo/customer-360-validation.md
+++ b/docs/demo/customer-360-validation.md
@@ -44,7 +44,13 @@ Current validator output keys, including alpha compatibility keys:
 
 - `platform.ready`
 - `dagster.customer_360_run`
+- `run_control.namespace`
+- `run_control.runtime_context`
+- `run_control.dagster.status`
+- `run_control.dagster.job_name`
+- `run_control.dagster.api_reachable`
 - `storage.customer_360_outputs`
+- `storage.iceberg.customer_360_outputs`
 - `observability.logs.status`
 - `observability.logs.count`
 - `observability.metrics.status`
@@ -78,6 +84,11 @@ evidence.business.customer_count=<non-negative integer>
 evidence.business.total_lifetime_value=<non-negative decimal>
 evidence.dagster.customer_360_run=true
 evidence.lineage.marquez_customer_360=true
+evidence.run_control.dagster.api_reachable=true
+evidence.run_control.dagster.job_name=customer_360
+evidence.run_control.dagster.status=pass
+evidence.run_control.namespace=floe-dev
+evidence.run_control.runtime_context=local
 evidence.observability.lineage.status=pass
 evidence.observability.lineage.count=<positive integer>
 evidence.observability.logs.status=pass
@@ -89,6 +100,7 @@ evidence.observability.traces.status=pass
 evidence.observability.traces.count=<positive integer>
 evidence.platform.ready=true
 evidence.storage.customer_360_outputs=true
+evidence.storage.iceberg.customer_360_outputs=true
 evidence.tracing.jaeger_customer_360=true
 ```
 

--- a/docs/platform-engineers/validate-platform.md
+++ b/docs/platform-engineers/validate-platform.md
@@ -75,7 +75,13 @@ Current validator output keys, including alpha compatibility keys:
 
 - `platform.ready`
 - `dagster.customer_360_run`
+- `run_control.namespace`
+- `run_control.runtime_context`
+- `run_control.dagster.status`
+- `run_control.dagster.job_name`
+- `run_control.dagster.api_reachable`
 - `storage.customer_360_outputs`
+- `storage.iceberg.customer_360_outputs`
 - `observability.logs.status`
 - `observability.logs.count`
 - `observability.metrics.status`

--- a/testing/ci/customer360_observability.py
+++ b/testing/ci/customer360_observability.py
@@ -39,11 +39,14 @@ class EvidenceStatus(str, Enum):
     """Classification for backend evidence checks."""
 
     PASS = "pass"
+    PLATFORM_SERVICE_FAILURE = "platform_service_failure"
     BACKEND_UNREACHABLE = "backend_unreachable"
     NO_FRESH_EVIDENCE = "no_fresh_evidence"
     STALE_EVIDENCE = "stale_evidence"
     WRONG_CONTEXT = "wrong_context"
     PRODUCT_FAILURE = "product_failure"
+    DASHBOARD_DATASOURCE_DRIFT = "dashboard_datasource_drift"
+    CONTRACT_GAP = "contract_gap"
 
 
 FAILURE_STATUSES = {"FAILURE", "FAILED", "ERROR", "CANCELED", "CANCELLED"}
@@ -490,12 +493,15 @@ def query_loki_logs(
     # the alpha chart sends runtime logs directly through the collector.
     loki_query = f'{{service_name=~".+"}} |= "{product}" |= "{run_id}"'
     url = _join_url(loki_url, "loki/api/v1/query_range")
+    ready_url = _join_url(loki_url, "ready")
     owns_client = client is None
     http_client = client or httpx.Client(timeout=timeout_seconds)
     try:
         response = http_client.get(url, params={"query": loki_query, "limit": "100"})
         response.raise_for_status()
         records = _loki_records(response.json())
+        ready_response = http_client.get(ready_url)
+        ready_response.raise_for_status()
     except Exception as exc:  # noqa: BLE001
         return classify_evidence_records(
             backend="logs",
@@ -509,11 +515,67 @@ def query_loki_logs(
         if owns_client:
             http_client.close()
 
+    log_context = ObservabilityContext(
+        product=context.product,
+        run_id=context.run_id,
+        freshness_window_seconds=context.freshness_window_seconds,
+        now_epoch_seconds=context.now_epoch_seconds,
+    )
     return classify_evidence_records(
         backend="logs",
         query=loki_query,
+        context=log_context,
+        records=records,
+        url=url,
+    )
+
+
+def query_prometheus_instant_metrics(
+    *,
+    prometheus_url: str,
+    product: str,
+    status: str,
+    plugin: str,
+    context: ObservabilityContext,
+    timeout_seconds: float = 30.0,
+    client: httpx.Client | None = None,
+) -> EvidenceResult:
+    """Query Prometheus instant metrics by product/status/plugin context."""
+    metric_name = (
+        ASSET_FAILURES_METRIC
+        if status.lower() in {"failure", "error"}
+        else ASSET_MATERIALIZATIONS_METRIC
+    )
+    prom_query = (
+        f'{metric_name}{{{METRIC_PRODUCT_NAME_LABEL}="{product}",'
+        f'{METRIC_STATUS_LABEL}="{status}",{METRIC_PLUGIN_NAME_LABEL}=~"{plugin}"}}'
+    )
+    url = _join_url(prometheus_url, "api/v1/query")
+    owns_client = client is None
+    http_client = client or httpx.Client(timeout=timeout_seconds)
+    try:
+        response = http_client.get(url, params={"query": prom_query})
+        response.raise_for_status()
+        records = _prometheus_records(response.json())
+    except Exception as exc:  # noqa: BLE001
+        return classify_evidence_records(
+            backend="metrics",
+            query=prom_query,
+            context=context,
+            records=None,
+            backend_error=str(exc),
+            url=url,
+        )
+    finally:
+        if owns_client:
+            http_client.close()
+
+    return _classify_metric_records(
+        query=prom_query,
         context=context,
         records=records,
+        status=status,
+        plugin=plugin,
         url=url,
     )
 
@@ -595,6 +657,8 @@ def query_marquez_lineage(
         f"api/v1/namespaces/{encoded_namespace}/jobs/{encoded_job}/runs",
     )
     jobs_url = _join_url(marquez_url, f"api/v1/namespaces/{encoded_namespace}/jobs")
+    datasets_url = _join_url(marquez_url, f"api/v1/namespaces/{encoded_namespace}/datasets")
+    graph_url = build_marquez_graph_query_url(marquez_url)
     query = f"namespace={namespace} job={job_name} run_id={context.run_id}"
     owns_client = client is None
     http_client = client or httpx.Client(timeout=timeout_seconds)
@@ -609,6 +673,21 @@ def query_marquez_lineage(
         jobs_response = http_client.get(jobs_url)
         jobs_response.raise_for_status()
         job_records = _marquez_job_records(jobs_response.json(), namespace=namespace)
+        dataset_records = _optional_marquez_dataset_records(
+            http_client=http_client,
+            datasets_url=datasets_url,
+            namespace=namespace,
+        )
+        if context.table:
+            _query_optional_marquez_graph(
+                http_client=http_client,
+                graph_url=graph_url,
+                node_id=build_marquez_graph_node_id(
+                    node_type="dataset",
+                    namespace=namespace,
+                    name=context.table,
+                ),
+            )
         model_run_records: list[EvidenceRecord] = []
         for model_job_name in _marquez_model_table_job_names(job_records, context):
             model_runs_url = _join_url(
@@ -650,7 +729,144 @@ def query_marquez_lineage(
         context=context,
         run_records=run_records,
         model_run_records=model_run_records,
+        dataset_records=dataset_records,
         url=runs_url,
+    )
+
+
+def build_marquez_graph_node_id(*, node_type: str, namespace: str, name: str) -> str:
+    """Build the Marquez lineage graph node id for a namespace-scoped object."""
+    return f"{node_type.lower()}:{namespace}:{name}"
+
+
+def build_marquez_graph_query_url(marquez_url: str) -> str:
+    """Return the Marquez lineage graph query URL."""
+    return _join_url(marquez_url, "api/v1/lineage")
+
+
+def extract_grafana_panel_queries(dashboard: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
+    """Extract datasource/query pairs from Grafana dashboard panels."""
+    dashboard_body = dashboard.get("dashboard", dashboard)
+    if not isinstance(dashboard_body, Mapping):
+        return ()
+    panels = dashboard_body.get("panels", [])
+    if not isinstance(panels, list):
+        return ()
+
+    queries: list[dict[str, str]] = []
+    for panel in panels:
+        if not isinstance(panel, Mapping):
+            continue
+        panel_title = str(panel.get("title") or "<untitled>")
+        panel_datasource_uid = _grafana_datasource_uid(panel.get("datasource"))
+        targets = panel.get("targets", [])
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if not isinstance(target, Mapping):
+                continue
+            query = target.get("expr") or target.get("query") or target.get("refId")
+            if not query:
+                continue
+            datasource_uid = _grafana_datasource_uid(target.get("datasource"))
+            datasource_uid = datasource_uid or panel_datasource_uid
+            if not datasource_uid:
+                continue
+            queries.append(
+                {
+                    "panel_title": panel_title,
+                    "datasource_uid": datasource_uid,
+                    "query": str(query),
+                    "backend": _grafana_backend_from_query_or_uid(
+                        query=str(query),
+                        datasource_uid=datasource_uid,
+                    ),
+                }
+            )
+    return tuple(queries)
+
+
+def query_grafana_dashboard_panels(
+    *,
+    grafana_url: str,
+    dashboard: Mapping[str, Any],
+    backend_results: Mapping[str, bool],
+    context: ObservabilityContext,
+    timeout_seconds: float = 30.0,
+    client: httpx.Client | None = None,
+) -> EvidenceResult:
+    """Validate Grafana datasource and panel queries against backend truth."""
+    panel_queries = extract_grafana_panel_queries(dashboard)
+    query = "grafana dashboard panel queries"
+    if not panel_queries:
+        return EvidenceResult(
+            backend="grafana",
+            status=EvidenceStatus.CONTRACT_GAP,
+            query=query,
+            message="Grafana dashboard contains no extractable panel queries",
+        )
+
+    owns_client = client is None
+    http_client = client or httpx.Client(timeout=timeout_seconds)
+    try:
+        for panel_query in panel_queries:
+            datasource_uid = panel_query["datasource_uid"]
+            datasource_url = _join_url(grafana_url, f"api/datasources/uid/{datasource_uid}")
+            datasource_response = http_client.get(datasource_url)
+            datasource_response.raise_for_status()
+            datasource_payload = datasource_response.json()
+            backend = _grafana_backend_from_datasource(
+                datasource_payload,
+                fallback=panel_query["backend"],
+            )
+            query_url = _join_url(grafana_url, "api/ds/query")
+            query_response = http_client.get(
+                query_url,
+                params={"query": panel_query["query"], "datasourceUid": datasource_uid},
+            )
+            query_response.raise_for_status()
+            if backend_results.get(backend, False) and not _grafana_query_has_frames(
+                query_response.json()
+            ):
+                return EvidenceResult(
+                    backend="grafana",
+                    status=EvidenceStatus.DASHBOARD_DATASOURCE_DRIFT,
+                    query=panel_query["query"],
+                    url=query_url,
+                    message=(
+                        "Grafana panel query returned no data through its configured "
+                        "datasource while the backend query passed"
+                    ),
+                    diagnostics={
+                        "datasource_uid": datasource_uid,
+                        "panel_title": panel_query["panel_title"],
+                        "backend": backend,
+                    },
+                )
+    except Exception as exc:  # noqa: BLE001
+        return classify_evidence_records(
+            backend="grafana",
+            query=query,
+            context=context,
+            records=None,
+            backend_error=str(exc),
+            url=_join_url(grafana_url, "api/ds/query"),
+        )
+    finally:
+        if owns_client:
+            http_client.close()
+
+    return EvidenceResult(
+        backend="grafana",
+        status=EvidenceStatus.PASS,
+        query=query,
+        message="Grafana dashboard panel queries returned data through configured datasources",
+        records=(
+            EvidenceRecord(
+                payload={"panel_queries": list(panel_queries), "product": context.product},
+                timestamp_epoch_seconds=context.now_epoch_seconds,
+            ),
+        ),
     )
 
 
@@ -932,6 +1148,7 @@ def _classify_marquez_lineage_records(
     context: ObservabilityContext,
     run_records: Sequence[EvidenceRecord],
     model_run_records: Sequence[EvidenceRecord],
+    dataset_records: Sequence[EvidenceRecord] = (),
     url: str,
 ) -> EvidenceResult:
     product_context = ObservabilityContext(
@@ -972,8 +1189,51 @@ def _classify_marquez_lineage_records(
         diagnostics={
             "product_run_count": str(product_result.evidence_count),
             "model_table_count": str(table_result.evidence_count),
+            "dataset_count": str(len(dataset_records)),
         },
     )
+
+
+def _optional_marquez_dataset_records(
+    *,
+    http_client: httpx.Client,
+    datasets_url: str,
+    namespace: str,
+) -> tuple[EvidenceRecord, ...]:
+    """Return Marquez dataset records when the endpoint is available."""
+    if not _should_query_optional_url(http_client, datasets_url):
+        return ()
+    try:
+        response = http_client.get(datasets_url)
+        response.raise_for_status()
+        return tuple(_marquez_dataset_records(response.json(), namespace=namespace))
+    except Exception:  # noqa: BLE001 - older Marquez endpoints may omit datasets listing.
+        return ()
+
+
+def _query_optional_marquez_graph(
+    *,
+    http_client: httpx.Client,
+    graph_url: str,
+    node_id: str,
+) -> None:
+    """Query Marquez lineage graph when available without making older APIs fail."""
+    if not _should_query_optional_url(http_client, graph_url):
+        return
+    try:
+        response = http_client.get(graph_url, params={"nodeId": node_id, "depth": "2"})
+        response.raise_for_status()
+    except Exception:  # noqa: BLE001 - graph evidence is additive for this helper.
+        return
+
+
+def _should_query_optional_url(http_client: httpx.Client, url: str) -> bool:
+    """Avoid perturbing local fake clients that do not model optional API URLs."""
+    for attribute in ("responses", "payload"):
+        configured = getattr(http_client, attribute, None)
+        if isinstance(configured, Mapping) and url not in configured:
+            return False
+    return True
 
 
 def _classify_marquez_model_table_run_records(
@@ -1449,6 +1709,67 @@ def _marquez_job_records(
         enriched.setdefault("namespace", namespace)
         records.append(EvidenceRecord(payload=enriched))
     return records
+
+
+def _marquez_dataset_records(
+    payload: Mapping[str, Any],
+    *,
+    namespace: str,
+) -> list[EvidenceRecord]:
+    datasets = payload.get("datasets", [])
+    if not isinstance(datasets, list):
+        return []
+    records: list[EvidenceRecord] = []
+    for dataset in datasets:
+        if not isinstance(dataset, Mapping):
+            continue
+        enriched = dict(dataset)
+        enriched.setdefault("namespace", namespace)
+        records.append(EvidenceRecord(payload=enriched))
+    return records
+
+
+def _grafana_datasource_uid(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, Mapping):
+        uid = value.get("uid")
+        if uid:
+            return str(uid)
+    return None
+
+
+def _grafana_backend_from_query_or_uid(*, query: str, datasource_uid: str) -> str:
+    combined = f"{datasource_uid} {query}".lower()
+    if "loki" in combined or "logql" in combined:
+        return "loki"
+    return "prometheus"
+
+
+def _grafana_backend_from_datasource(
+    payload: Mapping[str, Any],
+    *,
+    fallback: str,
+) -> str:
+    datasource_type = str(payload.get("type", "")).lower()
+    if "loki" in datasource_type:
+        return "loki"
+    if "prometheus" in datasource_type:
+        return "prometheus"
+    return fallback
+
+
+def _grafana_query_has_frames(payload: Mapping[str, Any]) -> bool:
+    results = payload.get("results", {})
+    if not isinstance(results, Mapping):
+        return False
+    for result in results.values():
+        if not isinstance(result, Mapping):
+            continue
+        frames = result.get("frames", [])
+        if isinstance(frames, list) and frames:
+            return True
+    return False
 
 
 def _dagster_run_record(run: Mapping[str, Any], *, product: str) -> EvidenceRecord:

--- a/testing/ci/customer360_observability.py
+++ b/testing/ci/customer360_observability.py
@@ -497,11 +497,11 @@ def query_loki_logs(
     owns_client = client is None
     http_client = client or httpx.Client(timeout=timeout_seconds)
     try:
+        ready_response = http_client.get(ready_url)
+        ready_response.raise_for_status()
         response = http_client.get(url, params={"query": loki_query, "limit": "100"})
         response.raise_for_status()
         records = _loki_records(response.json())
-        ready_response = http_client.get(ready_url)
-        ready_response.raise_for_status()
     except Exception as exc:  # noqa: BLE001
         return classify_evidence_records(
             backend="logs",
@@ -515,6 +515,8 @@ def query_loki_logs(
         if owns_client:
             http_client.close()
 
+    # Loki log proof is run-scoped. Drop table from the shared context so a
+    # valid run-level log stream is not rejected for missing table text.
     log_context = ObservabilityContext(
         product=context.product,
         run_id=context.run_id,
@@ -678,8 +680,9 @@ def query_marquez_lineage(
             datasets_url=datasets_url,
             namespace=namespace,
         )
+        graph_records: tuple[EvidenceRecord, ...] = ()
         if context.table:
-            _query_optional_marquez_graph(
+            graph_records = _query_optional_marquez_graph(
                 http_client=http_client,
                 graph_url=graph_url,
                 node_id=build_marquez_graph_node_id(
@@ -730,6 +733,7 @@ def query_marquez_lineage(
         run_records=run_records,
         model_run_records=model_run_records,
         dataset_records=dataset_records,
+        graph_records=graph_records,
         url=runs_url,
     )
 
@@ -1149,6 +1153,7 @@ def _classify_marquez_lineage_records(
     run_records: Sequence[EvidenceRecord],
     model_run_records: Sequence[EvidenceRecord],
     dataset_records: Sequence[EvidenceRecord] = (),
+    graph_records: Sequence[EvidenceRecord] = (),
     url: str,
 ) -> EvidenceResult:
     product_context = ObservabilityContext(
@@ -1190,6 +1195,7 @@ def _classify_marquez_lineage_records(
             "product_run_count": str(product_result.evidence_count),
             "model_table_count": str(table_result.evidence_count),
             "dataset_count": str(len(dataset_records)),
+            "graph_count": str(len(graph_records)),
         },
     )
 
@@ -1201,8 +1207,6 @@ def _optional_marquez_dataset_records(
     namespace: str,
 ) -> tuple[EvidenceRecord, ...]:
     """Return Marquez dataset records when the endpoint is available."""
-    if not _should_query_optional_url(http_client, datasets_url):
-        return ()
     try:
         response = http_client.get(datasets_url)
         response.raise_for_status()
@@ -1216,24 +1220,14 @@ def _query_optional_marquez_graph(
     http_client: httpx.Client,
     graph_url: str,
     node_id: str,
-) -> None:
-    """Query Marquez lineage graph when available without making older APIs fail."""
-    if not _should_query_optional_url(http_client, graph_url):
-        return
+) -> tuple[EvidenceRecord, ...]:
+    """Return Marquez lineage graph records when the endpoint is available."""
     try:
         response = http_client.get(graph_url, params={"nodeId": node_id, "depth": "2"})
         response.raise_for_status()
+        return tuple(_marquez_graph_records(response.json(), node_id=node_id))
     except Exception:  # noqa: BLE001 - graph evidence is additive for this helper.
-        return
-
-
-def _should_query_optional_url(http_client: httpx.Client, url: str) -> bool:
-    """Avoid perturbing local fake clients that do not model optional API URLs."""
-    for attribute in ("responses", "payload"):
-        configured = getattr(http_client, attribute, None)
-        if isinstance(configured, Mapping) and url not in configured:
-            return False
-    return True
+        return ()
 
 
 def _classify_marquez_model_table_run_records(
@@ -1727,6 +1721,17 @@ def _marquez_dataset_records(
         enriched.setdefault("namespace", namespace)
         records.append(EvidenceRecord(payload=enriched))
     return records
+
+
+def _marquez_graph_records(
+    payload: Mapping[str, Any],
+    *,
+    node_id: str,
+) -> list[EvidenceRecord]:
+    """Convert a Marquez lineage graph response into evidence records."""
+    enriched = dict(payload)
+    enriched.setdefault("node_id", node_id)
+    return [EvidenceRecord(payload=enriched)]
 
 
 def _grafana_datasource_uid(value: object) -> str | None:

--- a/testing/ci/tests/test_customer360_backend_helpers.py
+++ b/testing/ci/tests/test_customer360_backend_helpers.py
@@ -1,0 +1,304 @@
+"""Contract tests for Customer 360 backend observability helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import httpx
+
+from testing.ci.customer360_observability import (
+    EvidenceStatus,
+    ObservabilityContext,
+    build_marquez_graph_node_id,
+    build_marquez_graph_query_url,
+    extract_grafana_panel_queries,
+    query_grafana_dashboard_panels,
+    query_loki_logs,
+    query_marquez_lineage,
+    query_prometheus_instant_metrics,
+    query_prometheus_metrics,
+)
+
+JsonObject = dict[str, Any]
+HttpParams = Mapping[str, object] | None
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        payload: JsonObject | str,
+        *,
+        status_code: int = 200,
+        error: Exception | None = None,
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self._error = error
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+    def json(self) -> JsonObject:
+        if isinstance(self._payload, dict):
+            return self._payload
+        raise ValueError("response is not JSON")
+
+
+class _FakeClient:
+    def __init__(self, responses: Mapping[str, JsonObject | str | _FakeResponse]) -> None:
+        self.responses = responses
+        self.requests: list[tuple[str, HttpParams]] = []
+
+    def get(self, url: str, params: HttpParams = None) -> _FakeResponse:
+        self.requests.append((url, params))
+        response = self.responses.get(url)
+        if isinstance(response, _FakeResponse):
+            return response
+        if response is not None:
+            return _FakeResponse(response)
+        raise AssertionError(f"No fake response configured for {url}")
+
+
+def _context() -> ObservabilityContext:
+    return ObservabilityContext(
+        product="customer-360",
+        run_id="run-123",
+        table="mart_customer_360",
+        freshness_window_seconds=300,
+        now_epoch_seconds=1_700_000_000.0,
+    )
+
+
+def test_evidence_status_covers_all_alpha_failure_classes() -> None:
+    """Backend helpers can represent every alpha evidence class explicitly."""
+    assert {status.value for status in EvidenceStatus} >= {
+        "pass",
+        "product_failure",
+        "platform_service_failure",
+        "backend_unreachable",
+        "no_fresh_evidence",
+        "wrong_context",
+        "stale_evidence",
+        "dashboard_datasource_drift",
+        "contract_gap",
+    }
+
+
+def test_marquez_helper_uses_api_endpoints_and_graph_node_helpers() -> None:
+    """Marquez proof comes from namespace/job/run/dataset/lineage APIs, not root UI."""
+    client = _FakeClient(
+        {
+            "http://marquez/api/v1/namespaces/customer-360/jobs/customer-360/runs": {
+                "runs": [
+                    {
+                        "id": "run-123",
+                        "state": "COMPLETED",
+                        "startedAt": "2023-11-14T22:12:30Z",
+                        "facets": {"product": {"name": "customer-360"}},
+                    }
+                ]
+            },
+            "http://marquez/api/v1/namespaces/customer-360/jobs": {
+                "jobs": [{"name": "model.customer_360.mart_customer_360"}]
+            },
+            "http://marquez/api/v1/namespaces/customer-360/datasets": {
+                "datasets": [{"name": "mart_customer_360"}]
+            },
+            (
+                "http://marquez/api/v1/namespaces/customer-360/jobs/"
+                "model.customer_360.mart_customer_360/runs"
+            ): {
+                "runs": [
+                    {
+                        "id": "model-run-1",
+                        "state": "COMPLETED",
+                        "endedAt": "2023-11-14T22:12:40Z",
+                        "facets": {"parent": {"run": {"runId": "run-123"}}},
+                    }
+                ]
+            },
+            "http://marquez/api/v1/lineage": {"graph": []},
+        }
+    )
+
+    node_id = build_marquez_graph_node_id(
+        node_type="dataset",
+        namespace="customer-360",
+        name="mart_customer_360",
+    )
+    result = query_marquez_lineage(
+        marquez_url="http://marquez",
+        namespace="customer-360",
+        job_name="customer-360",
+        context=_context(),
+        client=cast(httpx.Client, client),
+    )
+
+    assert node_id == "dataset:customer-360:mart_customer_360"
+    assert build_marquez_graph_query_url("http://marquez") == "http://marquez/api/v1/lineage"
+    assert result.status is EvidenceStatus.PASS
+    requested_urls = {url for url, _params in client.requests}
+    assert "http://marquez/" not in requested_urls
+    assert "http://marquez/api/v1/namespaces/customer-360/datasets" in requested_urls
+    assert (
+        "http://marquez/api/v1/lineage",
+        {"nodeId": node_id, "depth": "2"},
+    ) in client.requests
+
+
+def test_loki_helper_checks_ready_and_query_range_without_root_ui() -> None:
+    """Loki root 404 is irrelevant when /ready and query_range pass."""
+    client = _FakeClient(
+        {
+            "http://loki/ready": "ready\n",
+            "http://loki/loki/api/v1/query_range": {
+                "data": {
+                    "result": [
+                        {
+                            "stream": {"service_name": "customer-360"},
+                            "values": [
+                                [
+                                    "1699999950000000000",
+                                    (
+                                        '{"product":"customer-360","run_id":"run-123",'
+                                        '"message":"runtime completed"}'
+                                    ),
+                                ]
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+    )
+
+    result = query_loki_logs(
+        loki_url="http://loki",
+        product="customer-360",
+        run_id="run-123",
+        context=_context(),
+        client=cast(httpx.Client, client),
+    )
+
+    assert result.status is EvidenceStatus.PASS
+    assert ("http://loki/ready", None) in client.requests
+    assert all(url != "http://loki/" for url, _params in client.requests)
+
+
+def test_prometheus_helpers_support_instant_and_range_queries() -> None:
+    """Prometheus proof can be checked through instant or range query APIs."""
+    instant_client = _FakeClient(
+        {
+            "http://prom/api/v1/query": {
+                "data": {
+                    "result": [
+                        {
+                            "metric": {
+                                "floe_product_name": "customer-360",
+                                "floe_status": "success",
+                                "floe_plugin_name": "dagster",
+                                "floe_asset_key": "mart_customer_360",
+                            },
+                            "value": [1_699_999_950.0, "1"],
+                        }
+                    ]
+                }
+            }
+        }
+    )
+    range_client = _FakeClient(
+        {
+            "http://prom/api/v1/query_range": {
+                "data": {
+                    "result": [
+                        {
+                            "metric": {
+                                "floe_product_name": "customer-360",
+                                "floe_status": "success",
+                                "floe_plugin_name": "dagster",
+                                "floe_asset_key": "mart_customer_360",
+                            },
+                            "values": [[1_699_999_950.0, "1"]],
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    instant = query_prometheus_instant_metrics(
+        prometheus_url="http://prom",
+        product="customer-360",
+        status="success",
+        plugin="dagster",
+        context=_context(),
+        client=cast(httpx.Client, instant_client),
+    )
+    ranged = query_prometheus_metrics(
+        prometheus_url="http://prom",
+        product="customer-360",
+        status="success",
+        plugin="dagster",
+        context=_context(),
+        client=cast(httpx.Client, range_client),
+    )
+
+    assert instant.status is EvidenceStatus.PASS
+    assert ranged.status is EvidenceStatus.PASS
+    assert instant.url == "http://prom/api/v1/query"
+    assert ranged.url == "http://prom/api/v1/query_range"
+
+
+def test_grafana_panel_queries_classify_datasource_drift() -> None:
+    """Empty panel results through Grafana are datasource drift when backend queries pass."""
+    dashboard = {
+        "dashboard": {
+            "panels": [
+                {
+                    "title": "Customer 360 materializations",
+                    "datasource": {"uid": "grafana-prometheus"},
+                    "targets": [
+                        {
+                            "datasource": {"uid": "grafana-prometheus"},
+                            "expr": (
+                                "floe_asset_materializations_total"
+                                '{floe_product_name="customer-360"}'
+                            ),
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    client = _FakeClient(
+        {
+            "http://grafana/api/datasources/uid/grafana-prometheus": {
+                "uid": "grafana-prometheus",
+                "type": "prometheus",
+                "url": "http://prometheus",
+            },
+            "http://grafana/api/ds/query": {"results": {"A": {"frames": []}}},
+        }
+    )
+
+    panel_queries = extract_grafana_panel_queries(dashboard)
+    result = query_grafana_dashboard_panels(
+        grafana_url="http://grafana",
+        dashboard=dashboard,
+        backend_results={"prometheus": True},
+        context=_context(),
+        client=cast(httpx.Client, client),
+    )
+
+    assert panel_queries == (
+        {
+            "panel_title": "Customer 360 materializations",
+            "datasource_uid": "grafana-prometheus",
+            "query": 'floe_asset_materializations_total{floe_product_name="customer-360"}',
+            "backend": "prometheus",
+        },
+    )
+    assert result.status is EvidenceStatus.DASHBOARD_DATASOURCE_DRIFT
+    assert result.diagnostics["datasource_uid"] == "grafana-prometheus"

--- a/testing/ci/tests/test_customer360_backend_helpers.py
+++ b/testing/ci/tests/test_customer360_backend_helpers.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 import httpx
+import pytest
 
 from testing.ci.customer360_observability import (
     EvidenceStatus,
@@ -58,7 +59,15 @@ class _FakeClient:
             return response
         if response is not None:
             return _FakeResponse(response)
-        raise AssertionError(f"No fake response configured for {url}")
+        raise httpx.HTTPStatusError(
+            "not found",
+            request=httpx.Request("GET", url),
+            response=httpx.Response(404),
+        )
+
+    def close(self) -> None:
+        """Mirror httpx.Client.close for tests that exercise owned clients."""
+        return None
 
 
 def _context() -> ObservabilityContext:
@@ -71,6 +80,7 @@ def _context() -> ObservabilityContext:
     )
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_evidence_status_covers_all_alpha_failure_classes() -> None:
     """Backend helpers can represent every alpha evidence class explicitly."""
     assert {status.value for status in EvidenceStatus} >= {
@@ -86,6 +96,7 @@ def test_evidence_status_covers_all_alpha_failure_classes() -> None:
     }
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_marquez_helper_uses_api_endpoints_and_graph_node_helpers() -> None:
     """Marquez proof comes from namespace/job/run/dataset/lineage APIs, not root UI."""
     client = _FakeClient(
@@ -139,6 +150,7 @@ def test_marquez_helper_uses_api_endpoints_and_graph_node_helpers() -> None:
     assert node_id == "dataset:customer-360:mart_customer_360"
     assert build_marquez_graph_query_url("http://marquez") == "http://marquez/api/v1/lineage"
     assert result.status is EvidenceStatus.PASS
+    assert result.diagnostics["graph_count"] == "1"
     requested_urls = {url for url, _params in client.requests}
     assert "http://marquez/" not in requested_urls
     assert "http://marquez/api/v1/namespaces/customer-360/datasets" in requested_urls
@@ -148,6 +160,7 @@ def test_marquez_helper_uses_api_endpoints_and_graph_node_helpers() -> None:
     ) in client.requests
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_loki_helper_checks_ready_and_query_range_without_root_ui() -> None:
     """Loki root 404 is irrelevant when /ready and query_range pass."""
     client = _FakeClient(
@@ -183,10 +196,44 @@ def test_loki_helper_checks_ready_and_query_range_without_root_ui() -> None:
     )
 
     assert result.status is EvidenceStatus.PASS
-    assert ("http://loki/ready", None) in client.requests
+    assert client.requests[0] == ("http://loki/ready", None)
     assert all(url != "http://loki/" for url, _params in client.requests)
 
 
+@pytest.mark.requirement("alpha-demo")
+def test_loki_helper_fails_fast_when_ready_endpoint_is_unavailable() -> None:
+    """Loki readiness failure is reported before running the range query."""
+    ready_url = "http://loki/ready"
+    client = _FakeClient(
+        {
+            ready_url: _FakeResponse(
+                "not ready\n",
+                status_code=503,
+                error=httpx.HTTPStatusError(
+                    "service unavailable",
+                    request=httpx.Request("GET", ready_url),
+                    response=httpx.Response(503),
+                ),
+            ),
+            "http://loki/loki/api/v1/query_range": {
+                "data": {"result": []},
+            },
+        }
+    )
+
+    result = query_loki_logs(
+        loki_url="http://loki",
+        product="customer-360",
+        run_id="run-123",
+        context=_context(),
+        client=cast(httpx.Client, client),
+    )
+
+    assert result.status is EvidenceStatus.BACKEND_UNREACHABLE
+    assert client.requests == [(ready_url, None)]
+
+
+@pytest.mark.requirement("alpha-demo")
 def test_prometheus_helpers_support_instant_and_range_queries() -> None:
     """Prometheus proof can be checked through instant or range query APIs."""
     instant_client = _FakeClient(
@@ -251,6 +298,37 @@ def test_prometheus_helpers_support_instant_and_range_queries() -> None:
     assert ranged.url == "http://prom/api/v1/query_range"
 
 
+@pytest.mark.requirement("alpha-demo")
+def test_prometheus_instant_helper_reports_backend_unreachable() -> None:
+    """Instant Prometheus query failures use the shared backend failure class."""
+    query_url = "http://prom/api/v1/query"
+    client = _FakeClient(
+        {
+            query_url: _FakeResponse(
+                {},
+                status_code=503,
+                error=httpx.HTTPStatusError(
+                    "service unavailable",
+                    request=httpx.Request("GET", query_url),
+                    response=httpx.Response(503),
+                ),
+            )
+        }
+    )
+
+    result = query_prometheus_instant_metrics(
+        prometheus_url="http://prom",
+        product="customer-360",
+        status="success",
+        plugin="dagster",
+        context=_context(),
+        client=cast(httpx.Client, client),
+    )
+
+    assert result.status is EvidenceStatus.BACKEND_UNREACHABLE
+
+
+@pytest.mark.requirement("alpha-demo")
 def test_grafana_panel_queries_classify_datasource_drift() -> None:
     """Empty panel results through Grafana are datasource drift when backend queries pass."""
     dashboard = {
@@ -302,3 +380,17 @@ def test_grafana_panel_queries_classify_datasource_drift() -> None:
     )
     assert result.status is EvidenceStatus.DASHBOARD_DATASOURCE_DRIFT
     assert result.diagnostics["datasource_uid"] == "grafana-prometheus"
+
+
+@pytest.mark.requirement("alpha-demo")
+def test_grafana_panel_queries_report_contract_gap_when_no_queries_exist() -> None:
+    """Dashboards with no extractable panel queries are contract gaps."""
+    result = query_grafana_dashboard_panels(
+        grafana_url="http://grafana",
+        dashboard={"dashboard": {"panels": []}},
+        backend_results={"prometheus": True},
+        context=_context(),
+        client=cast(httpx.Client, _FakeClient({})),
+    )
+
+    assert result.status is EvidenceStatus.CONTRACT_GAP

--- a/testing/demo/customer360_validator.py
+++ b/testing/demo/customer360_validator.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -20,12 +21,31 @@ DEFAULT_VALIDATION_MANIFEST = Path("demo/customer-360/validation.yaml")
 EXPECTED_EVIDENCE_KEYS = (
     "platform.ready",
     "dagster.customer_360_run",
+    "run_control.namespace",
+    "run_control.runtime_context",
+    "run_control.dagster.status",
+    "run_control.dagster.job_name",
+    "run_control.dagster.api_reachable",
     "storage.customer_360_outputs",
+    "storage.iceberg.customer_360_outputs",
     "lineage.marquez_customer_360",
     "tracing.jaeger_customer_360",
     "business.customer_count",
     "business.total_lifetime_value",
 )
+
+
+class FailureClass(str, Enum):
+    """Alpha operability failure classes emitted by the validator."""
+
+    PRODUCT_FAILURE = "product_failure"
+    PLATFORM_SERVICE_FAILURE = "platform_service_failure"
+    BACKEND_UNREACHABLE = "backend_unreachable"
+    NO_FRESH_EVIDENCE = "no_fresh_evidence"
+    WRONG_CONTEXT = "wrong_context"
+    STALE_EVIDENCE = "stale_evidence"
+    DASHBOARD_DATASOURCE_DRIFT = "dashboard_datasource_drift"
+    CONTRACT_GAP = "contract_gap"
 
 
 def default_command_runner(
@@ -178,6 +198,11 @@ class Customer360Validator:
     def validate(self) -> ValidationResult:
         """Validate service health and Customer 360 evidence."""
         evidence = dict.fromkeys(EXPECTED_EVIDENCE_KEYS, "unknown")
+        evidence["run_control.namespace"] = self._config.namespace
+        evidence["run_control.runtime_context"] = _runtime_context_for_namespace(
+            self._config.namespace
+        )
+        evidence["run_control.dagster.job_name"] = self._config.dagster_expected_text
         failures: list[str] = []
 
         self._check_platform(evidence, failures)
@@ -218,7 +243,12 @@ class Customer360Validator:
         )
         if not expected_services:
             evidence["platform.ready"] = "false"
-            failures.append("Platform expected services must contain at least one service fragment")
+            failures.append(
+                _classified_failure(
+                    FailureClass.PLATFORM_SERVICE_FAILURE,
+                    "Platform expected services must contain at least one service fragment",
+                )
+            )
             return
 
         command = ["kubectl", "get", "pods", "-n", self._config.namespace, "-o", "json"]
@@ -226,7 +256,12 @@ class Customer360Validator:
             pods = json.loads(self._run(command))
         except Exception as exc:  # noqa: BLE001 - validation should report all failures.
             evidence["platform.ready"] = "false"
-            failures.append(f"Unable to inspect Kubernetes pods: {exc}")
+            failures.append(
+                _classified_failure(
+                    FailureClass.BACKEND_UNREACHABLE,
+                    f"Unable to inspect Kubernetes pods: {exc}",
+                )
+            )
             return
 
         ready_pods = [
@@ -248,27 +283,46 @@ class Customer360Validator:
         evidence["platform.ready"] = str(ready).lower()
         if missing_services:
             failures.append(
-                f"Expected platform services are not ready in namespace {self._config.namespace}: "
-                f"{', '.join(missing_services)}"
+                _classified_failure(
+                    FailureClass.PLATFORM_SERVICE_FAILURE,
+                    (
+                        "Expected platform services are not ready in namespace "
+                        f"{self._config.namespace}: {', '.join(missing_services)}"
+                    ),
+                )
             )
 
     def _check_dagster(self, evidence: dict[str, str], failures: list[str]) -> None:
         url = _join_url(self._config.dagster_url, "server_info")
         try:
             self._run(["curl", "-fsS", url])
+            evidence["run_control.dagster.api_reachable"] = "true"
         except Exception as exc:  # noqa: BLE001
-            failures.append(f"Dagster API is not reachable: {exc}")
+            evidence["run_control.dagster.api_reachable"] = "false"
+            failures.append(
+                _classified_failure(
+                    FailureClass.BACKEND_UNREACHABLE,
+                    f"Dagster API is not reachable: {exc}",
+                )
+            )
 
         self._check_expected_text_command(
             evidence=evidence,
             failures=failures,
             key="dagster.customer_360_run",
+            alias_key="run_control.dagster.status",
+            alias_pass_value="pass",
+            alias_fail_value="fail",
             command=self._config.dagster_run_check_command,
             expected_text=self._config.dagster_expected_text,
             missing_message="Customer 360 Dagster run check is not configured",
             failed_message="Customer 360 Dagster run check failed",
             not_found_message="Customer 360 Dagster run evidence was not found",
             invalid_expected_message="Customer 360 Dagster expected text must be non-empty",
+            missing_failure_class=FailureClass.CONTRACT_GAP,
+            failed_failure_class=FailureClass.PRODUCT_FAILURE,
+            not_found_failure_class=FailureClass.NO_FRESH_EVIDENCE,
+            invalid_failure_class=FailureClass.CONTRACT_GAP,
         )
 
     def _check_marquez(self, evidence: dict[str, str], failures: list[str]) -> None:
@@ -276,7 +330,12 @@ class Customer360Validator:
         try:
             json.loads(self._run(["curl", "-fsS", url]))
         except Exception as exc:  # noqa: BLE001
-            failures.append(f"Unable to inspect Marquez namespaces: {exc}")
+            failures.append(
+                _classified_failure(
+                    FailureClass.BACKEND_UNREACHABLE,
+                    f"Unable to inspect Marquez namespaces: {exc}",
+                )
+            )
 
         self._check_expected_text_command(
             evidence=evidence,
@@ -288,6 +347,10 @@ class Customer360Validator:
             failed_message="Customer 360 lineage check failed",
             not_found_message="Customer 360 lineage evidence was not found",
             invalid_expected_message="Customer 360 lineage expected text must be non-empty",
+            missing_failure_class=FailureClass.CONTRACT_GAP,
+            failed_failure_class=FailureClass.PRODUCT_FAILURE,
+            not_found_failure_class=FailureClass.NO_FRESH_EVIDENCE,
+            invalid_failure_class=FailureClass.CONTRACT_GAP,
         )
 
     def _check_jaeger(self, evidence: dict[str, str], failures: list[str]) -> None:
@@ -295,7 +358,12 @@ class Customer360Validator:
         try:
             json.loads(self._run(["curl", "-fsS", url]))
         except Exception as exc:  # noqa: BLE001
-            failures.append(f"Unable to inspect Jaeger services: {exc}")
+            failures.append(
+                _classified_failure(
+                    FailureClass.BACKEND_UNREACHABLE,
+                    f"Unable to inspect Jaeger services: {exc}",
+                )
+            )
 
         self._check_expected_text_command(
             evidence=evidence,
@@ -307,31 +375,59 @@ class Customer360Validator:
             failed_message="Customer 360 tracing check failed",
             not_found_message="Customer 360 tracing evidence was not found",
             invalid_expected_message="Customer 360 tracing expected text must be non-empty",
+            missing_failure_class=FailureClass.CONTRACT_GAP,
+            failed_failure_class=FailureClass.PRODUCT_FAILURE,
+            not_found_failure_class=FailureClass.NO_FRESH_EVIDENCE,
+            invalid_failure_class=FailureClass.CONTRACT_GAP,
         )
 
     def _check_storage(self, evidence: dict[str, str], failures: list[str]) -> None:
         command = self._config.storage_check_command
         if command is None:
             evidence["storage.customer_360_outputs"] = "unknown"
-            failures.append("Customer 360 storage outputs check is not configured")
+            evidence["storage.iceberg.customer_360_outputs"] = "unknown"
+            failures.append(
+                _classified_failure(
+                    FailureClass.CONTRACT_GAP,
+                    "Customer 360 storage outputs check is not configured",
+                )
+            )
             return
         expected_text = self._config.storage_expected_text.strip()
         if not expected_text:
             evidence["storage.customer_360_outputs"] = "false"
-            failures.append("Customer 360 storage expected text must be non-empty")
+            evidence["storage.iceberg.customer_360_outputs"] = "false"
+            failures.append(
+                _classified_failure(
+                    FailureClass.CONTRACT_GAP,
+                    "Customer 360 storage expected text must be non-empty",
+                )
+            )
             return
 
         try:
             output = self._run(command)
         except Exception as exc:  # noqa: BLE001
             evidence["storage.customer_360_outputs"] = "false"
-            failures.append(f"Customer 360 storage outputs check failed: {exc}")
+            evidence["storage.iceberg.customer_360_outputs"] = "false"
+            failures.append(
+                _classified_failure(
+                    FailureClass.PRODUCT_FAILURE,
+                    f"Customer 360 storage outputs check failed: {exc}",
+                )
+            )
             return
 
         found = expected_text in output
         evidence["storage.customer_360_outputs"] = str(found).lower()
+        evidence["storage.iceberg.customer_360_outputs"] = str(found).lower()
         if not found:
-            failures.append("Customer 360 storage outputs were not found")
+            failures.append(
+                _classified_failure(
+                    FailureClass.PRODUCT_FAILURE,
+                    "Customer 360 storage outputs were not found",
+                )
+            )
 
     def _check_business_metric(
         self,
@@ -346,7 +442,7 @@ class Customer360Validator:
     ) -> None:
         if command is None:
             evidence[key] = "unknown"
-            failures.append(missing_message)
+            failures.append(_classified_failure(FailureClass.CONTRACT_GAP, missing_message))
             return
         metric_label = empty_message.removesuffix(" returned no value")
 
@@ -354,46 +450,86 @@ class Customer360Validator:
             output = self._run(command).strip()
         except Exception as exc:  # noqa: BLE001
             evidence[key] = "false"
-            failures.append(f"{metric_label} command failed: {exc}")
+            failures.append(
+                _classified_failure(
+                    FailureClass.PRODUCT_FAILURE,
+                    f"{metric_label} command failed: {exc}",
+                )
+            )
             return
 
         if not output:
             evidence[key] = "false"
-            failures.append(empty_message)
+            failures.append(_classified_failure(FailureClass.PRODUCT_FAILURE, empty_message))
             return
         if integer:
             try:
                 value = Decimal(output)
             except InvalidOperation:
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned non-numeric value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned non-numeric value",
+                    )
+                )
                 return
             if not value.is_finite():
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned non-numeric value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned non-numeric value",
+                    )
+                )
                 return
             if value < 0:
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned negative value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned negative value",
+                    )
+                )
                 return
             if value != value.to_integral_value():
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned non-integer value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned non-integer value",
+                    )
+                )
                 return
         else:
             try:
                 value = Decimal(output)
             except InvalidOperation:
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned non-numeric value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned non-numeric value",
+                    )
+                )
                 return
             if not value.is_finite():
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned non-numeric value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned non-numeric value",
+                    )
+                )
                 return
             if value < 0:
                 evidence[key] = "false"
-                failures.append(f"{metric_label} returned negative value")
+                failures.append(
+                    _classified_failure(
+                        FailureClass.PRODUCT_FAILURE,
+                        f"{metric_label} returned negative value",
+                    )
+                )
                 return
 
         evidence[key] = output
@@ -410,28 +546,53 @@ class Customer360Validator:
         failed_message: str,
         not_found_message: str,
         invalid_expected_message: str,
+        missing_failure_class: FailureClass,
+        failed_failure_class: FailureClass,
+        not_found_failure_class: FailureClass,
+        invalid_failure_class: FailureClass,
+        alias_key: str | None = None,
+        alias_pass_value: str = "true",
+        alias_fail_value: str = "false",
     ) -> None:
         if command is None:
             evidence[key] = "unknown"
-            failures.append(missing_message)
+            if alias_key:
+                evidence[alias_key] = "unknown"
+            failures.append(_classified_failure(missing_failure_class, missing_message))
             return
         expected_text = expected_text.strip()
         if not expected_text:
             evidence[key] = "false"
-            failures.append(invalid_expected_message)
+            if alias_key:
+                evidence[alias_key] = alias_fail_value
+            failures.append(_classified_failure(invalid_failure_class, invalid_expected_message))
             return
 
         try:
             output = self._run(command)
         except Exception as exc:  # noqa: BLE001
             evidence[key] = "false"
-            failures.append(f"{failed_message}: {exc}")
+            if alias_key:
+                evidence[alias_key] = alias_fail_value
+            failures.append(_classified_failure(failed_failure_class, f"{failed_message}: {exc}"))
             return
 
         found = expected_text in output
         evidence[key] = str(found).lower()
+        if alias_key:
+            evidence[alias_key] = alias_pass_value if found else alias_fail_value
         if not found:
-            failures.append(not_found_message)
+            failures.append(_classified_failure(not_found_failure_class, not_found_message))
+
+
+def _classified_failure(failure_class: FailureClass, message: str) -> str:
+    """Format a validation failure with the alpha class prefix."""
+    return f"{failure_class.value}: {message}"
+
+
+def _runtime_context_for_namespace(namespace: str) -> str:
+    """Return the alpha runtime context represented by a demo namespace."""
+    return "devpod_flux" if namespace == "floe-test" else "local"
 
 
 def _join_url(base_url: str, path: str) -> str:

--- a/testing/demo/customer360_validator.py
+++ b/testing/demo/customer360_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -17,6 +18,7 @@ CommandRunner = Callable[[list[str]], str]
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
 DEFAULT_PLATFORM_SERVICE_FRAGMENTS = ("dagster", "polaris", "minio", "jaeger", "marquez")
 DEFAULT_VALIDATION_MANIFEST = Path("demo/customer-360/validation.yaml")
+KUBERNETES_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
 
 EXPECTED_EVIDENCE_KEYS = (
     "platform.ready",
@@ -251,9 +253,23 @@ class Customer360Validator:
             )
             return
 
-        command = ["kubectl", "get", "pods", "-n", self._config.namespace, "-o", "json"]
+        namespace = _validate_kubernetes_namespace(self._config.namespace)
+        if namespace is None:
+            evidence["platform.ready"] = "false"
+            failures.append(
+                _classified_failure(
+                    FailureClass.PLATFORM_SERVICE_FAILURE,
+                    f"Invalid Kubernetes namespace: {self._config.namespace}",
+                )
+            )
+            return
+
+        command = ["kubectl", "get", "pods", "-n", namespace, "-o", "json"]
         try:
-            pods = json.loads(self._run(command))
+            pods = _json_mapping_from_command_output(
+                self._run(command),
+                context="kubectl pods response",
+            )
         except Exception as exc:  # noqa: BLE001 - validation should report all failures.
             evidence["platform.ready"] = "false"
             failures.append(
@@ -295,7 +311,7 @@ class Customer360Validator:
     def _check_dagster(self, evidence: dict[str, str], failures: list[str]) -> None:
         url = _join_url(self._config.dagster_url, "server_info")
         try:
-            self._run(["curl", "-fsS", url])
+            self._run(_curl_command(url))
             evidence["run_control.dagster.api_reachable"] = "true"
         except Exception as exc:  # noqa: BLE001
             evidence["run_control.dagster.api_reachable"] = "false"
@@ -328,7 +344,10 @@ class Customer360Validator:
     def _check_marquez(self, evidence: dict[str, str], failures: list[str]) -> None:
         url = _join_url(self._config.marquez_url, "api/v1/namespaces")
         try:
-            json.loads(self._run(["curl", "-fsS", url]))
+            _json_mapping_from_command_output(
+                self._run(_curl_command(url)),
+                context="Marquez namespaces response",
+            )
         except Exception as exc:  # noqa: BLE001
             failures.append(
                 _classified_failure(
@@ -356,7 +375,10 @@ class Customer360Validator:
     def _check_jaeger(self, evidence: dict[str, str], failures: list[str]) -> None:
         url = _join_url(self._config.jaeger_url, "api/services")
         try:
-            json.loads(self._run(["curl", "-fsS", url]))
+            _json_mapping_from_command_output(
+                self._run(_curl_command(url)),
+                context="Jaeger services response",
+            )
         except Exception as exc:  # noqa: BLE001
             failures.append(
                 _classified_failure(
@@ -592,7 +614,33 @@ def _classified_failure(failure_class: FailureClass, message: str) -> str:
 
 def _runtime_context_for_namespace(namespace: str) -> str:
     """Return the alpha runtime context represented by a demo namespace."""
+    # Alpha has two supported runtime contexts today. Treat any namespace
+    # outside the DevPod/Flux test namespace as the local validator context.
     return "devpod_flux" if namespace == "floe-test" else "local"
+
+
+def _validate_kubernetes_namespace(namespace: str) -> str | None:
+    """Return the namespace when it is a valid Kubernetes namespace."""
+    namespace = namespace.strip()
+    if KUBERNETES_NAMESPACE_PATTERN.fullmatch(namespace) is None:
+        return None
+    return namespace
+
+
+def _json_mapping_from_command_output(output: str, *, context: str) -> dict[str, Any]:
+    """Parse command JSON output and require a JSON object payload."""
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {context}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid {context}: expected JSON object")
+    return payload
+
+
+def _curl_command(url: str) -> list[str]:
+    """Return a curl argv list that stops option parsing before the URL."""
+    return ["curl", "-fsS", "--", url]
 
 
 def _join_url(base_url: str, path: str) -> str:

--- a/testing/demo/tests/test_customer360_validator_contract.py
+++ b/testing/demo/tests/test_customer360_validator_contract.py
@@ -1,0 +1,141 @@
+"""Contract tests for Customer 360 alpha validator evidence output."""
+
+from __future__ import annotations
+
+import json
+
+from testing.demo.customer360_validator import (
+    Customer360Config,
+    Customer360Validator,
+)
+
+
+def test_customer360_validator_emits_normalized_evidence_and_compatibility_keys() -> None:
+    """Successful validation emits alpha key families without dropping old keys."""
+    config = Customer360Config(
+        namespace="floe-test",
+        dagster_run_check_command=["dagster-run"],
+        lineage_check_command=["lineage"],
+        tracing_check_command=["tracing"],
+        storage_check_command=["storage"],
+        customer_count_command=["customer-count"],
+        lifetime_value_command=["lifetime-value"],
+    )
+
+    def run(command: list[str]) -> str:
+        if command[:3] == ["kubectl", "get", "pods"]:
+            return json.dumps(
+                {
+                    "items": [
+                        _ready_pod("dagster-webserver"),
+                        _ready_pod("polaris"),
+                        _ready_pod("minio"),
+                        _ready_pod("jaeger"),
+                        _ready_pod("marquez"),
+                    ]
+                }
+            )
+        return {
+            ("curl", "-fsS", "http://localhost:3100/server_info"): "{}",
+            ("curl", "-fsS", "http://localhost:5100/api/v1/namespaces"): "{}",
+            ("curl", "-fsS", "http://localhost:16686/api/services"): "{}",
+            ("dagster-run",): "customer_360",
+            ("lineage",): "customer_360",
+            ("tracing",): "customer_360",
+            ("storage",): "customer_360",
+            ("customer-count",): "500",
+            ("lifetime-value",): "1194501.08",
+        }[tuple(command)]
+
+    result = Customer360Validator(config=config, command_runner=run).validate()
+
+    assert result.status == "PASS"
+    assert result.failures == []
+    assert result.evidence["dagster.customer_360_run"] == "true"
+    assert result.evidence["storage.customer_360_outputs"] == "true"
+    assert result.evidence["run_control.namespace"] == "floe-test"
+    assert result.evidence["run_control.runtime_context"] == "devpod_flux"
+    assert result.evidence["run_control.dagster.status"] == "pass"
+    assert result.evidence["run_control.dagster.job_name"] == "customer_360"
+    assert result.evidence["storage.iceberg.customer_360_outputs"] == "true"
+    assert result.evidence["business.customer_count"] == "500"
+
+
+def test_customer360_validator_classifies_unhealthy_platform_services() -> None:
+    """Missing ready platform pods are platform service failures."""
+    config = Customer360Config(platform_expected_services=("dagster",))
+
+    def run(command: list[str]) -> str:
+        if command[:3] == ["kubectl", "get", "pods"]:
+            return json.dumps({"items": [_not_ready_pod("dagster-webserver")]})
+        return "{}"
+
+    result = Customer360Validator(config=config, command_runner=run).validate()
+
+    assert result.status == "FAIL"
+    assert result.evidence["platform.ready"] == "false"
+    assert result.evidence["run_control.namespace"] == "floe-dev"
+    assert result.evidence["run_control.runtime_context"] == "local"
+    assert any(
+        failure.startswith("platform_service_failure: Expected platform services")
+        for failure in result.failures
+    )
+
+
+def test_customer360_validator_classifies_missing_checks_as_contract_gaps() -> None:
+    """Missing validation commands are contract gaps, not product failures."""
+    config = Customer360Config(platform_expected_services=("dagster",))
+
+    def run(command: list[str]) -> str:
+        if command[:3] == ["kubectl", "get", "pods"]:
+            return json.dumps({"items": [_ready_pod("dagster-webserver")]})
+        return "{}"
+
+    result = Customer360Validator(config=config, command_runner=run).validate()
+
+    assert result.status == "FAIL"
+    assert any(
+        failure == "contract_gap: Customer 360 storage outputs check is not configured"
+        for failure in result.failures
+    )
+    assert any(
+        failure == "contract_gap: Customer 360 customer count check is not configured"
+        for failure in result.failures
+    )
+
+
+def test_customer360_validator_classifies_business_assertion_failures() -> None:
+    """Invalid generated mart assertions are product failures."""
+    config = Customer360Config(
+        platform_expected_services=("dagster",),
+        customer_count_command=["customer-count"],
+    )
+
+    def run(command: list[str]) -> str:
+        if command[:3] == ["kubectl", "get", "pods"]:
+            return json.dumps({"items": [_ready_pod("dagster-webserver")]})
+        if command == ["customer-count"]:
+            return "-1"
+        return "{}"
+
+    result = Customer360Validator(config=config, command_runner=run).validate()
+
+    assert result.status == "FAIL"
+    assert any(
+        failure == "product_failure: Customer 360 customer count check returned negative value"
+        for failure in result.failures
+    )
+
+
+def _ready_pod(name: str) -> dict[str, object]:
+    return {
+        "metadata": {"name": name},
+        "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}]},
+    }
+
+
+def _not_ready_pod(name: str) -> dict[str, object]:
+    return {
+        "metadata": {"name": name},
+        "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "False"}]},
+    }

--- a/testing/demo/tests/test_customer360_validator_contract.py
+++ b/testing/demo/tests/test_customer360_validator_contract.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+from testing.ci.customer360_observability import EvidenceStatus
 from testing.demo.customer360_validator import (
     Customer360Config,
     Customer360Validator,
+    FailureClass,
 )
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_customer360_validator_emits_normalized_evidence_and_compatibility_keys() -> None:
     """Successful validation emits alpha key families without dropping old keys."""
     config = Customer360Config(
@@ -36,9 +41,9 @@ def test_customer360_validator_emits_normalized_evidence_and_compatibility_keys(
                 }
             )
         return {
-            ("curl", "-fsS", "http://localhost:3100/server_info"): "{}",
-            ("curl", "-fsS", "http://localhost:5100/api/v1/namespaces"): "{}",
-            ("curl", "-fsS", "http://localhost:16686/api/services"): "{}",
+            ("curl", "-fsS", "--", "http://localhost:3100/server_info"): "{}",
+            ("curl", "-fsS", "--", "http://localhost:5100/api/v1/namespaces"): "{}",
+            ("curl", "-fsS", "--", "http://localhost:16686/api/services"): "{}",
             ("dagster-run",): "customer_360",
             ("lineage",): "customer_360",
             ("tracing",): "customer_360",
@@ -61,6 +66,33 @@ def test_customer360_validator_emits_normalized_evidence_and_compatibility_keys(
     assert result.evidence["business.customer_count"] == "500"
 
 
+@pytest.mark.requirement("alpha-demo")
+def test_customer360_validator_rejects_invalid_kubernetes_namespace() -> None:
+    """Namespace values must be Kubernetes-safe before invoking kubectl."""
+    commands: list[list[str]] = []
+
+    def run(command: list[str]) -> str:
+        commands.append(command)
+        return "{}"
+
+    result = Customer360Validator(
+        config=Customer360Config(namespace="bad;namespace"),
+        command_runner=run,
+    ).validate()
+
+    assert result.status == "FAIL"
+    assert commands == [
+        ["curl", "-fsS", "--", "http://localhost:3100/server_info"],
+        ["curl", "-fsS", "--", "http://localhost:5100/api/v1/namespaces"],
+        ["curl", "-fsS", "--", "http://localhost:16686/api/services"],
+    ]
+    assert any(
+        failure.startswith("platform_service_failure: Invalid Kubernetes namespace")
+        for failure in result.failures
+    )
+
+
+@pytest.mark.requirement("alpha-demo")
 def test_customer360_validator_classifies_unhealthy_platform_services() -> None:
     """Missing ready platform pods are platform service failures."""
     config = Customer360Config(platform_expected_services=("dagster",))
@@ -82,6 +114,7 @@ def test_customer360_validator_classifies_unhealthy_platform_services() -> None:
     )
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_customer360_validator_classifies_missing_checks_as_contract_gaps() -> None:
     """Missing validation commands are contract gaps, not product failures."""
     config = Customer360Config(platform_expected_services=("dagster",))
@@ -104,6 +137,7 @@ def test_customer360_validator_classifies_missing_checks_as_contract_gaps() -> N
     )
 
 
+@pytest.mark.requirement("alpha-demo")
 def test_customer360_validator_classifies_business_assertion_failures() -> None:
     """Invalid generated mart assertions are product failures."""
     config = Customer360Config(
@@ -125,6 +159,14 @@ def test_customer360_validator_classifies_business_assertion_failures() -> None:
         failure == "product_failure: Customer 360 customer count check returned negative value"
         for failure in result.failures
     )
+
+
+@pytest.mark.requirement("alpha-demo")
+def test_customer360_failure_class_vocabulary_matches_observability_statuses() -> None:
+    """Demo and backend validators share the same alpha failure vocabulary."""
+    assert {status.value for status in FailureClass} == {
+        status.value for status in EvidenceStatus if status is not EvidenceStatus.PASS
+    }
 
 
 def _ready_pod(name: str) -> dict[str, object]:

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -91,10 +91,10 @@ def test_customer360_validator_reports_checked_service_evidence() -> None:
     assert result.evidence["storage.customer_360_outputs"] == "unknown"
     assert result.evidence["business.customer_count"] == "unknown"
     assert result.evidence["business.total_lifetime_value"] == "unknown"
-    assert "Customer 360 Dagster run check is not configured" in result.failures
-    assert "Customer 360 lineage check is not configured" in result.failures
-    assert "Customer 360 tracing check is not configured" in result.failures
-    assert "Customer 360 storage outputs check is not configured" in result.failures
+    assert "contract_gap: Customer 360 Dagster run check is not configured" in result.failures
+    assert "contract_gap: Customer 360 lineage check is not configured" in result.failures
+    assert "contract_gap: Customer 360 tracing check is not configured" in result.failures
+    assert "contract_gap: Customer 360 storage outputs check is not configured" in result.failures
 
 
 @pytest.mark.requirement("alpha-demo")
@@ -111,7 +111,7 @@ def test_customer360_validator_fails_when_expected_text_is_empty() -> None:
 
     assert result.status == "FAIL"
     assert result.evidence["lineage.marquez_customer_360"] == "false"
-    assert "Customer 360 lineage expected text must be non-empty" in result.failures
+    assert "contract_gap: Customer 360 lineage expected text must be non-empty" in result.failures
 
 
 @pytest.mark.requirement("alpha-demo")
@@ -132,7 +132,7 @@ def test_customer360_validator_fails_when_lineage_output_lacks_customer360_text(
 
     assert result.status == "FAIL"
     assert result.evidence["lineage.marquez_customer_360"] == "false"
-    assert "Customer 360 lineage evidence was not found" in result.failures
+    assert "no_fresh_evidence: Customer 360 lineage evidence was not found" in result.failures
 
 
 @pytest.mark.requirement("alpha-demo")
@@ -195,7 +195,7 @@ def test_customer360_validator_requires_expected_platform_services() -> None:
 
     assert result.evidence["platform.ready"] == "false"
     assert (
-        "Expected platform services are not ready in namespace floe-dev: "
+        "platform_service_failure: Expected platform services are not ready in namespace floe-dev: "
         "dagster, polaris, minio, jaeger, marquez"
     ) in result.failures
 
@@ -210,7 +210,8 @@ def test_customer360_validator_rejects_empty_expected_platform_services() -> Non
 
     assert result.evidence["platform.ready"] == "false"
     assert (
-        "Platform expected services must contain at least one service fragment" in result.failures
+        "platform_service_failure: Platform expected services must contain at least one "
+        "service fragment" in result.failures
     )
 
 
@@ -237,7 +238,8 @@ def test_customer360_validator_requires_ready_condition_for_running_pods() -> No
 
     assert result.evidence["platform.ready"] == "false"
     assert (
-        "Expected platform services are not ready in namespace floe-dev: dagster" in result.failures
+        "platform_service_failure: Expected platform services are not ready in namespace "
+        "floe-dev: dagster" in result.failures
     )
 
 
@@ -320,7 +322,7 @@ def test_customer360_validator_rejects_invalid_business_metrics(
     result = Customer360Validator(config=config, command_runner=runner).validate()
 
     assert result.status == "FAIL"
-    assert expected_failure in result.failures
+    assert f"product_failure: {expected_failure}" in result.failures
 
 
 @pytest.mark.requirement("alpha-demo")
@@ -348,7 +350,9 @@ def test_customer360_validator_reports_business_metric_command_failure() -> None
 
     result = Customer360Validator(config=config, command_runner=runner).validate()
 
-    assert "Customer 360 customer count check command failed: boom" in result.failures
+    assert (
+        "product_failure: Customer 360 customer count check command failed: boom" in result.failures
+    )
 
 
 @pytest.mark.requirement("alpha-demo")

--- a/testing/tests/unit/test_customer360_validator.py
+++ b/testing/tests/unit/test_customer360_validator.py
@@ -55,11 +55,11 @@ def _healthy_runner() -> FakeRunner:
                     ]
                 }
             ),
-            ("curl", "-fsS", "http://localhost:3100/server_info"): "{}",
-            ("curl", "-fsS", "http://localhost:5100/api/v1/namespaces"): json.dumps(
+            ("curl", "-fsS", "--", "http://localhost:3100/server_info"): "{}",
+            ("curl", "-fsS", "--", "http://localhost:5100/api/v1/namespaces"): json.dumps(
                 {"namespaces": [{"name": "customer_360"}]}
             ),
-            ("curl", "-fsS", "http://localhost:16686/api/services"): json.dumps(
+            ("curl", "-fsS", "--", "http://localhost:16686/api/services"): json.dumps(
                 {"data": ["dagster"]}
             ),
         }
@@ -157,11 +157,13 @@ def test_customer360_validator_uses_configurable_namespace_and_urls() -> None:
                     ]
                 }
             ),
-            ("curl", "-fsS", "http://dagster.example/server_info"): "{}",
-            ("curl", "-fsS", "http://marquez.example/api/v1/namespaces"): json.dumps(
+            ("curl", "-fsS", "--", "http://dagster.example/server_info"): "{}",
+            ("curl", "-fsS", "--", "http://marquez.example/api/v1/namespaces"): json.dumps(
                 {"namespaces": [{"name": "customer-360"}]}
             ),
-            ("curl", "-fsS", "http://jaeger.example/api/services"): json.dumps({"data": ["floe"]}),
+            ("curl", "-fsS", "--", "http://jaeger.example/api/services"): json.dumps(
+                {"data": ["floe"]}
+            ),
         }
     )
 
@@ -169,9 +171,9 @@ def test_customer360_validator_uses_configurable_namespace_and_urls() -> None:
 
     assert runner.commands == [
         ("kubectl", "get", "pods", "-n", "custom-ns", "-o", "json"),
-        ("curl", "-fsS", "http://dagster.example/server_info"),
-        ("curl", "-fsS", "http://marquez.example/api/v1/namespaces"),
-        ("curl", "-fsS", "http://jaeger.example/api/services"),
+        ("curl", "-fsS", "--", "http://dagster.example/server_info"),
+        ("curl", "-fsS", "--", "http://marquez.example/api/v1/namespaces"),
+        ("curl", "-fsS", "--", "http://jaeger.example/api/services"),
     ]
 
 
@@ -183,11 +185,11 @@ def test_customer360_validator_requires_expected_platform_services() -> None:
             ("kubectl", "get", "pods", "-n", "floe-dev", "-o", "json"): json.dumps(
                 {"items": [_ready_pod("unrelated-worker")]}
             ),
-            ("curl", "-fsS", "http://localhost:3100/server_info"): "{}",
-            ("curl", "-fsS", "http://localhost:5100/api/v1/namespaces"): json.dumps(
+            ("curl", "-fsS", "--", "http://localhost:3100/server_info"): "{}",
+            ("curl", "-fsS", "--", "http://localhost:5100/api/v1/namespaces"): json.dumps(
                 {"namespaces": []}
             ),
-            ("curl", "-fsS", "http://localhost:16686/api/services"): json.dumps({"data": []}),
+            ("curl", "-fsS", "--", "http://localhost:16686/api/services"): json.dumps({"data": []}),
         }
     )
 

--- a/tests/unit/test_observability_trigger_helper.py
+++ b/tests/unit/test_observability_trigger_helper.py
@@ -481,19 +481,22 @@ def test_customer360_loki_helper_queries_logs_by_product_and_run() -> None:
     """Loki helper queries structured logs without live services."""
     client = _FakeClient(
         {
-            "data": {
-                "result": [
-                    {
-                        "stream": {"service_name": "customer-360"},
-                        "values": [
-                            [
-                                "1699999950000000000",
-                                '{"product":"customer-360","run_id":"run-123"}',
-                            ]
-                        ],
-                    }
-                ]
-            }
+            "http://loki/ready": {},
+            "http://loki/loki/api/v1/query_range": {
+                "data": {
+                    "result": [
+                        {
+                            "stream": {"service_name": "customer-360"},
+                            "values": [
+                                [
+                                    "1699999950000000000",
+                                    '{"product":"customer-360","run_id":"run-123"}',
+                                ]
+                            ],
+                        }
+                    ]
+                }
+            },
         }
     )
     context = ObservabilityContext(
@@ -512,8 +515,9 @@ def test_customer360_loki_helper_queries_logs_by_product_and_run() -> None:
     )
 
     assert result.status is EvidenceStatus.PASS
-    assert client.requests[0][0] == "http://loki/loki/api/v1/query_range"
-    params = client.requests[0][1]
+    assert client.requests[0] == ("http://loki/ready", None)
+    assert client.requests[1][0] == "http://loki/loki/api/v1/query_range"
+    params = client.requests[1][1]
     assert isinstance(params, Mapping)
     assert params["query"] == '{service_name=~".+"} |= "customer-360" |= "run-123"'
 
@@ -698,6 +702,14 @@ def test_customer360_marquez_helper_queries_lineage_by_namespace_job_and_run() -
             None,
         ),
         ("http://marquez/api/v1/namespaces/customer-360/jobs", None),
+        ("http://marquez/api/v1/namespaces/customer-360/datasets", None),
+        (
+            "http://marquez/api/v1/lineage",
+            {
+                "nodeId": "dataset:customer-360:mart_customer_360",
+                "depth": "2",
+            },
+        ),
         (
             (
                 "http://marquez/api/v1/namespaces/customer-360/jobs/"


### PR DESCRIPTION
## Summary

Implements the Phase 2A alpha operability validator foundation for Customer 360.

- Adds normalized evidence output for `run_control.*`, `storage.*`, `business.*`, and `observability.*` while preserving alpha compatibility keys.
- Adds explicit failure classes for product failures, platform service failures, backend reachability, stale/missing/wrong-context evidence, dashboard datasource drift, and contract gaps.
- Validates API-only backend surfaces through API behavior: Loki `/ready` + `query_range`, Marquez namespace/job/run/dataset/lineage APIs, Prometheus instant/range queries, and Grafana datasource/panel query extraction.
- Adds regression coverage for the new backend helpers, demo validator evidence, runtime context, and updated legacy unit expectations.

## Validation

- `uv run python -m testing.ci.validate_customer_360_demo --help`
- `uv run pytest testing/ci/tests testing/demo/tests -q` -> 161 passed
- `pre-commit run --files testing/ci/validate_customer_360_demo.py testing/ci/customer360_observability.py testing/demo/customer360_validator.py`
- `uv run pytest testing/tests/unit/test_customer360_validator.py testing/demo/tests/test_customer360_validator_contract.py testing/ci/tests/test_customer360_backend_helpers.py -q` -> 43 passed
- `uv run pytest tests/contract/test_observability_manifests.py tests/contract/test_rbac_least_privilege.py tests/contract/test_helm_security_contexts.py tests/contract/test_test_infra_chart_integrity.py -q` -> 55 passed
- Pre-push hook passed: lint, format, mypy, dbt version requirements, Bandit, uv-secure, broad unit tests + coverage, contract tests, no-hardcoded-sleep, traceability, docs validation, helm lint.

## Live validation

Not run. Local forwarded endpoints were not available from this shell:

- `http://localhost:3100/server_info` refused
- `http://localhost:5100/api/v1/namespaces` refused
- `http://localhost:3101/ready` refused
- `http://localhost:9090/-/ready` refused

DevPod workspaces existed locally, but the required forwarded service endpoints were not active, so no live Customer 360 validator run was attempted.

## Notes

- `PROMPT.md` remains untracked and is not included in this PR.
