### PR TITLE
Pin GitHub Actions to Node 24-compatible refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload Bandit report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bandit-report
           path: bandit-report.json
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: matrix.python-version == env.PYTHON_VERSION_DEFAULT
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: coverage-report
           path: coverage-${{ matrix.python-version }}.xml

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,6 +17,9 @@ env:
   # See: https://codspeed.io/docs/instruments/cpu
   PYTHON_VERSION_DEFAULT: "3.12"
   UV_CACHE_DIR: /tmp/.uv-cache
+  # CodSpeed's composite action currently wraps actions/cache. Force nested
+  # JavaScript actions onto Node 24 until CodSpeed pins a Node 24 cache action.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   codspeed:
@@ -41,7 +44,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@0d7de549485db8284c0b87a0d2c0dd871097e641  # v4
+        uses: CodSpeedHQ/action@e736f0d2aeb36da38e9f08eca4dff7967408d154 # v4.8.2
         with:
           # CPU simulation for consistent comparisons with main branch
           # Python 3.12+ enables execution profiles (flamegraphs)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: e2e-results
           path: |

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -146,7 +146,7 @@ jobs:
           ls -la dist/
 
       - name: Upload chart artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: helm-charts
           path: dist/*.tgz
@@ -170,7 +170,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download chart artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: helm-charts
           path: charts-new
@@ -224,7 +224,7 @@ jobs:
       id-token: write
     steps:
       - name: Download chart artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: helm-charts
           path: dist
@@ -298,7 +298,7 @@ jobs:
       contents: write
     steps:
       - name: Download chart artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: helm-charts
           path: dist

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -185,7 +185,7 @@ jobs:
             --dist-dir dist
 
       - name: Upload package dry-run artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: package-build-dry-run
           path: dist/
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload DevPod artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: devpod-full-e2e
           path: test-artifacts/devpod-*
@@ -407,7 +407,7 @@ jobs:
 
       - name: Upload AWS provider artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: aws-provider-live
           path: test-artifacts/devpod-*
@@ -481,7 +481,7 @@ jobs:
 
       - name: Upload cleanup summary
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cleanup-summary
           path: cleanup-summary.json
@@ -535,7 +535,7 @@ jobs:
           AWS_LIVE_RESULT: ${{ needs.aws-live.result }}
 
       - name: Upload release evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: release-evidence
           path: release-evidence.md
@@ -564,7 +564,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release evidence
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-evidence
 
@@ -593,7 +593,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.resolve-candidate.outputs.python_version }}
 
       - name: Upload release metadata
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: release-metadata
           path: release-metadata/release-metadata.json

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.event_name == 'workflow_dispatch' || steps.release_metadata.outputs.publish == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: python-packages
           path: dist/
@@ -284,7 +284,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-packages
           path: dist/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -161,7 +161,7 @@ jobs:
           bandit -r packages/ plugins/ -f txt || true
 
       - name: Upload Bandit Report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: bandit-report
           path: bandit-report.json

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload JUnit XML
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: e2e-test-results
           path: |

--- a/testing/ci/tests/test_github_actions_node24_pins.py
+++ b/testing/ci/tests/test_github_actions_node24_pins.py
@@ -11,20 +11,34 @@ OLD_ACTION_PINS = {
     "actions/checkout": "34e114876b0b11c390a56381ad16ebd13914f8d5",  # pragma: allowlist secret
     "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",  # pragma: allowlist secret
     "astral-sh/setup-uv": "e4db8464a088ece1b920f60402e813ea4de65b8f",  # pragma: allowlist secret
+    "actions/download-artifact": (
+        "d3f86a106a0bac45b974a628896c90dbdf5c8093"  # pragma: allowlist secret
+    ),
+    "actions/upload-artifact": (
+        "ea165f8d65b6e75b540449e92b4886f43607fa02"  # pragma: allowlist secret
+    ),
     "azure/setup-helm": "1a275c3b69536ee54be43f2070a358922e12c8d4",  # pragma: allowlist secret
+    "CodSpeedHQ/action": "0d7de549485db8284c0b87a0d2c0dd871097e641",  # pragma: allowlist secret
     "helm/kind-action": "a1b0e391336a6ee6713a0583f8c6240d70863de3",  # pragma: allowlist secret
 }
 
 NODE24_ACTION_PINS = {
     "actions/checkout": "de0fac2e4500dabe0009e67214ff5f5447ce83dd",  # pragma: allowlist secret
     "actions/deploy-pages": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",  # pragma: allowlist secret
+    "actions/download-artifact": (
+        "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"  # pragma: allowlist secret
+    ),
     "actions/setup-node": "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",  # pragma: allowlist secret
     "actions/setup-python": "a309ff8b426b58ec0e2a45f0f869d46889d02405",  # pragma: allowlist secret
+    "actions/upload-artifact": (
+        "b7c566a772e6b6bfb58ed0dc250532a479d7789f"  # pragma: allowlist secret
+    ),
     "actions/upload-pages-artifact": (
         "fc324d3547104276b827a68afc52ff2a11cc49c9"  # pragma: allowlist secret
     ),
     "astral-sh/setup-uv": "08807647e7069bb48b6ef5acd8ec9567f424441b",  # pragma: allowlist secret
     "Azure/setup-helm": "dda3372f752e03dde6b3237bc9431cdc2f7a02a2",  # pragma: allowlist secret
+    "CodSpeedHQ/action": "e736f0d2aeb36da38e9f08eca4dff7967408d154",  # pragma: allowlist secret
     "helm/kind-action": "ef37e7f390d99f746eb8b610417061a60e82a6cc",  # pragma: allowlist secret
 }
 
@@ -90,3 +104,12 @@ def test_setup_helm_action_owner_uses_canonical_case() -> None:
             lowercase_setup_helm.append(f"{workflow}:{line_number}: {action}@{ref}")
 
     assert lowercase_setup_helm == []
+
+
+@pytest.mark.requirement("github-actions-node24")
+def test_codspeed_forces_node24_for_transitive_composite_actions() -> None:
+    """CodSpeed wraps actions/cache, so the workflow must force Node 24 execution."""
+    codspeed_workflow = WORKFLOWS_DIR / "codspeed.yml"
+    workflow_text = codspeed_workflow.read_text()
+
+    assert 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"' in workflow_text

--- a/testing/tests/unit/test_ci_workflows.py
+++ b/testing/tests/unit/test_ci_workflows.py
@@ -284,7 +284,7 @@ class TestPypiPublishWorkflow:
         workflow_text = PREPARE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
         assert "release-metadata/release-metadata.json" in workflow_text
-        assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in workflow_text
+        assert "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f" in workflow_text
         assert "RELEASE_VERSION: ${{ needs.resolve-candidate.outputs.python_version }}" in (
             workflow_text
         )

--- a/testing/tests/unit/test_e2e_workflow.py
+++ b/testing/tests/unit/test_e2e_workflow.py
@@ -23,7 +23,7 @@ SETUP_PYTHON_SHA = "a309ff8b426b58ec0e2a45f0f869d46889d02405"  # pragma: allowli
 SETUP_UV_SHA = "08807647e7069bb48b6ef5acd8ec9567f424441b"  # pragma: allowlist secret
 SETUP_HELM_SHA = "dda3372f752e03dde6b3237bc9431cdc2f7a02a2"  # pragma: allowlist secret
 KIND_ACTION_SHA = "ef37e7f390d99f746eb8b610417061a60e82a6cc"  # pragma: allowlist secret
-UPLOAD_ARTIFACT_SHA = "ea165f8d65b6e75b540449e92b4886f43607fa02"  # pragma: allowlist secret
+UPLOAD_ARTIFACT_SHA = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"  # pragma: allowlist secret
 
 
 def _load_workflow() -> dict[object, Any]:


### PR DESCRIPTION
## Summary
- update artifact upload/download actions to Node 24-compatible pinned SHAs
- update CodSpeed action pin and force Node 24 for transitive composite actions/cache usage
- extend workflow contract tests so old Node 20 pins and missing CodSpeed Node 24 forcing are caught

## Validation
- uv run pytest testing/ci/tests/test_github_actions_node24_pins.py -q
- uv run pytest testing/ci/tests/test_github_actions_node24_pins.py testing/tests/unit/test_ci_workflows.py testing/tests/unit/test_e2e_workflow.py -q
- uv run ruff check testing/ci/tests/test_github_actions_node24_pins.py testing/tests/unit/test_ci_workflows.py testing/tests/unit/test_e2e_workflow.py
- uv run ruff format --check testing/ci/tests/test_github_actions_node24_pins.py testing/tests/unit/test_ci_workflows.py testing/tests/unit/test_e2e_workflow.py
- python YAML parse over .github/workflows/*.yml and *.yaml
- git diff --check
- pre-push hook suite passed, including unit tests, contract tests, traceability, docs validation, and helm lint